### PR TITLE
Add a link to the side by side browser on site dashboards

### DIFF
--- a/app/views/sites/_tools.html.erb
+++ b/app/views/sites/_tools.html.erb
@@ -1,6 +1,16 @@
 <div class="panel panel-default">
   <h3 class="panel-heading remove-top-margin">Tools</h3>
   <div class="panel-body">
+    <h4 class="remove-top-margin">Side by side browser</h4>
+    <p>
+      Browse <i><%= site.default_host.hostname %></i> in the left panel, and, as you navigate, preview redirections and archives in the right panel.
+    </p>
+    <ul>
+      <li>
+        <a href="http://<%= site.default_host.hostname %>.side-by-side.alphagov.co.uk/__/#/">Open side by side browser</a>
+      </li>
+    </ul>
+    <hr />
     <h4 class="remove-top-margin">Preview redirections</h4>
     <p>
       To test a redirection for a pre-transition website:

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -27,7 +27,7 @@
       <%= date_or_not_yet(@site.launch_date) %>
     </div>
 
-    <%= render 'tools' %>
+    <%= render partial: 'tools', locals: {site: @site } %>
     
   </div>
 </div>

--- a/features/site.feature
+++ b/features/site.feature
@@ -19,6 +19,7 @@ Scenario: Visit a post-transition site's page
   And I should be able to edit the site's mappings
   And I should be able to view the site's analytics
   And I should see the site's configuration including all host aliases
+  And I should see a link to the side by side browser
 
 Scenario: Visit a pre-transition site's page
   Given I have logged in as an admin

--- a/features/step_definitions/site_assertion_steps.rb
+++ b/features/step_definitions/site_assertion_steps.rb
@@ -64,3 +64,7 @@ Then(/^I should be able to view the site's mappings$/) do
     expect(page).to have_link('a', href: site_mappings_path(@site))
   end
 end
+
+Then(/^I should see a link to the side by side browser$/) do
+  expect(page).to have_selector('a[href*="www.attorney-general.gov.uk.side-by-side"]')
+end


### PR DESCRIPTION
- Link to the side by side browser for the given site
- Caveats: This isn’t a smart link and will show for sites without an AKA domain, at the moment neither side by side browser or Transition handles this gracefully.
