### PR TITLE
Speed up Whitehall mappings import by 50%

### DIFF
--- a/lib/transition/import/whitehall/mappings_csv.rb
+++ b/lib/transition/import/whitehall/mappings_csv.rb
@@ -27,7 +27,7 @@ module Transition
                 next
               end
 
-              host = Host.find_by_hostname(old_uri.host)
+              host = hosts_by_hostname[old_uri.host]
 
               if host.nil?
                 Rails.logger.warn("Skipping mapping for unknown host in Whitehall URL CSV: '#{old_uri.host}'")
@@ -48,6 +48,10 @@ module Transition
               end
             end
           end
+        end
+
+        def hosts_by_hostname
+          @_hosts ||= Host.all.inject({}) { |accumulator,host| accumulator.merge(host.hostname => host) }
         end
 
         def path_hash(canonical_path)


### PR DESCRIPTION
Until now, we have been loading the host for each old URL in the CSV from the
database each time. This manually caches the hosts (and semi-accidentally the sites too).

In development this changed the runtime from:

```
FILENAME=tmp/1396018394-whitehall_mappings.csv bundle exec rake   181.65s user 112.01s system 88% cpu 5:31.37 total
```

to:

```
FILENAME=tmp/1396018394-whitehall_mappings.csv bundle exec rake   95.10s user 54.83s system 86% cpu 2:53.45 total
```
