### PR TITLE
After editing mappings via hits, return to hits

### DIFF
--- a/app/controllers/mappings_controller.rb
+++ b/app/controllers/mappings_controller.rb
@@ -28,7 +28,12 @@ class MappingsController < ApplicationController
     flash[:success] = bulk_add.success_message
     flash[:saved_mapping_ids] = bulk_add.modified_mappings.map {|m| m.id}
     flash[:saved_operation] = bulk_add.operation_description
-    redirect_to site_mappings_path(@site)
+
+    if params[:return_path] && params[:return_path].start_with?('/')
+      redirect_to params[:return_path]
+    else
+      redirect_to site_mappings_path(@site)
+    end
   end
 
   def index
@@ -159,9 +164,9 @@ class MappingsController < ApplicationController
 
     mapping = @site.mappings.find_by_path(path)
     if mapping.present?
-      redirect_to edit_site_mapping_path(@site, mapping)
+      redirect_to edit_site_mapping_path(@site, mapping, return_path: params[:return_path])
     else
-      redirect_to new_multiple_site_mappings_path(@site, paths: path)
+      redirect_to new_multiple_site_mappings_path(@site, paths: path, return_path: params[:return_path])
     end
   end
 

--- a/app/views/hits/_hits_table.html.erb
+++ b/app/views/hits/_hits_table.html.erb
@@ -41,7 +41,7 @@
         <td class="action">
           <% unless hit.homepage? %>
             <%= link_to "#{hit.mapping.present? ? 'Edit' : 'Add'} mapping",
-                        site_mapping_find_path(@site, path: hit.path), class: 'btn btn-default btn-xs' %>
+                        site_mapping_find_path(@site, path: hit.path, return_path: request.fullpath), class: 'btn btn-default btn-xs' %>
           <% end %>
         </td>
       <% end %>

--- a/app/views/mappings/_mappings_table.html.erb
+++ b/app/views/mappings/_mappings_table.html.erb
@@ -23,7 +23,7 @@
       <% end %>
     </tr>
     <% if current_user.can_edit?(site.organisation) %>
-      <%= render partial: 'mappings_table_header', locals: {footer: false, include_bulk_add: include_bulk_add} %>
+      <%= render partial: 'mappings/mappings_table_header', locals: {footer: false, include_bulk_add: include_bulk_add} %>
     <% end %>
   </thead>
   <tbody>
@@ -43,7 +43,7 @@
       </td>
       <td class="mapping-path">
         <strong class="pull-left"><%= link_to mapping.path, mapping.old_url, class: 'breakable' %></strong>
-        <%= render partial: 'tags', locals: { mapping: mapping } %>
+        <%= render partial: 'mappings/tags', locals: { mapping: mapping } %>
         <% if mapping.redirect? %>
           <br><span class="text-muted">redirects to</span>
           <%= link_to mapping.new_url, mapping.new_url, class: 'link-muted breakable' if mapping.new_url.present? %>
@@ -61,7 +61,7 @@
   </tbody>
   <% if include_footer && current_user.can_edit?(site.organisation) %>
     <tfoot class="if-no-js-hide">
-      <%= render partial: 'mappings_table_header', locals: {footer: true, include_bulk_add: include_bulk_add} %>
+      <%= render partial: 'mappings/mappings_table_header', locals: {footer: true, include_bulk_add: include_bulk_add} %>
     </tfoot>
   <% end %>
 </table>

--- a/app/views/mappings/_mappings_table_header.html.erb
+++ b/app/views/mappings/_mappings_table_header.html.erb
@@ -32,7 +32,7 @@
     </div>
     <% if include_bulk_add %>
       <div class="pull-right">
-        <%= render partial: 'add_button' %>
+        <%= render partial: 'mappings/add_button' %>
       </div>
     <% end %>
   </td>

--- a/app/views/mappings/_saved_mappings_modal.html.erb
+++ b/app/views/mappings/_saved_mappings_modal.html.erb
@@ -13,7 +13,7 @@
         <a href="#close" data-dismiss="modal" class="btn btn-success btn-modal-close">OK</a>
       </header>
       <div class="modal-body remove-bottom-padding">
-        <%= render partial: 'mappings_table',
+        <%= render partial: 'mappings/mappings_table',
           locals: {
             site: site,
             mappings: mappings

--- a/app/views/mappings/new_multiple.html.erb
+++ b/app/views/mappings/new_multiple.html.erb
@@ -13,6 +13,10 @@
   <% if @errors %>
     <%= render 'shared/error_messages', error_messages: @errors.values %>
   <% end %>
+  
+  <% if params[:return_path].present? %>
+    <%= hidden_field_tag 'return_path', params[:return_path] %>
+  <% end %>
 
   <div class="row <% if @errors && @errors[:http_status] %>field_with_errors<% end %>">
     <div class="col-md-2">

--- a/app/views/mappings/new_multiple_confirmation.html.erb
+++ b/app/views/mappings/new_multiple_confirmation.html.erb
@@ -11,6 +11,10 @@
 
 <%= form_tag create_multiple_site_mappings_path(@site) do %>
 
+  <% if params[:return_path].present? %>
+    <%= hidden_field_tag 'return_path', params[:return_path] %>
+  <% end %>
+
   <% if existing_mappings_count > 0 %>
     <div class="alert alert-warning">
       <h4>We’ve found <%= pluralize(existing_mappings_count, "existing mapping") %> for the paths entered</h4>

--- a/features/hits_all.feature
+++ b/features/hits_all.feature
@@ -33,7 +33,7 @@ Scenario: No hits exist
   When I visit the associated site's hits
   Then I should see "We don’t have any traffic data for ago"
 
-Scenario: Check mapping for a hit
+Scenario: Add mapping for a hit
   Given I have logged in as an admin
   And the date is 19/10/12
   And these hits exist for the Attorney General's office site:
@@ -46,3 +46,22 @@ Scenario: Check mapping for a hit
   When I click on the link to check the mapping for the top hit
   Then I should be on the add mapping page
   And the top hit's canonicalized path should already be in the form
+  When I make the mapping an archive
+  And I continue
+  And I save my changes
+  Then I should see "1 mapping created. 0 mappings updated." in a modal window
+  And I should be on the site's hits summary page
+
+Scenario: Edit mapping from a hit
+  Given I have logged in as an admin
+  And the date is 19/10/12
+  And these hits exist for the Attorney General's office site:
+    | http_status | path | hit_on   | count |
+    | 410         | /A   | 16/10/12 | 100   |
+  And a 410 mapping exists for the site with the path /A
+  And I am on the Attorney General's office site's hits page
+  When I click on the link to check the mapping for the top hit
+  Then I should be on the edit mapping page
+  When I save the mapping
+  Then I should see "Mapping saved" in a modal window
+  And I should be on the site's hits summary page

--- a/features/step_definitions/fixture_steps.rb
+++ b/features/step_definitions/fixture_steps.rb
@@ -53,6 +53,10 @@ Given (/^a (\d+) mapping exists for the (.+) site with the path (.*)$/) do |stat
   site.mappings << create(:mapping, http_status: status, path: path)
 end
 
+Given (/^a (\d+) mapping exists for the site with the path (.*)$/) do |status, path|
+  @site.mappings << create(:mapping, http_status: status, path: path)
+end
+
 Given(/^there is an organisation with the whitehall_slug "(.*?)"$/) do |abbr|
   @organisation = create(:organisation, whitehall_slug: "ukaea")
 end

--- a/features/step_definitions/hits_assertion_steps.rb
+++ b/features/step_definitions/hits_assertion_steps.rb
@@ -113,13 +113,21 @@ Then(/^each hit except homepages should have a link to check its mapping$/) do
     page.all('tr').each do |row|
       path = row.find(:css, '.path').text
       mapping = row.find(:css, '.action')
-      expect(mapping).to have_link('', href: site_mapping_find_path(@site, path: path)) unless path == '/'
+      expect(mapping).to have_link('', href: site_mapping_find_path(@site, path: path, return_path: site_hits_path(@site))) unless path == '/'
     end
   end
 end
 
 Then(/^I should be on the add mapping page$/) do
   step 'I should see "Add mapping"'
+end
+
+Then(/^I should be on the edit mapping page$/) do
+  step 'I should see "Edit mapping"'
+end
+
+Then(/^I should be on the site's hits summary page$/) do
+  step "I should be on the path \"#{site_hits_path(@site)}\""
 end
 
 Then(/^the top hit's canonicalized path should already be in the form$/) do

--- a/features/step_definitions/hits_interaction_steps.rb
+++ b/features/step_definitions/hits_interaction_steps.rb
@@ -1,5 +1,5 @@
 When(/^I click on the link to check the mapping for the top hit/) do
-  click_link '', href: site_mapping_find_path(@site, path: '/A')
+  click_link '', href: site_mapping_find_path(@site, path: '/A', return_path: site_hits_path(@site))
 end
 
 When(/^I filter by the date period "([^"]*)"$/) do |period_title|

--- a/features/step_definitions/page_assertion_steps.rb
+++ b/features/step_definitions/page_assertion_steps.rb
@@ -14,6 +14,11 @@ Then(/^there should be a tooltip which includes "([^"]*)"$/) do |text|
   expect(page).to have_selector("[title*='#{text}']")
 end
 
+Then(/^I should be on the path "([^"]*)"$/) do |path|
+  uri = URI.parse(current_url)
+  uri.path.should == path
+end
+
 # Modals
 
 Then(/^I should see an open modal window$/) do


### PR DESCRIPTION
- When a user is editing mappings via hits, then the best place to return them to is where they came from
- Use the return_url parameters as mappings links do
- Use absolute paths for partials to avoid missing partial errors when rendering modal on hits pages
- Pass the return_url through from find method to new/edit methods
