### PR TITLE
Remove extra add mapping button

### DIFF
--- a/app/assets/stylesheets/base.css.scss
+++ b/app/assets/stylesheets/base.css.scss
@@ -188,6 +188,7 @@ main a {
 
 .table-header-secondary {
   background-color: $tableBackgroundAccent;
+  font-weight: bold;
 }
 
 thead .table-header-secondary td {

--- a/app/views/mappings/index.html.erb
+++ b/app/views/mappings/index.html.erb
@@ -73,7 +73,7 @@
     <% end %>
     </tbody>
     <% if current_user.can_edit?(@site.organisation) %>
-      <tfoot class="if-no-js-hide bold">
+      <tfoot class="if-no-js-hide">
         <%= render partial: 'mappings_table_header', locals: {footer: true} %>
       </tfoot>
     <% end %>


### PR DESCRIPTION
- Move pagination into the mappings.any block
- Only show another add mappings button if there are no existing
  mappings, ie the button isn’t already being shown within the table
- Fix an inconsistency between header and footer edit buttons
