### PR TITLE
MappingsController#find_global should keep querystring intact

### DIFF
--- a/app/controllers/mappings_controller.rb
+++ b/app/controllers/mappings_controller.rb
@@ -151,7 +151,7 @@ class MappingsController < ApplicationController
     site = Host.where(hostname: url.host).first.try(:site)
     render_error(404) and return unless site
 
-    redirect_to site_mapping_find_url(site, path: url.path)
+    redirect_to site_mapping_find_url(site, path: url.request_uri)
   end
 
   def find

--- a/spec/controllers/mappings_controller_spec.rb
+++ b/spec/controllers/mappings_controller_spec.rb
@@ -98,6 +98,14 @@ describe MappingsController do
       end
     end
 
+    context 'when the URL has a querystring' do
+      let!(:host) { create :host, hostname: 'example.com' }
+      it 'should preserve the querystring' do
+        get :find_global, url: 'http://example.com/baz?q=a'
+        expect(response).to redirect_to site_mapping_find_url(host.site, path: '/baz?q=a')
+      end
+    end
+
     context 'when the URL isn\'t an HTTP(S) URL' do
       it 'returns a 400 error' do
         get :find_global, url: "huihguifbelgfebigf"


### PR DESCRIPTION
If the querystring is relevant, this meant that it was lost when it should have
been kept.
