### PR TITLE
Don't leave empty cells for blank values in changesets:

### DIFF
--- a/app/assets/stylesheets/versions.css.scss
+++ b/app/assets/stylesheets/versions.css.scss
@@ -1,12 +1,45 @@
 @import '_mixins';
+@import 'bootstrap/_variables';
 
 .versions {
   table {
-    tr.selected > td {
+    tr.selected  {
       $highlight: #ff9744;
       border-top: 2px solid $highlight;
       border-bottom: 2px solid $highlight;
       @include transition(border-color, 2s);
+    }
+
+    &.changes {
+      tr {
+        td {
+          word-break: break-all;
+
+          .blank {
+            font-style: italic;
+            color: silver;
+          }
+        }
+
+        .field-name {
+          text-align: right;
+        }
+
+        .becomes {
+          background: url(divider.gif) no-repeat center center;
+          border-left: none;
+        }
+
+        .new-value {
+          border-left: none;
+        }
+
+        &:nth-child(odd) {
+          .becomes {
+            background-color: $tableBackgroundAccent; // from bootstrap
+          }
+        }
+      }
     }
   }
 }

--- a/app/helpers/versions_helper.rb
+++ b/app/helpers/versions_helper.rb
@@ -1,0 +1,5 @@
+module VersionsHelper
+  def value_or_blank(value)
+    value.blank? ? content_tag(:span, class: 'blank') { '<blank>' } : value
+  end
+end

--- a/app/views/versions/_changeset_table.html.erb
+++ b/app/views/versions/_changeset_table.html.erb
@@ -6,8 +6,9 @@
       <% version.changeset.each_pair do |field, change| %>
           <tr>
             <td class="field-name"><%= titleize_known_abbr(field) %></td>
-            <td class="old-value"><%= change.first %></td>
-            <td class="new-value"><%= change.last %></td>
+            <td class="old-value"><%= value_or_blank(change[0]) %></td>
+            <td class="becomes"></td>
+            <td class="new-value"><%= value_or_blank(change[1]) %></td>
           </tr>
       <% end %>
       </tbody>


### PR DESCRIPTION
- Show they were <blank> (grey out a little, italicise)
- if we're not using table headers for the changes, try
  and be explicit that this was a change by using a visual
  trick like
  field_name | old_value > new_value
