### PR TITLE
Prevent bulk tag modal from disappearing when selecting many paths

### DIFF
--- a/app/views/mappings/_tag_list_field.html.erb
+++ b/app/views/mappings/_tag_list_field.html.erb
@@ -1,9 +1,17 @@
 <% modal ||= false %>
 
 <%= field_set_tag nil, class: 'form-group' do %>
-  <legend class="rm">
-    Tagging
-  </legend>
+
+  <%
+    # Rendering a legend with hidden content in a bootstrap modal
+    # causes the entire modal to disappear in Chrome ~32
+    # Firefox and Safari don't seem affected
+  %>
+  <% unless modal %>
+    <legend class="rm">
+      Tagging
+    </legend>
+  <% end %>
 
   <% tag_list_label = capture do %>
     Tags


### PR DESCRIPTION
- In Chrome ~32 the modal would report as display block, and using the
  inspector everything looked correct, except that the content was
  invisible. Toggling display:block on and off brought the content up.
- Debugging showed that the `<legend>` element caused the strange
  behaviour, the fix is to remove when using a modal.
- I can’t find any Bootstrap or Chrome bugs that relate to this.
