### PR TITLE
Add pre-transition-stats to notmodules and hits import

### DIFF
--- a/.notmodules.yaml
+++ b/.notmodules.yaml
@@ -2,3 +2,5 @@
   url   : git@github.com:alphagov/redirector.git
 - path  : data/transition-stats
   url   : git@github.com:alphagov/transition-stats.git
+- path  : data/pre-transition-stats
+  url   : git@github.com:alphagov/pre-transition-stats.git

--- a/lib/tasks/import/all.rake
+++ b/lib/tasks/import/all.rake
@@ -1,3 +1,7 @@
+def glob_from_array(array)
+  '{' + array.join(',') + '}'
+end
+
 namespace :import do
   desc 'Import Organisations, Sites, Hosts, Mappings and Hits'
   task :all => [
@@ -14,8 +18,7 @@ namespace :import do
         'data/redirector/data/transition-sites/*.yml',
         'data/redirector/data/sites/*.yml',
       ]
-      glob = '{' + patterns.join(',') + '}'
-      Rake::Task['import:orgs_sites_hosts'].invoke(glob)
+      Rake::Task['import:orgs_sites_hosts'].invoke(glob_from_array(patterns))
     end
 
     desc 'Import all mappings'
@@ -25,7 +28,11 @@ namespace :import do
 
     desc 'Import all hits'
     task :hits do
-      Rake::Task['import:hits'].invoke('data/transition-stats/hits/*.tsv')
+      patterns = [
+        'data/transition-stats/hits/*.tsv',
+        'data/pre-transition-stats/hits/*.tsv',
+      ]
+      Rake::Task['import:hits'].invoke(glob_from_array(patterns))
     end
   end
 end


### PR DESCRIPTION
The jobs which run the import:all task will also need updating to
clone the pre-transition-stats repo, but that can be done independently
of this change.
