### PR TITLE
Override archived mappings from Whitehall

### DIFF
--- a/lib/transition/import/whitehall/mappings_csv.rb
+++ b/lib/transition/import/whitehall/mappings_csv.rb
@@ -37,12 +37,13 @@ module Transition
                 canonical_path = host.site.canonical_path(row['Old URL'])
                 existing_mapping = host.site.mappings.where(path_hash: path_hash(canonical_path)).first
 
-                unless existing_mapping && existing_mapping.edited_by_human?
-                  if existing_mapping
-                    existing_mapping.update_attributes(new_url: row['New URL'], http_status: '301')
-                  else
-                    host.site.mappings.create(path: canonical_path, new_url: row['New URL'], http_status: '301')
-                  end
+                if existing_mapping
+                    if existing_mapping.http_status == '410' ||
+                        ! existing_mapping.edited_by_human?
+                      existing_mapping.update_attributes(new_url: row['New URL'], http_status: '301')
+                    end
+                else
+                  host.site.mappings.create(path: canonical_path, new_url: row['New URL'], http_status: '301')
                 end
               end
             end

--- a/spec/lib/transition/import/whitehall/mappings_csv_spec.rb
+++ b/spec/lib/transition/import/whitehall/mappings_csv_spec.rb
@@ -59,9 +59,9 @@ describe Transition::Import::Whitehall::MappingsCSV do
         its(:http_status) { should == '301' }
       end
 
-      context 'existing mapping edited by a human' do
+      context 'existing redirect mapping edited by a human' do
         let(:csv) {
-          create(:mapping, from_redirector: true, site: site, path: '/oldurl', new_url: 'https://www.gov.uk/curated')
+          create(:mapping, from_redirector: true, site: site, path: '/oldurl', http_status: '301', new_url: 'https://www.gov.uk/curated')
           csv_for('/oldurl', '/automated')
         }
 
@@ -70,6 +70,20 @@ describe Transition::Import::Whitehall::MappingsCSV do
         specify { Mapping.count.should == 1 }
 
         its(:new_url)     { should == 'https://www.gov.uk/curated' }
+      end
+
+      context 'existing archive mapping edited by a human' do
+        let(:csv) {
+          create(:mapping, from_redirector: true, site: site, path: '/oldurl', http_status: '410')
+          csv_for('/oldurl', '/automated')
+        }
+
+        subject(:mapping) { Mapping.first }
+
+        specify { Mapping.count.should == 1 }
+
+        its(:http_status) { should == '301' }
+        its(:new_url)     { should == 'https://www.gov.uk/automated' }
       end
 
       context 'CSV row without an Old URL' do


### PR DESCRIPTION
We want users to be able to bulk-add mappings as 410s, and then
have them automatically updated later to redirect when their content
is published in Whitehall. An existing mapping will now not be
updated from the Whitehall mappings CSV only if its last edit was
made by a human and it is a redirect.
