### PR TITLE
Extract path from URL supplied for filtering

### DIFF
--- a/app/controllers/mappings_controller.rb
+++ b/app/controllers/mappings_controller.rb
@@ -21,6 +21,13 @@ class MappingsController < ApplicationController
   def index
     store_site_return_path
 
+    if params[:contains] =~ %r{^https?://}
+      begin
+        params[:contains] = URI.parse(params[:contains]).path
+      rescue URI::InvalidURIError
+      end
+    end
+
     @mappings = @site.mappings.order(:path).page(params[:page])
     @mappings = if params[:filter_field] == 'new_url'
        @mappings.redirects.filtered_by_new_url(params[:contains])

--- a/spec/controllers/mappings_controller_spec.rb
+++ b/spec/controllers/mappings_controller_spec.rb
@@ -40,6 +40,16 @@ describe MappingsController do
       get :index, site_id: site.abbr, contains: 'f.co/1', filter_field: 'new_url'
       assigns(:mappings).should == [mapping_a]
     end
+
+    it 'extracts paths from full URLs supplied for filtering' do
+      get :index, site_id: site.abbr, contains: 'https://www.example.com/foobar'
+      controller.params[:contains].should eql('/foobar')
+    end
+
+    it 'gracefully degrades if the filtering value looks like a URL but is unparseable' do
+      get :index, site_id: site.abbr, contains: 'https://____'
+      controller.params[:contains].should eql('https://____')
+    end
   end
 
   describe '#find' do


### PR DESCRIPTION
We've seen users supply full URLs for the filtering value during testing, which doesn't work, but it isn't clear why it shouldn't.

An elaboration on this might be to canonicalise the value as well, but this has value as-is.
