### PR TITLE
Fix mappings header to top when scrolling

### DIFF
--- a/app/assets/javascripts/modules/fixed_table_header.js
+++ b/app/assets/javascripts/modules/fixed_table_header.js
@@ -1,0 +1,38 @@
+(function(Modules) {
+  "use strict"
+
+  Modules.FixedTableHeader = function() {
+    var that = this;
+    that.start = function(element) {
+
+      // Clone the current table header into a fixed container
+      // Use .container class for correct width and responsiveness
+      // Setup a dummy table for correct rendering of cloned <thead>
+      // Basics derived from http://stackoverflow.com/questions/4709390/
+
+      var header = element.find('thead'),
+          headerOffset = header.offset().top,
+          fixedHeader = header.clone(),
+          fixedHeaderContainer = $('\
+          <div class="fixed-table-header-container">\
+            <div class="container">\
+              <table class="table table-bordered">\
+              </table>\
+            </div>\
+          </div>');
+
+      fixedHeaderContainer.hide().find('table').append(fixedHeader);
+      element.prepend(fixedHeaderContainer);
+      $(window).bind("scroll", checkOffsetAndToggleFixedHeader);
+
+      function checkOffsetAndToggleFixedHeader() {
+        var offset = $(window).scrollTop();
+        if (offset >= headerOffset && fixedHeaderContainer.is(":hidden")) {
+          fixedHeaderContainer.show();
+        } else if (offset < headerOffset) {
+          fixedHeaderContainer.hide();
+        }
+      }
+    }
+  };
+})(window.GOVUK.Modules);

--- a/app/assets/stylesheets/base.css.scss
+++ b/app/assets/stylesheets/base.css.scss
@@ -177,7 +177,7 @@ main a {
   &:visited {
     color: $link-color-visited;
   }
-  
+
   &.no-visit:visited {
     color: $link-color;
   }
@@ -282,6 +282,18 @@ thead .table-header-secondary td {
 
 .radio.table-header-radio {
   padding-top: 0;
+}
+
+.fixed-table-header-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 10;
+
+  table {
+    box-shadow: 0 3px 10px -5px rgba(0, 0, 0, 0.3);
+  }
 }
 
 /* Selectable rows

--- a/app/assets/stylesheets/mappings.css.scss
+++ b/app/assets/stylesheets/mappings.css.scss
@@ -5,7 +5,7 @@
 }
 
 .mapping-type-column {
-  width: 70px;
+  width: 75px;
 }
 
 .mapping-edit-column {

--- a/app/views/mappings/_mappings_table.html.erb
+++ b/app/views/mappings/_mappings_table.html.erb
@@ -1,9 +1,11 @@
 <% css ||= false %>
 <% include_footer ||= false %>
 <% include_bulk_add ||= false %>
+<% fix_header ||= false %>
 
 <% if current_user.can_edit?(site.organisation) %>
   <div data-module="selectable-table">
+    <% if fix_header %><div data-module="fixed-table-header"><% end %>
 <% end %>
 <%= form_tag edit_multiple_site_mappings_path(site), remote: true do %>
 <table class="mappings <%= css if css %> table table-bordered">
@@ -65,5 +67,6 @@
 </table>
 <% end %>
 <% if current_user.can_edit?(site.organisation) %>
+    <% if fix_header %></div><% end %>
   </div>
 <% end %>

--- a/app/views/mappings/index.html.erb
+++ b/app/views/mappings/index.html.erb
@@ -24,7 +24,8 @@
       site: @site,
       css: 'mappings-index',
       include_footer: true,
-      include_bulk_add: true
+      include_bulk_add: true,
+      fix_header: true
     }
   %>
 

--- a/spec/javascripts/spec/fixed_table_header.spec.js
+++ b/spec/javascripts/spec/fixed_table_header.spec.js
@@ -1,0 +1,75 @@
+describe('A fixed table header', function() {
+  "use strict"
+
+  var root = window,
+      module,
+      element;
+
+  beforeEach(function() {
+    // Use a large padding bottom to make window scrollable.
+    element = $('\
+      <div style="padding-bottom: 10000px">\
+        <table>\
+          <thead>\
+          </thead>\
+        </table>\
+      </div>\
+    ');
+
+    module = new GOVUK.Modules.FixedTableHeader();
+  });
+
+  describe('when starting', function() {
+
+    beforeEach(function() {
+      module.start(element);
+    });
+
+    it('clones the table header and appends to a dummy table', function() {
+      expect(element.find('.fixed-table-header-container table thead').length).toBe(1);
+      expect(element.find('thead').length).toBe(2);
+    });
+
+    it('defaults to hiding the container', function() {
+      expect(element.find('.fixed-table-header-container').is(':hidden')).toBe(true);
+    });
+  });
+
+  describe('when scrolling', function() {
+    beforeEach(function() {
+      $('body').append(element);
+      module.start(element);
+    });
+
+    afterEach(function() {
+      element.remove();
+    });
+
+    it('toggles the table based on the window and table scroll positions', function() {
+      shouldHeaderBeHidden(true);
+      var headerPosition = element.offset().top;
+
+      scroll(headerPosition - 1); // scroll approaching element
+      shouldHeaderBeHidden(true);
+
+      scroll(headerPosition);     // scroll reached element
+      shouldHeaderBeHidden(false);
+      
+      scroll(headerPosition + 1); // scroll beyond element
+      shouldHeaderBeHidden(false);
+
+      scroll(headerPosition - 1); // scoll back, to before element
+      shouldHeaderBeHidden(true);
+
+      function shouldHeaderBeHidden(hidden) {
+        expect(element.find('.fixed-table-header-container').is(':hidden')).toBe(hidden);
+      }
+
+      function scroll(y) {
+        window.scrollTo(0, y);
+        $(window).trigger('scroll');
+      }
+    });
+  });
+
+});


### PR DESCRIPTION
- When scrolling past a mapping table header, it fixes to the top to
  avoid losing context whilst editing mappings
- Only applies to tables not in a modal
- Increase mapping type column size to prevent re-sizing when table
  header toggles
