### PR TITLE
Fix deprecation warning for i18n 0.6.9

### DIFF
--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -1,0 +1,1 @@
+I18n.config.enforce_available_locales = true


### PR DESCRIPTION
Without this, i18n 0.6.9 issues a deprecation warning on test.
