### PR TITLE
Use mapping path as link text

### DIFF
--- a/app/views/mappings/index.html.erb
+++ b/app/views/mappings/index.html.erb
@@ -53,7 +53,7 @@
           <%= mapping.type.titleize %>
         </td>
         <td>
-          <%= link_to mapping.old_url, mapping.old_url %>
+          <%= link_to mapping.path, mapping.old_url %>
           <% if mapping.redirect? %>
             <i class="muted">redirects to</i><br>
             <%= link_to mapping.new_url, mapping.new_url, class: 'muted-link' if mapping.new_url.present? %>


### PR DESCRIPTION
- Fix regression caused by old_url refactor
