### PR TITLE
Disallow invalid mapping paths

### DIFF
--- a/app/models/mapping.rb
+++ b/app/models/mapping.rb
@@ -19,6 +19,7 @@ class Mapping < ActiveRecord::Base
   validates :site, presence: true
   validates :path,
             presence: true,
+            path: true,
             length: { maximum: 1024 },
             exclusion: { in: ['/'], message: I18n.t('not_possible_to_edit_homepage_mapping')}
   validates :http_status, presence: true, length: { maximum: 3 }

--- a/app/validators/path_validator.rb
+++ b/app/validators/path_validator.rb
@@ -1,0 +1,12 @@
+class PathValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    begin
+      uri = URI.parse(value)
+      valid_path = uri.is_a?(URI::Generic) && (uri.path =~ /^\/.*/)
+    rescue URI::InvalidURIError
+      valid_path = false
+    end
+
+    record.errors.add attribute, (options[:message] || 'is not a valid path') unless valid_path
+  end
+end


### PR DESCRIPTION
Paths that don't pass a URI.parse to create a
URI::Generic are no longer let through
