### PR TITLE
Swap UKVI for UKBA

### DIFF
--- a/db/seeds/css-furl-fudge.yml
+++ b/db/seeds/css-furl-fudge.yml
@@ -10,9 +10,9 @@
 # In the meantime, this is where Organisation CSS and FURL get
 # set predictably and repeatably for both dev and production.
 ---
-uk-border-agency:
+uk-visas-and-immigration:
   :css: home-office
-  :furl: www.gov.uk/ukba
+  :furl:
 attorney-generals-office:
   :css: attorney-generals-office
   :furl: www.gov.uk/ago


### PR DESCRIPTION
We've made the UKBA sites owned by UKVI. So that they get some branding on 404
and 410 pages in Bouncer, we need to make a corresponding change here.
