### PR TITLE
Remove network dependency for DNS import tests

### DIFF
--- a/spec/lib/transition/import/dns_details_spec.rb
+++ b/spec/lib/transition/import/dns_details_spec.rb
@@ -18,7 +18,7 @@ describe Transition::Import::DnsDetails do
       subject { transitioned }
 
       its(:cname) { should =~ /gov.uk$/ }
-      its(:ttl)   { should be > 1 && be < 999999 }
+      its(:ttl)   { should be_between(1, 999999) }
     end
 
     describe 'The host that is not transitioning' do


### PR DESCRIPTION
These tests have been failing in CI today. We can't quite see why that has started happening in that environment, but removing the network dependency here is a positive step anyway.
