### PR TITLE
Give Whitehall more time to finish mappings export

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -4,11 +4,11 @@ set :output, {:error => 'log/cron.error.log', :standard => 'log/cron.log'}
 job_type :rake, 'cd :path && /usr/local/bin/govuk_setenv transition bundle exec rake :task :output'
 
 # Run when the file has just been generated.
-# It appears to take ~50 minutes to generate based on the Last Modified HTTP header
+# If it runs while the file is being generated, it will download an incomplete file!
 #
 # At the time of writing, the file is generated twice a day:
 # https://github.com/alphagov/whitehall/blob/master/config/schedule.rb#L18
-every :day, at: ['3:30am', '1:15pm'] do
+every :day, at: ['4:15am', '2pm'] do
   rake 'import:whitehall:mappings'
 end
 


### PR DESCRIPTION
We're currently sometimes downloading the file before it has finished being
generated. This means we only get the file as it stands when we download it.

For UKBA, which is near the end of the file, this meant we weren't getting any
of their mappings.

It currently takes ~42 minutes to generate the file; we were allowing 30 mins.
Let's give it 1hr 15mins.

Relevant Whitehall cron: https://github.com/alphagov/whitehall/blob/master/config/schedule.rb#L20-L22
