### PR TITLE
Create a GOVUK date format to match style guide

### DIFF
--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -1,6 +1,6 @@
 module OrganisationsHelper
   def date_or_not_yet(date)
-    date.nil? ? 'No date set' : date.to_s(:long_ordinal)
+    date.nil? ? 'No date set' : (I18n.l date, :format => :govuk_date)
   end
 
   def add_indefinite_article(noun_phrase)

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -29,7 +29,7 @@
   <dt>Significant query parameters</dt>
   <dd><%= @site.query_params.presence || 'None' %></dd>
   <dt>The National Archive (<abbr>TNA</abbr>) timestamp</dt>
-  <dd><%= @site.tna_timestamp.to_formatted_s(:long) %> <span class="text-muted"> — <%= @site.tna_timestamp.to_formatted_s(:number) %></span></dd>
+  <dd><%= I18n.l @site.tna_timestamp, :format => :govuk_date %> <span class="text-muted"> — <%= @site.tna_timestamp.to_formatted_s(:number) %></span></dd>
   <dt>Transition status</dt>
   <dd><%= render partial: 'transition_status', locals: {site: @site} %></dd>
   <dt>Transition date</dt>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,4 +2,10 @@
 # See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
 
 en:
+  date:
+    formats:
+      govuk_date: "%-e %B %Y" # 1 January 2013 - https://www.gov.uk/design-principles/style-guide/style-points#style-dates-and-times
+  time:
+    formats:
+      govuk_date: "%-e %B %Y %-I:%m%P" # 1 January 2013 1:15pm
   not_possible_to_edit_homepage_mapping: "It’s not currently possible to edit the mapping for a site’s homepage."

--- a/spec/helpers/organisations_helper_spec.rb
+++ b/spec/helpers/organisations_helper_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe OrganisationsHelper do
   describe '#date_or_not_yet' do
     specify { helper.date_or_not_yet(nil).should == 'No date set' }
-    specify { helper.date_or_not_yet(Date.new(2014)).should == 'January 1st, 2014' }
+    specify { helper.date_or_not_yet(Date.new(2014)).should == '1 January 2014' }
   end
 
   describe '#add_indefinite_article' do


### PR DESCRIPTION
- Use on transition dates and TNA timestamps
- Matches GOV.UK style guide:
  https://www.gov.uk/design-principles/style-guide/style-points#style-date
  s-and-times
