### PR TITLE
Allow tag autocomplete in <IE8

### DIFF
--- a/app/assets/javascripts/tagging.js
+++ b/app/assets/javascripts/tagging.js
@@ -16,8 +16,8 @@
           setTags(
             $(input.val().split(",")).map(function () {
               return {
-                id: this.trim(),
-                text: this.trim()
+                id: $.trim(this),
+                text: $.trim(this)
               };
             })
           )


### PR DESCRIPTION
- "trim" isn't available in IE8, use jQuery’s trim instead
