### PR TITLE
Fix exception notification

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,4 +64,10 @@ Transition::Application.configure do
   # Log the query plan for queries taking more than this (works
   # with SQLite, MySQL, and PostgreSQL)
   # config.active_record.auto_explain_threshold_in_seconds = 0.5
+
+  config.action_mailer.default_url_options = {
+    :host => URI.parse(Plek.current.find('transition')).host,
+    :protocol => 'https'
+  }
+  config.action_mailer.delivery_method = :ses
 end


### PR DESCRIPTION
Because we hadn't told it to use ses, it was trying to use the server's smtp server and encountering a bogus cert.

Thanks to @alext for pointing out the cause of the problem.
