### PR TITLE
Tidy the BulkEditor

### DIFF
--- a/app/controllers/mappings_controller.rb
+++ b/app/controllers/mappings_controller.rb
@@ -37,7 +37,6 @@ class MappingsController < ApplicationController
   end
 
   def edit_multiple
-    @back_to_index = site_return_url
     redirect_to site_return_url, notice: bulk.params_invalid_notice and return if bulk.params_invalid?
 
     if request.xhr?
@@ -46,7 +45,6 @@ class MappingsController < ApplicationController
   end
 
   def update_multiple
-    @back_to_index = site_return_url
     redirect_to site_return_url, notice: bulk.params_invalid_notice and return if bulk.params_invalid?
 
     if bulk.would_fail?
@@ -87,7 +85,7 @@ class MappingsController < ApplicationController
 
   private
   def bulk
-    @bulk ||= View::Mappings::BulkEditor.new(@site, params)
+    @bulk ||= View::Mappings::BulkEditor.new(@site, params, site_return_url)
   end
 
   private

--- a/app/models/view/mappings/bulk_editor.rb
+++ b/app/models/view/mappings/bulk_editor.rb
@@ -6,7 +6,7 @@ module View
     #
     # Needs a site and params to work out what is being edited
     # and what the new values are
-    class BulkEditor < Struct.new(:site, :params)
+    class BulkEditor < Struct.new(:site, :params, :back_to_index)
       def mappings
         @mappings ||= site.mappings.where(id: params[:mapping_ids]).order(:path)
       end

--- a/app/views/mappings/edit_multiple.html.erb
+++ b/app/views/mappings/edit_multiple.html.erb
@@ -13,8 +13,8 @@
   <%= render partial: 'edit_multiple_table',
              locals: { modal: false, mappings: @bulk.mappings, site: @site } %>
   <%= render partial: 'edit_multiple_redirect',
-             locals: { modal: false, new_url: @bulk.updates[:new_url],
+             locals: { modal: false, new_url: @bulk.new_url,
                        new_url_error: @new_url_error, http_status: @bulk.http_status } %>
-  <%= link_to 'Cancel', @back_to_index, class: 'btn add-right-margin' %>
+  <%= link_to 'Cancel', @bulk.back_to_index, class: 'btn add-right-margin' %>
   <%= submit_tag 'Save', class: 'btn btn-success' %>
 <% end %>

--- a/app/views/mappings/edit_multiple_modal.html.erb
+++ b/app/views/mappings/edit_multiple_modal.html.erb
@@ -9,7 +9,7 @@
     <%= render partial: 'edit_multiple_redirect',
                locals: {
                        modal: true,
-                       new_url: @bulk.updates[:new_url],
+                       new_url: @bulk.new_url,
                        new_url_error: @new_url_error,
                        http_status: @bulk.http_status } %>
     <%= render partial: 'edit_multiple_table',


### PR DESCRIPTION
- Stop stuffing the view with fields (use `@bulk.mappings`)
- Stop giving the impression we can deal with multiple failures
  (it's all or nothing)
- Naming & whitespace
