### PR TITLE
Hotfix remove unncessary styling for links

### DIFF
--- a/app/assets/stylesheets/base.css.scss
+++ b/app/assets/stylesheets/base.css.scss
@@ -42,6 +42,10 @@ footer {
   margin-bottom: $baseLineHeight;
 }
 
+.add-big-bottom-margin {
+  margin-bottom: $baseLineHeight *2;
+}
+
 .remove-bottom-margin {
   margin-bottom: 0;
 }

--- a/app/assets/stylesheets/hits.css.scss
+++ b/app/assets/stylesheets/hits.css.scss
@@ -25,15 +25,6 @@
   background-color: $badHTTPStatusColor;
 }
 
-.hits-summary {
-  margin-bottom: $baseLineHeight * 4;
-}
-
-.hits-summary-link a {
-  font-weight: normal;
-  font-size: (14/13)+em;
-}
-
 .hits {
   table-layout: fixed;
 }

--- a/app/views/hits/_summary_section.html.erb
+++ b/app/views/hits/_summary_section.html.erb
@@ -1,4 +1,4 @@
-<section class="hits-summary hits-summary-<%= category.name %>">
+<section class="hits-summary-<%= category.name %> add-big-bottom-margin">
   
   <h2>
   <% if category.hits.count < 10 %>
@@ -10,9 +10,7 @@
   
   <% if category.hits.any? %>
     <%= render partial: 'hits_table', locals: { hits: category.hits} %>
-    <p class="hits-summary-link">
-      <%= link_to "See all #{category.name}", (send category.path_method, @site, period: @period.query_slug) %>
-    </p>
+    <%= link_to "See all #{category.name}", (send category.path_method, @site, period: @period.query_slug) %>
   <% else %>
     <p class="no-content no-content-bordered">
       There are no known <%= category.name.pluralize %> for <%= @site.abbr %> <%= @period.no_content %>.


### PR DESCRIPTION
- Replace .hits-summary with generic spacing class
- Remove .hits-summary-link styles to inherit default
