### PR TITLE
Check the site abbr when showing a mapping's history

### DIFF
--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -1,6 +1,15 @@
 class VersionsController < ApplicationController
+
+  before_filter :find_site
+
   def index
     @mapping = Mapping.find(params[:mapping_id])
     @versions = @mapping.versions
+  end
+
+private
+
+  def find_site
+    @site = Site.find_by_abbr!(params[:site_id])
   end
 end

--- a/features/mapping_history.feature
+++ b/features/mapping_history.feature
@@ -32,3 +32,11 @@ Feature: History of edits to a mapping
     And there is a mapping that has no history
     When I go to edit that mapping
     Then I should see no history
+
+  @allow-rescue
+  Scenario: Trying to look at a mapping's history on the wrong site
+    When I log in as a SIRO
+    And I visit the path /sites/directgov/mappings/1/versions
+    Then I should see "History"
+    When I visit the path /sites/not_a_site/mappings/1/versions
+    Then I should see our custom 404 page


### PR DESCRIPTION
The versions controller was only using the mapping id and ignoring
the site_id param, so it was possible to see a mapping's history
even when the site abbr in the URL did not match the mapping's site's
abbr. Now it 404s in this case. (The page always showed the correct
site's details in the breadcrumb and elsewhere.)
