### PR TITLE
Default hits to last 30 days instead of all time

### DIFF
--- a/app/models/view/hits/time_period.rb
+++ b/app/models/view/hits/time_period.rb
@@ -21,6 +21,7 @@ module View
       end
 
       DATE_RANGE = /[0-9]{8}(?:-[0-9]{8})?/
+      DEFAULT_SLUG = 'last-30-days'
 
       PERIODS_BY_SLUG = {
         'Yesterday'       => lambda { Date.yesterday..Date.today },
@@ -49,7 +50,7 @@ module View
       end
 
       def self.default
-        PERIODS_BY_SLUG['all-time']
+        PERIODS_BY_SLUG[DEFAULT_SLUG]
       end
 
       def self.[](slug)
@@ -64,7 +65,7 @@ module View
       end
 
       def query_slug
-        slug unless slug == 'all-time'
+        slug unless slug == DEFAULT_SLUG
       end
 
       def range

--- a/features/hits_all.feature
+++ b/features/hits_all.feature
@@ -5,6 +5,7 @@ Feature: All traffic for site
 
 Scenario: Hits exist and are ordered for a site
   Given I have logged in as an admin
+  And the date is 19/10/12
   And these hits exist for the Attorney General's office site:
     | http_status | path | hit_on   | count |
     | 410         | /    | 16/10/12 | 100   |
@@ -30,10 +31,11 @@ Scenario: No hits exist
   Given I have logged in as an admin
   And no hits exist for the Attorney General's office site
   When I visit the associated site's hits
-  Then I should see "We don’t have any traffic data for ago yet."
+  Then I should see "We don’t have any traffic data for ago"
 
 Scenario: Check mapping for a hit
   Given I have logged in as an admin
+  And the date is 19/10/12
   And these hits exist for the Attorney General's office site:
     | http_status | path | hit_on   | count |
     | 301         | /    | 16/10/12 | 100   |

--- a/features/hits_summary.feature
+++ b/features/hits_summary.feature
@@ -20,6 +20,7 @@ Background: I start at the summary page
     | 301         | /9   | 18/10/12 | 100   |
     | 301         | /10  | 18/10/12 | 100   |
     | 301         | /11  | 18/10/12 | 10    |
+    | 301         | /12  | 10/08/12 | 10    |
     | 410         | /    | 17/10/12 | 100   |
     | 410         | /2   | 17/10/12 | 100   |
     | 410         | /3   | 18/10/12 | 100   |
@@ -31,6 +32,7 @@ Background: I start at the summary page
     | 410         | /9   | 18/10/12 | 100   |
     | 410         | /10  | 18/10/12 | 100   |
     | 410         | /11  | 18/10/12 | 10    |
+    | 410         | /12  | 10/08/12 | 10    |
     | 404         | /    | 17/10/12 | 100   |
     | 404         | /2   | 17/10/12 | 100   |
     | 404         | /3   | 18/10/12 | 100   |
@@ -42,6 +44,7 @@ Background: I start at the summary page
     | 404         | /9   | 18/10/12 | 100   |
     | 404         | /10  | 18/10/12 | 100   |
     | 404         | /11  | 18/10/12 | 10    |
+    | 404         | /12  | 10/08/12 | 10    |
     | 200         | /    | 17/10/12 | 100   |
     | 200         | /2   | 17/10/12 | 100   |
     | 200         | /3   | 18/10/12 | 100   |
@@ -53,6 +56,7 @@ Background: I start at the summary page
     | 200         | /9   | 18/10/12 | 100   |
     | 200         | /10  | 18/10/12 | 100   |
     | 200         | /11  | 18/10/12 | 10    |
+    | 200         | /12  | 10/08/12 | 10    |
   When I visit the associated site
   And I click the link "Analytics"
 
@@ -70,9 +74,16 @@ Scenario: Hits exist and are summarised for a site, displayed with a graph
   And it should show only the top 9 errors in descending count order
   But I should not see a graph
 
+Scenario: Hits exist and show the last 30 days by default
+  When I click the link "Redirects"
+  Then I should see an redirects graph showing a green trend line with 2 points
+  And I should see a redirects graph showing a green trend line
+  And I should see hits from the last 30 days with a redirect status, in descending count order
+  And the period "Last 30 days" should be selected
+
 Scenario: Hits exist and can be filtered by error and time period "Yesterday"
   When I click the link "Errors"
-  Then I should see all hits with an error status for the Attorney General's office in descending count order
+  Then I should see hits from the last 30 days with an error status, in descending count order
   And I should see an errors graph showing a red trend line
   When I filter by the date period "Yesterday"
   Then I should see only yesterday's errors in descending count order
@@ -81,18 +92,16 @@ Scenario: Hits exist and can be filtered by error and time period "Yesterday"
 
 Scenario: Hits exist and can be filtered by archives and time period "Last seven days"
   When I click the link "Archives"
-  Then I should see all hits with an archive status for the Attorney General's office in descending count order
+  Then I should see hits from the last 30 days with an archive status, in descending count order
   When I filter by the date period "Last seven days"
   Then I should see an archives graph showing a grey trend line with 2 points
   And the period "Last seven days" should be selected
 
-Scenario: Hits exist and can be filtered by redirects and time period "Last 30 days"
+Scenario: Hits exist and can be filtered by redirects and time period "All time"
   When I click the link "Redirects"
-  Then I should see all hits with a redirect status for the Attorney General's office in descending count order
-  And I should see a redirects graph showing a green trend line
-  When I filter by the date period "Last 30 days"
-  Then I should see an redirects graph showing a green trend line with 2 points
-  And the period "Last 30 days" should be selected
+  And I filter by the date period "All time"
+  Then I should see all hits with a redirect status, in descending count order
+  And the period "All time" should be selected
 
 Scenario: There are multiple pages for a category
   Given the hits page size is 11
@@ -106,9 +115,9 @@ Scenario: No hits exist at all
   When I visit the associated site
   And I click the link "Analytics"
   Then I should not see a graph
-  And I should see "There are no known hits for the ago summary yet"
+  And I should see "There are no known hits for the ago summary"
   When I click the link "Errors"
-  Then I should see "There are no errors for ago yet"
+  Then I should see "There are no errors for ago"
   And I should not see a graph
   When I filter by the date period "Last seven days"
   Then I should see "There are no errors for ago in this time period"

--- a/features/step_definitions/hits_assertion_steps.rb
+++ b/features/step_definitions/hits_assertion_steps.rb
@@ -76,7 +76,7 @@ Then(/^I should see a trend for all hits, errors, archives and redirects$/) do
   end
 end
 
-Then(/^I should see all hits with a[n]? (\w+) status for the Attorney General's office in descending count order$/) do |category|
+Then(/^I should see hits from the last 30 days with a[n]? (\w+) status, in descending count order$/) do |category|
 
   case category
   when 'error'
@@ -89,6 +89,22 @@ Then(/^I should see all hits with a[n]? (\w+) status for the Attorney General's 
 
   within '.hits' do
     expect(page).to have_sorted_bar_rows(11).for_status(status)
+  end
+end
+
+Then(/^I should see all hits with a[n]? (\w+) status, in descending count order$/) do |category|
+
+  case category
+  when 'error'
+    status = 404
+  when 'archive'
+    status = 410
+  when 'redirect'
+    status = 301
+  end
+
+  within '.hits' do
+    expect(page).to have_sorted_bar_rows(12).for_status(status)
   end
 end
 

--- a/spec/controllers/hits_controller_spec.rb
+++ b/spec/controllers/hits_controller_spec.rb
@@ -27,6 +27,7 @@ describe HitsController do
     end
 
     before do
+      Timecop.freeze(Date.new(2013, 01, 01))
       login_as_stub_user
       Transition::Import::DailyHitTotals.from_hits!
       get :category, site_id: site, category: test_category_name

--- a/spec/models/view/time_period_spec.rb
+++ b/spec/models/view/time_period_spec.rb
@@ -17,18 +17,34 @@ describe View::Hits::TimePeriod do
       its(:query_slug) { should == 'yesterday' }
     end
 
-    describe 'the default, all-time' do
+    describe 'the default, last-30-days' do
       subject { View::Hits::TimePeriod.default }
 
-      its(:title)      { should == 'All time' }
-      its(:slug)       { should == 'all-time' }
+      its(:title)      { should == 'Last 30 days' }
+      its(:slug)       { should == 'last-30-days' }
       its(:query_slug) { should be_nil }
-      its(:no_content) { should == 'yet' }
+      its(:no_content) { should == 'in this time period' }
     end
 
     describe 'indexing on slug' do
       it 'returns nil on unrecognised time periods' do
         View::Hits::TimePeriod['non-existent'].should be_nil
+      end
+      
+      describe 'All time' do
+        subject { View::Hits::TimePeriod['all-time'] }
+
+        its(:title)      { should == 'All time' }
+        its(:range)      { should == (100.years.ago.to_date..Date.today) }
+        its(:start_date) { should == 100.years.ago.to_date }
+        its(:end_date)   { should == Date.today }
+        its(:no_content) { should == 'yet' }
+
+        it 'calculates dates correctly even if, say, the server has been up a few decades' do
+          Timecop.freeze(Date.new(2112, 10, 31)) do
+            View::Hits::TimePeriod['all-time'].range.should == (100.years.ago.to_date..Date.today)
+          end
+        end
       end
 
       describe 'Last 30 days' do


### PR DESCRIPTION
- Switch from All time to Last 30 days
- Show more relevant errors and load pages faster
- Tweak feature so there’s a difference between 30 days and all time
- Use Timecop to freeze time in feature and specs
