### PR TITLE
Validate the authenticity token on POST requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,11 +5,20 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery
 
+  rescue_from ActionController::InvalidAuthenticityToken do
+    render text: "Invalid authenticity token", status: 403
+  end
+
   def user_for_paper_trail
     current_user.name if user_signed_in?
   end
 
   def info_for_paper_trail
     { user_id: current_user.id } if user_signed_in?
+  end
+
+private
+  def verify_authenticity_token
+    raise ActionController::InvalidAuthenticityToken unless verified_request?
   end
 end

--- a/spec/controllers/mappings_controller_spec.rb
+++ b/spec/controllers/mappings_controller_spec.rb
@@ -146,4 +146,22 @@ describe MappingsController do
       end
     end
   end
+
+  describe 'rejecting an invalid or missing authenticity (CSRF) token' do
+    before do
+      login_as admin_bob
+    end
+
+    it 'should return a 403 response' do
+      # as allow_forgery_protection is disabled in the test environment, we're
+      # stubbing the verified_request? method from
+      # ActionController::RequestForgeryProtection::ClassMethods to return false
+      # in order to test our override of the verify_authenticity_token method
+      subject.stub(:verified_request?).and_return(false)
+      post :create, site_id: mapping.site,
+               mapping: { path: '/foo', http_status: '410' }
+      response.status.should eql(403)
+      response.body.should eql('Invalid authenticity token')
+    end
+  end
 end


### PR DESCRIPTION
Without this, the most Rails will do is to log a warning, which means that we are theoretically vulnerable to a [CSRF attack](http://guides.rubyonrails.org/security.html#cross-site-request-forgery-csrf).

Shamelessly copied from https://github.com/alphagov/maslow/pull/31
