### PR TITLE
Fix error in mapping saved modal on non-site pages

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -71,12 +71,13 @@
       <% end %>
 
       <% if flash[:saved_mapping_ids] %>
+        <% mappings_from_ids = mappings_from_ids(flash[:saved_mapping_ids]) %>
         <%= render partial: 'mappings/saved_mappings_modal',
           locals: {
-            site: @site,
+            site: mappings_from_ids.first.site, # we *might* be able to use @site, but we may be on a page where it isn't loaded
             operation: flash[:saved_operation],
             message: flash[:success],
-            mappings: mappings_from_ids(flash[:saved_mapping_ids])
+            mappings: mappings_from_ids,
           }
         %>
       <% end %>


### PR DESCRIPTION
It is possible to have saved_mapping_ids in your session, but to be viewing a
page which doesn't relate to a site, so @site isn't set. Before now, this would
mean seeing a 5xx error page.

I was able to reproduce this by saving mappings in one tab and quickly
refreshing the homepage in another. There are lots of other ways to trigger the
problem.
