### PR TITLE
Change the message for removing all tags from mappings

### DIFF
--- a/app/models/view/mappings/bulk_tagger.rb
+++ b/app/models/view/mappings/bulk_tagger.rb
@@ -48,7 +48,11 @@ module View
 
       def success_message
         successes = mappings.count - @failure_ids.length
-        "#{successes} #{ 'mapping'.pluralize(successes) } tagged “#{tag_list}”"
+        if tag_list.blank?
+          "Tags removed from #{successes} #{ 'mapping'.pluralize(successes) }"
+        else
+          "#{successes} #{ 'mapping'.pluralize(successes) } tagged “#{tag_list}”"
+        end
       end
 
     private


### PR DESCRIPTION
- The message reads: "Tags removed from num_x mappings".
- This is an alternative to "Tags a and b removed from num_x
  mappings", which I don't think could be done due to tag_list being
  blank at the time of saving when tags are deleted.
