### PR TITLE
Delete 'Others' section from hits

### DIFF
--- a/app/controllers/hits_controller.rb
+++ b/app/controllers/hits_controller.rb
@@ -16,7 +16,7 @@ class HitsController < ApplicationController
     end
 
     unless @period.single_day?
-      @point_categories = View::Hits::Category.all.reject { |c| c.name == 'other' }.map do |category|
+      @point_categories = View::Hits::Category.all.map do |category|
         category.tap do |c|
           c.points = ((c.name == 'all') ? totals_in_period : totals_in_period.send(category.to_sym))
         end
@@ -25,10 +25,10 @@ class HitsController < ApplicationController
   end
 
   def category
-    # Category - one of %w(archives redirect errors other) (see routes.rb)
+    # Category - one of %w(archives redirect errors) (see routes.rb)
     @category = View::Hits::Category[params[:category]].tap do |c|
       c.hits   = hits_in_period.by_path_and_status.send(c.to_sym).page(params[:page]).order('count DESC')
-      c.points = params[:category] == 'other' ? totals_in_period.by_date.other : totals_in_period.by_date_and_status.send(c.to_sym)
+      c.points = totals_in_period.by_date_and_status.send(c.to_sym)
     end
   end
 

--- a/app/models/daily_hit_total.rb
+++ b/app/models/daily_hit_total.rb
@@ -12,5 +12,4 @@ class DailyHitTotal < ActiveRecord::Base
   scope :errors,     -> { where(http_status: '404') }
   scope :archives,   -> { where(http_status: '410') }
   scope :redirects,  -> { where(http_status: '301') }
-  scope :other,      -> { where("http_status NOT IN ('404', '410', '301')") }
 end

--- a/app/models/hit.rb
+++ b/app/models/hit.rb
@@ -33,7 +33,6 @@ class Hit < ActiveRecord::Base
   scope :errors,     -> { where(http_status: '404') }
   scope :archives,   -> { where(http_status: '410') }
   scope :redirects,  -> { where(http_status: '301') }
-  scope :other,      -> { where("http_status NOT IN ('404', '410', '301')") }
   scope :top_ten,    -> { order('count DESC').limit(10) }
 
   protected

--- a/app/models/view/hits/category.rb
+++ b/app/models/view/hits/category.rb
@@ -10,8 +10,7 @@ module View
         'all'       => '#333',
         'errors'    => '#e99',
         'archives'  => '#aaa',
-        'redirects' => '#9e9',
-        'other'     => '#aaa'
+        'redirects' => '#9e9'
       }
 
       def self.all

--- a/app/views/hits/_hits_tabs.html.erb
+++ b/app/views/hits/_hits_tabs.html.erb
@@ -6,8 +6,7 @@
         'All hits'   => site_hits_path(@site, period),
         'Errors'     => errors_site_hits_path(@site, period),
         'Archives'   => archives_site_hits_path(@site, period),
-        'Redirects'  => redirects_site_hits_path(@site, period),
-        'Other'      => other_site_hits_path(@site, period)
+        'Redirects'  => redirects_site_hits_path(@site, period)
       }, active: active
     )
 %>

--- a/features/hits_summary.feature
+++ b/features/hits_summary.feature
@@ -63,8 +63,6 @@ Scenario: Hits exist and are summarised for a site, displayed with a graph
   And it should show only the top 10 archives in descending count order
   And I should see a section for the most common redirects
   And it should show only the top 10 redirects in descending count order
-  And I should see a section for the other hits, the most common miscellany
-  And it should show only the top 10 other in descending count order
   And I should see a graph representing hits data over time
   And I should see a trend for all hits, errors, archives and redirects
   When I click a point for the date 18/10/12
@@ -95,11 +93,6 @@ Scenario: Hits exist and can be filtered by redirects and time period "Last 30 d
   When I filter by the date period "Last 30 days"
   Then I should see an redirects graph showing a green trend line with 2 points
   And the period "Last 30 days" should be selected
-
-Scenario: Hits exist and can be filtered by other statuses
-  When I click the link "Other"
-  Then I should see all hits with an other status for the Attorney General's office in descending count order
-  And I should see an other graph showing a grey trend line
 
 Scenario: There are multiple pages for a category
   Given the hits page size is 11

--- a/features/step_definitions/hits_assertion_steps.rb
+++ b/features/step_definitions/hits_assertion_steps.rb
@@ -42,10 +42,6 @@ Then(/^I should see a section for the most common (\w+)$/) do |category|
   expect(page).to have_selector('h2', text: category.titleize)
 end
 
-Then(/^I should see a section for the other hits, the most common miscellany$/) do
-  expect(page).to have_selector('h2', text: 'Other')
-end
-
 Then(/^it should show(?: only the top) (\d+) (\w+) in descending count order$/) do |count, category|
 
   case category
@@ -55,8 +51,6 @@ Then(/^it should show(?: only the top) (\d+) (\w+) in descending count order$/) 
     status = 410
   when 'redirects'
     status = 301
-  else
-    status = 200
   end
 
   within ".hits-summary-#{category}" do
@@ -91,8 +85,6 @@ Then(/^I should see all hits with a[n]? (\w+) status for the Attorney General's 
     status = 410
   when 'redirect'
     status = 301
-  else
-    status = 200
   end
 
   within '.hits' do

--- a/spec/controllers/hits_controller_spec.rb
+++ b/spec/controllers/hits_controller_spec.rb
@@ -18,12 +18,11 @@ describe HitsController do
         create(:hit, host: host, hit_on: '2012-12-31', count: 1, http_status: 404)
       ]
     end
-    let!(:others) do
+    let!(:archives) do
       [
-       create(:hit, host: host, hit_on: '2012-12-28', count: 2, http_status: 200),
-       create(:hit, host: host, hit_on: '2012-12-28', count: 2, http_status: 501),
-       create(:hit, host: host, hit_on: '2012-12-31', count: 2, http_status: 200),
-       create(:hit, host: host_alias, hit_on: '2012-12-31', count: 2, http_status: 200)
+       create(:hit, host: host, hit_on: '2012-12-28', count: 2, http_status: 410),
+       create(:hit, host: host, hit_on: '2012-12-31', count: 2, http_status: 410),
+       create(:hit, host: host_alias, hit_on: '2012-12-31', count: 2, http_status: 410)
       ]
     end
 
@@ -47,22 +46,21 @@ describe HitsController do
       end
     end
 
-    context 'a multi-status category, other' do
-      let(:test_category_name) { 'other' }
+    context 'a multi-status category, archives' do
+      let(:test_category_name) { 'archives' }
 
       it 'has one point per day' do
         category.should have(4).points
       end
-      it 'adds up to eight total others' do
-        sum_of_hit_counts.should == 8
+      it 'adds up to eight total archives' do
+        sum_of_hit_counts.should == 6
       end
       it 'groups hits by path and status' do
         results = category.hits.map {|r| [r.http_status, r.path, r.count]}
         results.should == [
-          ['200', '/article/123', 6],
-          ['501', '/article/123', 2]
+          ['410', '/article/123', 6]
         ]
-        category.hits.length.should == 2
+        category.hits.length.should == 1
       end
     end
   end

--- a/spec/models/view/category_spec.rb
+++ b/spec/models/view/category_spec.rb
@@ -5,7 +5,7 @@ describe View::Hits::Category do
     subject(:all_categories) { View::Hits::Category.all }
 
     it { should be_an(Array) }
-    it { should have(5).categories }
+    it { should have(4).categories }
 
     describe 'the first' do
       subject(:all_category) { View::Hits::Category.all.first }
@@ -24,32 +24,32 @@ describe View::Hits::Category do
         expect { View::Hits::Category['non-existent'] }.to raise_error(ArgumentError)
       end
 
-      subject(:others_category) { View::Hits::Category['other'] }
+      subject(:errors_category) { View::Hits::Category['errors'] }
 
-      its(:title)       { should == 'Other' }
-      its(:to_sym)      { should == :other }
-      its(:color)       { should == '#aaa' }
-      its(:plural)      { should == 'others' }
-      its(:path_method) { should == :other_site_hits_path }
+      its(:title)       { should == 'Errors' }
+      its(:to_sym)      { should == :errors }
+      its(:color)       { should == '#e99' }
+      its(:plural)      { should == 'errors' }
+      its(:path_method) { should == :errors_site_hits_path }
 
       describe 'the polyfill of points when points= is called' do
         context 'valid data' do
-          let(:others) do
+          let(:errors) do
             [
-              build(:daily_hit_total, total_on: '2012-12-28', count: 1000, http_status: 200),
-              build(:daily_hit_total, total_on: '2012-12-31', count: 3, http_status: 200)
+              build(:daily_hit_total, total_on: '2012-12-28', count: 1000, http_status: 404),
+              build(:daily_hit_total, total_on: '2012-12-31', count: 3, http_status: 404)
             ]
           end
 
-          before { others_category.points = others }
+          before { errors_category.points = errors }
 
           it { should have(4).points }
 
-          its(:'points.first') { should == others.first }
-          its(:'points.last')  { should == others.last }
+          its(:'points.first') { should == errors.first }
+          its(:'points.last')  { should == errors.last }
 
           describe 'the first inserted total' do
-            subject { others_category.points[1] }
+            subject { errors_category.points[1] }
 
             its(:total_on) { should eql(Date.new(2012, 12, 29)) }
             its(:count) { should eql(0) }
@@ -57,7 +57,7 @@ describe View::Hits::Category do
         end
 
         context 'invalid data - more than one row per date' do
-          let(:others) do
+          let(:errors) do
             [
               build(:daily_hit_total, total_on: '2012-12-28', count: 1000, http_status: 200),
               build(:daily_hit_total, total_on: '2012-12-28', count: 3, http_status: 200)
@@ -65,7 +65,7 @@ describe View::Hits::Category do
           end
 
           it 'raises an error' do
-            expect { others_category.points = others }.to raise_error(ArgumentError)
+            expect { errors_category.points = errors }.to raise_error(ArgumentError)
           end
         end
       end


### PR DESCRIPTION
- Others confused all users in research
- The list cannot be acted on or resolved from within transition alone
- Attempts to create mappings for these statuses will put the system in
  a confusing state (eg. for robots.txt)
- Remove references to Other from all tests, models, controllers and
  views
- All hit information remains available under 'All hits'
