### PR TITLE
Switch to storing sessions in database

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,8 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
-Transition::Application.config.session_store :cookie_store, key: '_transition_session', secure: Rails.env.production?
-
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information
 # (create the session table with "rails generate session_migration")
-# Transition::Application.config.session_store :active_record_store
+Transition::Application.config.session_store :active_record_store

--- a/db/migrate/20140225152616_add_sessions_table.rb
+++ b/db/migrate/20140225152616_add_sessions_table.rb
@@ -1,0 +1,12 @@
+class AddSessionsTable < ActiveRecord::Migration
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, :null => false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id
+    add_index :sessions, :updated_at
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -103,6 +103,17 @@ CREATE TABLE `schema_migrations` (
   UNIQUE KEY `unique_schema_migrations` (`version`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
+CREATE TABLE `sessions` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `session_id` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `data` text COLLATE utf8_unicode_ci,
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `index_sessions_on_session_id` (`session_id`),
+  KEY `index_sessions_on_updated_at` (`updated_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
 CREATE TABLE `sites` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `organisation_id` int(11) NOT NULL,
@@ -227,3 +238,5 @@ INSERT INTO schema_migrations (version) VALUES ('20131231133153');
 INSERT INTO schema_migrations (version) VALUES ('20140127151418');
 
 INSERT INTO schema_migrations (version) VALUES ('20140127151419');
+
+INSERT INTO schema_migrations (version) VALUES ('20140225152616');


### PR DESCRIPTION
- We were exceeding the cookie size limit in our sessions
  (save_mapping_ids)
- Send less data with each request
- Table generated using `rake db:sessions:create`
- See
  http://stackoverflow.com/questions/11706297/rails-3-storing-session-in-active-record-not-cookie
