### PR TITLE
Ask for confirmation if site has a global status

### DIFF
--- a/lib/tasks/import/create_mappings_from_host_paths.rake
+++ b/lib/tasks/import/create_mappings_from_host_paths.rake
@@ -6,7 +6,16 @@ namespace :import do
     site = Site.find_by_abbr(args[:site_abbr])
     raise "No site found for #{args[:site_abbr]}" unless site
     raise 'ABORT: This site is not managed by transition' unless site.managed_by_transition?
-    puts 'WARNING: This site has a global_http_status' if site.global_http_status
+
+    if site.global_http_status
+      STDOUT.flush
+      STDOUT.puts "WARNING: This site has a global_http_status, so Bouncer will not use any mappings you create.\nDo you want to continue? (y/N)"
+      input = STDIN.gets.chomp
+      unless %w(y yes).include?(input)
+        abort("Not creating mappings for site #{args[:site_abbr]} with global_http_status.")
+      end
+    end
+
     Transition::Import::CreateMappingsFromHostPaths.call(site)
   end
 end


### PR DESCRIPTION
Only showing a warning doesn't give the user time to react, so also
ask for explicit confirmation before continuing.
