### PR TITLE
Update Host CNAMEs every hour

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -11,3 +11,7 @@ job_type :rake, 'cd :path && /usr/local/bin/govuk_setenv transition bundle exec 
 every :day, at: ['3:30am', '1:15pm'] do
   rake 'import:whitehall:mappings'
 end
+
+every :hour do
+  rake 'import:dns_details'
+end


### PR DESCRIPTION
This will mean that the transition status for a site will be more up-to-date if it has transitioned today. Currently this happens at midnight when data is imported from Redirector.

The rake task currently takes about 45 seconds to run.
