### PR TITLE
Update counts on existing hits rows if data changed

### DIFF
--- a/lib/transition/import/hits.rb
+++ b/lib/transition/import/hits.rb
@@ -46,12 +46,13 @@ module Transition
       mySQL
 
       INSERT_FROM_STAGING = <<-mySQL
-        INSERT IGNORE INTO hits (host_id, path, path_hash, http_status, `count`, hit_on)
+        INSERT INTO hits (host_id, path, path_hash, http_status, `count`, hit_on)
         SELECT h.id, st.path, SHA1(st.path), st.http_status, st.count, st.hit_on
         FROM   hits_staging st
         INNER JOIN hosts h on h.hostname = st.hostname
         WHERE  st.count >= 10
         AND    st.path NOT IN (#{BOUNCER_PATHS.map { |path| "'" + path + "'" }.join(', ')})
+        ON DUPLICATE KEY UPDATE hits.count=st.count
       mySQL
 
       def self.from_redirector_tsv_file!(filename)

--- a/spec/lib/transition/import/hits_spec.rb
+++ b/spec/lib/transition/import/hits_spec.rb
@@ -46,6 +46,22 @@ describe Transition::Import::Hits do
         Hit.count.should eql(1)
       end
     end
+
+    context 'a hits row already exists with a different count', testing_before_all: true do
+      before :all do
+        create_test_hosts
+        create(:hit, host: @businesslink_host, path: '/', count: 10, http_status: '301', hit_on: '2012-10-15')
+        Transition::Import::Hits.from_redirector_tsv_file!('spec/fixtures/hits/businesslink_2012-10-15.tsv')
+      end
+
+      it 'does not create a second hits row' do
+        Hit.count.should eql(1)
+      end
+
+      it 'updates the count for the existing row' do
+        Hit.first.count.should eql(21)
+      end
+    end
   end
 
   describe '.from_redirector_mask!', testing_before_all: true do


### PR DESCRIPTION
When we process logs, we will have data for partial days at the ends
of periods covered because the logs will not have been rotated at
exactly midnight. When subsequent days' logs are processed,
pre-transition-stats will update the hits file containing the partial
day's data with the full day's data, so long as the intermediate
cache file is not deleted between processing runs. This change to the
hits import allows us to re-import hits files containing updated counts
and have the counts on the already-imported rows updated, rather than
no change being made to rows which already exist.

This change appears to make the hits import take a couple of seconds
longer to run, but it's a pretty insignificant difference.

It's worth noting that both INSERT IGNORE and ON DUPLICATE KEY UPDATE
are MySQL-specific, so this change doesn't make it any harder to
move to PostGRES than it was before.
