### PR TITLE
Don't import mappings for sites managed by transition

### DIFF
--- a/spec/fixtures/mappings/no_rows.csv
+++ b/spec/fixtures/mappings/no_rows.csv
@@ -1,0 +1,1 @@
+Old Url,New Url,Status,Suggested Link,Archive Link


### PR DESCRIPTION
If there are any mappings in Redirector for these sites, they are not canonical and should not overwrite whatever our users have edited.

I thought about not importing Sites and Hosts as well, but adding/editing files in Redirector currently our only way of adding/editing these things to Transition.
