### PR TITLE
Prevent empty parentheses from showing in site header

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,4 +19,13 @@ module ApplicationHelper
   def first_page?
     !past_first_page?
   end
+
+  def organisation_with_abbreviation(org)
+    if org.abbreviation.present?
+      "#{org.title} (#{org.abbreviation})"
+    else
+      org.title
+    end
+  end
+
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,7 +37,7 @@
           </li>
           <% if current_user.organisation %>
             <li <% if current_page?(organisation_path(current_user.organisation)) %> class="active" <% end %>>
-              <%= link_to "#{current_user.organisation.title} #{if current_user.organisation.abbreviation.present? then "(#{current_user.organisation.abbreviation})" end}", organisation_path(current_user.organisation), title: 'Your organisation' %>
+              <%= link_to organisation_with_abbreviation(current_user.organisation), organisation_path(current_user.organisation), title: 'Your organisation' %>
             </li>
           <% end %>
         </ul>


### PR DESCRIPTION
- In header only show an organisation's abbreviation when present
- Prevent empty parentheses showing in the header bar if the org abbreviation is blank
