### PR TITLE
Hide sites not yet managed_by_transition

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -1,11 +1,11 @@
 class OrganisationsController < ApplicationController
   def index
-    @organisations = Organisation.with_sites.order(:title)
-    @site_count = Site.count
+    @organisations = Organisation.with_sites_managed_by_transition.order(:title)
+    @site_count = Site.managed_by_transition.count
   end
 
   def show
     @organisation = Organisation.find_by_whitehall_slug(params[:id])
-    @sites = @organisation.sites.order(:abbr)
+    @sites = @organisation.sites.managed_by_transition.order(:abbr)
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -23,9 +23,10 @@ class Organisation < ActiveRecord::Base
   validates_uniqueness_of :whitehall_slug
   validates_presence_of :title
 
-  scope :with_sites,
+  scope :with_sites_managed_by_transition,
         select('organisations.*, count(sites.id) AS site_count').
         joins(:sites).
+        where("sites.managed_by_transition = 1").
         group('organisations.id').  # Using a sloppy mySQL GROUP. Note well, Postgres upgraders
         having('site_count > 0')
 

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -11,6 +11,8 @@ class Site < ActiveRecord::Base
   validates_presence_of :organisation
   validates_uniqueness_of :abbr
 
+  scope :managed_by_transition, where(managed_by_transition: true)
+
   def to_param
     abbr
   end

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -16,7 +16,7 @@
   </p>
 <% end %>
 
-<% unless @organisation.sites.empty? %>
+<% unless @sites.empty? %>
   <h2>Sites</h2>
   <table class="sites table table-hover table-striped table-bordered">
     <thead>


### PR DESCRIPTION
Also hides organisations unless they have sites managed_by_transition.
