### PR TITLE
Move launch_date from Organisation to Site

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,5 +1,5 @@
 class Organisation < ActiveRecord::Base
-  attr_accessible :title, :launch_date, :homepage, :furl, :css
+  attr_accessible :title, :homepage, :furl, :css
 
   belongs_to :parent, class_name: Organisation, foreign_key: 'parent_id'
 

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -13,7 +13,7 @@
   <tr>
     <th class="abbr" scope="col">Abbreviation</th>
     <th class="title" scope="col">Organisation</th>
-    <th scope="col">Launch date</th>
+    <th scope="col">Sites</th>
   </tr>
   </thead>
 
@@ -29,7 +29,7 @@
         <%= link_to org.title, organisation_path(org) %>
       </td>
       <td>
-        <%= date_or_not_yet(org.launch_date) %>
+        <%= pluralize(org.sites.count, 'site') %>
       </td>
     </tr>
   <% end %>

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -25,6 +25,7 @@
         <th scope="col">Mappings</th>
         <th scope="col">Analytics</th>
         <th scope="col">New homepage</th>
+        <th scope="col">Launch date</th>
       </tr>
     </thead>
     <tbody>
@@ -34,6 +35,7 @@
         <td><%= link_to "Mappings", site_mappings_path(site) %></td>
         <td><%= link_to 'Analytics', summary_site_hits_path(site) %></td>
         <td><%= link_to site.homepage, site.homepage, class: 'breakable' %></td>
+        <td><%= date_or_not_yet(site.launch_date) %></td>
       </tr>
     <% end %>
     </tbody>

--- a/db/migrate/20131127140136_move_redirection_date_to_site.rb
+++ b/db/migrate/20131127140136_move_redirection_date_to_site.rb
@@ -1,0 +1,24 @@
+class MoveRedirectionDateToSite < ActiveRecord::Migration
+  class Organisation < ActiveRecord::Base
+  end
+
+  class Site < ActiveRecord::Base
+    belongs_to :organisation
+  end
+
+  def up
+    add_column :sites, :launch_date, :date
+    Site.all.each do |site|
+      site.update_attribute(:launch_date, site.organisation.launch_date)
+    end
+    remove_column :organisations, :launch_date
+  end
+
+  def down
+    add_column :organisations, :launch_date, :date
+    Organisation.all.each do |organisation|
+      organisation.update_attribute(:launch_date, organisation.sites.first.launch_date)
+    end
+    remove_column :sites, :launch_date
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -84,7 +84,6 @@ CREATE TABLE `organisations` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `redirector_abbr` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `title` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `launch_date` date DEFAULT NULL,
   `homepage` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `furl` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
@@ -116,6 +115,7 @@ CREATE TABLE `sites` (
   `global_http_status` varchar(3) COLLATE utf8_unicode_ci DEFAULT NULL,
   `global_new_url` text COLLATE utf8_unicode_ci,
   `managed_by_transition` tinyint(1) NOT NULL DEFAULT '1',
+  `launch_date` date DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_sites_on_site` (`abbr`),
   KEY `index_sites_on_organisation_id` (`organisation_id`)
@@ -181,6 +181,8 @@ INSERT INTO schema_migrations (version) VALUES ('20131107202738');
 INSERT INTO schema_migrations (version) VALUES ('20131108121241');
 
 INSERT INTO schema_migrations (version) VALUES ('20131112133657');
+
+INSERT INTO schema_migrations (version) VALUES ('20131127140136');
 
 INSERT INTO schema_migrations (version) VALUES ('20131128120152');
 

--- a/lib/transition/import/orgs_sites_hosts.rb
+++ b/lib/transition/import/orgs_sites_hosts.rb
@@ -46,7 +46,6 @@ module Transition
           %w(title furl homepage css).each { |attr| org.send "#{attr}=".to_sym, site.send(attr.to_sym) }
 
           org.redirector_abbr = site.inferred_organisation
-          org.launch_date     = site.redirection_date
 
           if (whitehall_org = whitehall_organisations.by_title[org.title])
             org.abbreviation   = whitehall_org.details.abbreviation

--- a/lib/transition/import/site_yaml_file.rb
+++ b/lib/transition/import/site_yaml_file.rb
@@ -19,7 +19,7 @@ module Transition
         HTMLEntities.new.decode(yaml['title'])
       end
 
-      %w(furl redirection_date homepage css).each do |name|
+      %w(furl homepage css).each do |name|
         define_method name.to_sym do
           yaml[name]
         end
@@ -79,6 +79,7 @@ module Transition
               Organisation.find_by_redirector_abbr(inferred_organisation)
             end
           site.tna_timestamp          = yaml['tna_timestamp']
+          site.launch_date            = yaml['redirection_date']
           site.query_params           = yaml['options'] ? yaml['options'].sub(/^.*--query-string /, '') : ''
           site.global_http_status     = global_http_status
           site.global_new_url         = global_new_url

--- a/spec/factories/organisations.rb
+++ b/spec/factories/organisations.rb
@@ -2,7 +2,6 @@ FactoryGirl.define do
   factory :organisation do
     sequence(:redirector_abbr) {|n| "org#{n}" }
     title 'Orgtastic'
-    launch_date { 1.month.ago }
 
     ga_profile_id '46600000'
     whitehall_type 'Executive non-departmental public body'

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     abbr 'cic_regulator'
     homepage 'https://www.gov.uk/government/organisations/cic-regulator'
     query_params ''
+    launch_date { 1.month.ago }
     tna_timestamp '2012-08-16 22:40:15'
     managed_by_transition true
 


### PR DESCRIPTION
It is becoming more and more obvious that the unit of transition is a site, not an organisation. This is particularly apparent for the Cabinet Office which has several sites transitioning at wildly different times.

The complicating factor to this is partial domains, but that's a problem for another day.

Note: the migration fills in the site launch date from the organisation one, so will produce misleading data for eg Cabinet Office sites until the data from redirector is next imported.
