### PR TITLE
Stop the logo being cropped

### DIFF
--- a/app/assets/stylesheets/navbar.css.scss
+++ b/app/assets/stylesheets/navbar.css.scss
@@ -8,6 +8,7 @@
   font-size: 20px;
   margin-left: 0;
   padding-left: 2.3em;
+  min-height: 37px;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
- An update to Bootstrap 3.1 caused a regression with the logo in the
  navbar. This fixes it by forcing a minimum height.
