### PR TITLE
Fix summary grouping for hosts

### DIFF
--- a/app/helpers/hits_helper.rb
+++ b/app/helpers/hits_helper.rb
@@ -1,6 +1,6 @@
 module HitsHelper
-  def link_to_hit(hit)
-    scheme_and_host = 'http://'+ hit.host.hostname
+  def link_to_hit(hit, host = hit.host)
+    scheme_and_host = 'http://'+ host.hostname
     link_to hit.path, scheme_and_host + hit.path
   end
 

--- a/app/models/hit.rb
+++ b/app/models/hit.rb
@@ -18,8 +18,8 @@ class Hit < ActiveRecord::Base
   validates :path_hash, presence: true
 
   scope :by_path_and_status, -> {
-    select('hits.path, sum(hits.count) as count, hits.http_status, hits.host_id').
-      group(:host_id, :path_hash, :http_status)
+    select('hits.path, sum(hits.count) as count, hits.http_status').
+      group(:path_hash, :http_status)
   }
   scope :points_by_date, -> {
     select('hits.hit_on, sum(hits.count) as count').group(:hit_on)

--- a/app/views/hits/_hits.html.erb
+++ b/app/views/hits/_hits.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, title %>
-<%= breadcrumb(hits.first || site.default_host.hits.build) %>
+<%= breadcrumb(site.default_host.hits.build) %>
 
 <h1><%= title %></h1>
 

--- a/app/views/hits/_hits_table.html.erb
+++ b/app/views/hits/_hits_table.html.erb
@@ -17,7 +17,7 @@
       <td class="status"><%= hit.http_status %></td>
       <td class="relative">
         <%= render partial: 'bar_chart_row', locals: { count: hit.count, max: max, status: hit.http_status } %>
-        <span class="path"><%= link_to_hit(hit) %></span>
+        <span class="path"><%= link_to_hit(hit, @site.default_host) %></span>
       </td>
       <td class="count"><%= number_with_delimiter hit.count %></td>
       <% if current_user.can_edit?(@site.organisation) %>

--- a/spec/controllers/hits_controller_spec.rb
+++ b/spec/controllers/hits_controller_spec.rb
@@ -3,17 +3,28 @@ require 'transition/import/daily_hit_totals'
 
 describe HitsController do
   describe '#category' do
-    let(:site) { create :site_with_default_host }
-    let(:host) { site.default_host }
+    let(:site) do
+      create :site_with_default_host do |site|
+        site.hosts << create(:host, hostname: 'alias.gov.uk')
+      end
+    end
+
+    let(:host)       { site.default_host }
+    let(:host_alias) { site.hosts.last }
 
     let!(:errors) do
-      [create(:hit, host: host, hit_on: '2012-12-28', count: 1, http_status: 404),
-       create(:hit, host: host, hit_on: '2012-12-31', count: 1, http_status: 404)]
+      [
+        create(:hit, host: host, hit_on: '2012-12-28', count: 1, http_status: 404),
+        create(:hit, host: host, hit_on: '2012-12-31', count: 1, http_status: 404)
+      ]
     end
     let!(:others) do
-      [create(:hit, host: host, hit_on: '2012-12-28', count: 2, http_status: 200),
+      [
+       create(:hit, host: host, hit_on: '2012-12-28', count: 2, http_status: 200),
        create(:hit, host: host, hit_on: '2012-12-28', count: 2, http_status: 501),
-       create(:hit, host: host, hit_on: '2012-12-31', count: 2, http_status: 200)]
+       create(:hit, host: host, hit_on: '2012-12-31', count: 2, http_status: 200),
+       create(:hit, host: host_alias, hit_on: '2012-12-31', count: 2, http_status: 200)
+      ]
     end
 
     before do
@@ -42,8 +53,16 @@ describe HitsController do
       it 'has one point per day' do
         category.should have(4).points
       end
-      it 'adds up to six total others' do
-        sum_of_hit_counts.should == 6
+      it 'adds up to eight total others' do
+        sum_of_hit_counts.should == 8
+      end
+      it 'groups hits by path and status' do
+        results = category.hits.map {|r| [r.http_status, r.path, r.count]}
+        results.should == [
+          ['200', '/article/123', 6],
+          ['501', '/article/123', 2]
+        ]
+        category.hits.length.should == 2
       end
     end
   end


### PR DESCRIPTION
When we brought back hit query forms from the Postgres spike
to avoid mySQL sloppiness, we left a GROUP BY host_id in there.
That host ID has also been taken out of the query. We now link
from hits only to `@site.default_host`, rather than a random
one from mySQL's broken GROUP BY implementation.

This addresses duplicates in the hits tables (for, e.g., /sites/ago/hits)
