### PR TITLE
Set the 'secure' option on session cookies

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
-Transition::Application.config.session_store :cookie_store, key: '_transition_session'
+Transition::Application.config.session_store :cookie_store, key: '_transition_session', secure: Rails.env.production?
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information


### PR DESCRIPTION
This was an outcome of the penetration test.

Setting this tells the browser that the cookie should only be sent over HTTPS:
http://en.wikipedia.org/wiki/HTTP_cookie#Secure_and_HttpOnly

Code inspired by: https://github.com/alphagov/whitehall/blob/master/config/initializers/session_store.rb#L3-L4
