### PR TITLE
Fetch Whitehall orgs from production in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,4 +34,11 @@ Transition::Application.configure do
 
   # Expands the lines which load the assets
   config.assets.debug = true
+
+  # Fetch Whitehall organisations from production in development, so that we can
+  # rake import:all without having to have whitehall running locally with
+  # up-to-date data
+  if ENV['GOVUK_APP_DOMAIN'].blank?
+    ENV['GOVUK_APP_DOMAIN'] = 'production.alphagov.co.uk'
+  end
 end


### PR DESCRIPTION
We frequently need to run the rake import:all task in development,
which currently requires Whitehall to be running locally, with
up-to-date data. This change means that the task will call the
production organisations API from dev instead, which avoids the
overhead of keeping Whitehall up to date and running locally.
