### PR TITLE
Exclude furniture URLs from hits

### DIFF
--- a/lib/transition/import/hits.rb
+++ b/lib/transition/import/hits.rb
@@ -31,6 +31,16 @@ module Transition
         '/wales_crest_18px_x2.png',
       ]
 
+      FURNITURE_PATTERNS = [
+        '.*\.css',
+        '.*\.js',
+        '.*\.gif',
+        '.*\.ico',
+        '.*\.jpg',
+        '.*\.jpeg',
+        '.*\.png',
+      ]
+
       TRUNCATE = <<-mySQL
         TRUNCATE hits_staging
       mySQL
@@ -52,6 +62,7 @@ module Transition
         INNER JOIN hosts h on h.hostname = st.hostname
         WHERE  st.count >= 10
         AND    st.path NOT IN (#{BOUNCER_PATHS.map { |path| "'" + path + "'" }.join(', ')})
+        AND    st.path NOT REGEXP '#{ FURNITURE_PATTERNS.join('|') }'
         ON DUPLICATE KEY UPDATE hits.count=st.count
       mySQL
 

--- a/spec/fixtures/hits/furniture_paths.tsv
+++ b/spec/fixtures/hits/furniture_paths.tsv
@@ -1,0 +1,8 @@
+date	count status	host	path
+2012-10-14	11	200	www.businesslink.gov.uk	/legitimate
+2012-10-14	11	200	www.businesslink.gov.uk	/static/css/theme3.css
+2012-10-14	11	200	www.businesslink.gov.uk	/syntegra/js/s_code_remote.js
+2012-10-14	11	200	www.businesslink.gov.uk	/syntegra/images/sbs_bdotg_favicon.ico
+2012-10-14	11	200	www.businesslink.gov.uk	/syntegra/images/cheese.jpg
+2012-10-14	11	200	www.businesslink.gov.uk	/syntegra/images/wine.jpeg
+2012-10-14	11	200	www.businesslink.gov.uk	/syntegra/images/grapes.png

--- a/spec/lib/transition/import/hits_spec.rb
+++ b/spec/lib/transition/import/hits_spec.rb
@@ -36,13 +36,24 @@ describe Transition::Import::Hits do
       end
     end
 
-    context 'a single import from a file with bouncer-related paths' do
+    context 'a single import from a file with bouncer-related paths', testing_before_all: true do
       before :all do
         create_test_hosts
         Transition::Import::Hits.from_redirector_tsv_file!('spec/fixtures/hits/bouncer_paths.tsv')
       end
 
       it 'should ignore hits that are a bouncer implementation detail' do
+        Hit.count.should eql(1)
+      end
+    end
+
+    context 'import from a file with furniture asset paths', testing_before_all: true do
+      before :all do
+        create_test_hosts
+        Transition::Import::Hits.from_redirector_tsv_file!('spec/fixtures/hits/furniture_paths.tsv')
+      end
+
+      it 'should ignore hits that are furniture so are uninteresting and unlikely to be mapped' do
         Hit.count.should eql(1)
       end
     end


### PR DESCRIPTION
These are rarely mapped, are generally not very interesting, but flood the analytics pages.

It will be necessary to truncate the hits and daily_hit_totals tables and then reimport them to remove the already imported furniture hits. This should be easy to do by hand.

Some totally unscientific testing on my VM:
Before:
Hits.count: 2,020,511
bundle exec rake import:all
11.45s user 6.42s system 11% cpu 2:32.23 total

After:
Hits.count: 1,734,744
bundle exec rake import:all
11.08s user 5.90s system 9% cpu 2:57.39 total
