### PR TITLE
Fill in missing scheme in urls

### DIFF
--- a/app/models/mapping.rb
+++ b/app/models/mapping.rb
@@ -26,7 +26,7 @@ class Mapping < ActiveRecord::Base
 
   # set a hash of the path because we can't have a unique index on
   # the path (it's too long)
-  before_validation :canonicalize_path, :set_path_hash
+  before_validation :fill_in_scheme, :canonicalize_path, :set_path_hash
   validates :path_hash, presence: true
 
   validates :new_url, :suggested_url, :archive_url, length: { maximum: (64.kilobytes - 1) }, non_blank_url: true
@@ -82,6 +82,26 @@ class Mapping < ActiveRecord::Base
   end
 
   protected
+  def fill_in_scheme
+    self.new_url       = Mapping.ensure_url(new_url)
+    self.suggested_url = Mapping.ensure_url(suggested_url)
+    self.archive_url   = Mapping.ensure_url(archive_url)
+  end
+
+  # uri can be a URL or something that is intended to be a URL,
+  # eg www.gov.uk/foo is technically not a URL, but we can prepend https:// and
+  # it becomes a URL.
+  def self.ensure_url(uri)
+    case
+    when uri.blank? || uri =~ %r{^https?:}
+      uri
+    when uri =~ %r{^www.gov.uk}
+      'https://' + uri
+    else
+      'http://' + uri
+    end
+  end
+
   def set_path_hash
     self.path_hash = Digest::SHA1.hexdigest(path) if path_changed?
   end

--- a/features/mapping_edit.feature
+++ b/features/mapping_edit.feature
@@ -44,7 +44,7 @@ Feature: Edit a site's mapping
     Then I should see the link replaced with a suggested URL field
 
   Scenario: Editing a mapping with invalid values
-    When I make the mapping a redirect to not-a-url
+    When I make the mapping a redirect to http:////not-a-url
     And I save the mapping
     Then I should still be editing a mapping
     And I should see "New URL is not a URL"


### PR DESCRIPTION
In user research, we have seen users adding URLs without schemes and being very confused when the change is rejected because the URL is invalid.
