### PR TITLE
Fix bar chart within Path table cell

### DIFF
--- a/app/assets/stylesheets/hits.css.scss
+++ b/app/assets/stylesheets/hits.css.scss
@@ -7,13 +7,32 @@
   font-weight: normal;
 }
 
+.hits {
+  table-layout: fixed;
+}
+
+.hits td {
+  overflow: hidden;
+}
+
+
+.bar-chart-wrap {
+  position: relative;
+  height: 100%;
+  width: 100%;
+  margin: -8px;
+}
+
 .bar-chart-row {
   position: absolute;
-  left: 0;
   top: 0;
+  left: 0;
   bottom: 0;
+  
   background-color: $defaultHTTPStatusColor;
+  
   min-width: 3px;
+  min-height: 40px;
 }
 
 .bar-chart-row-301 {
@@ -25,9 +44,6 @@
   background-color: $badHTTPStatusColor;
 }
 
-.hits {
-  table-layout: fixed;
-}
 
 .status {
   width: $gridColumnWidth;
@@ -46,6 +62,9 @@
 
 .path {
   word-wrap: break-word;
+  display: inline-block;
+  margin: 8px;
+  
   position: relative;
   z-index: 1;
 }

--- a/app/views/hits/_bar_chart_row.html.erb
+++ b/app/views/hits/_bar_chart_row.html.erb
@@ -4,3 +4,4 @@
 %>
 <% style_rows = %( style="width: #{count / max * 100}%").html_safe %>
 <div class="bar-chart-row bar-chart-row-<%= status %>"<%= style_rows if first_page? %>></div>
+

--- a/app/views/hits/_hits_table.html.erb
+++ b/app/views/hits/_hits_table.html.erb
@@ -19,9 +19,11 @@
           <%= hit.http_status %>
         </abbr>
       </td>
-      <td class="relative">
-        <%= render partial: 'bar_chart_row', locals: { count: hit.count, max: max, status: hit.http_status } %>
-        <span class="path"><%= link_to_hit(hit, @site.default_host) %></span>
+      <td>
+        <div class="bar-chart-wrap">
+          <%= render partial: 'bar_chart_row', locals: { count: hit.count, max: max, status: hit.http_status } %>
+          <span class="path"><%= link_to_hit(hit, @site.default_host) %></span>
+        </div>
       </td>
       <td class="count"><%= number_with_delimiter hit.count %></td>
       <% if current_user.can_edit?(@site.organisation) %>


### PR DESCRIPTION
- Pivotal #60785792 (Fix Firefox hits graph overlay)
- Remove relative class from table cell
- Add inner div as relatively positioned wrapper
- Hide any overflow of the chart bar
