### PR TITLE
Add canonical HTTP status text (Gone, Moved Permanently)

### DIFF
--- a/app/helpers/mappings_helper.rb
+++ b/app/helpers/mappings_helper.rb
@@ -43,4 +43,13 @@ module MappingsHelper
         options)
     end
   end
+
+  ##
+  # Return a FormBuilder-compatible list of HTTP Status codes with descriptions
+  # e.g. [['301 Moved Permanently', '301'], ['410 Gone', '410']]
+  def options_for_supported_statuses
+    Mapping::SUPPORTED_STATUSES.map do |status|
+      ["#{status} #{Rack::Utils::HTTP_STATUS_CODES[status]}", status.to_s]
+    end
+  end
 end

--- a/app/models/mapping.rb
+++ b/app/models/mapping.rb
@@ -1,5 +1,7 @@
 require 'digest/sha1'
 class Mapping < ActiveRecord::Base
+  SUPPORTED_STATUSES = [301, 410]
+  
   attr_accessible :path, :site, :http_status, :new_url, :suggested_url, :archive_url
 
   paginates_per 100

--- a/app/views/mappings/_form.html.erb
+++ b/app/views/mappings/_form.html.erb
@@ -12,7 +12,7 @@
     <% end %>
 
     <%= f.label :http_status, 'HTTP Status' %>
-    <%= f.select :http_status, ['301', '410'] %>
+    <%= f.select :http_status, options_for_supported_statuses %>
 
     <%= f.label :new_url, 'New URL' %>
     <%= f.text_field :new_url, class: 'span8' %>

--- a/spec/helpers/mappings_helper_spec.rb
+++ b/spec/helpers/mappings_helper_spec.rb
@@ -31,4 +31,10 @@ describe MappingsHelper do
     it { should include('<li class="active"><a href="#"') }
     it { should include(%(<li><a href="#{site_mapping_versions_path(@mapping.site, @mapping)}")) }
   end
+
+  describe '#options_for_supported_statuses' do
+    it 'provides an array of supported statuses in a form compatible with FormBuilder#select' do
+      helper.options_for_supported_statuses.should == [['301 Moved Permanently', '301'], ['410 Gone', '410']]
+    end
+  end
 end


### PR DESCRIPTION
to the create/edit mappings screens
