### PR TITLE
Fix error in modal when no mappings affected

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -64,17 +64,17 @@
         <div class="
           alert
           alert-<%= k == :notice || k == :alert ? 'warning' : k %>
-          <% if k == :success && flash[:saved_mapping_ids] %>if-js-hide<% end %>
+          <% if k == :success && flash[:saved_mapping_ids] && @site %>if-js-hide<% end %>
         ">
           <%= flash[k] %>
         </div>
       <% end %>
 
-      <% if flash[:saved_mapping_ids] %>
+      <% if flash[:saved_mapping_ids] && @site %>
         <% mappings_from_ids = mappings_from_ids(flash[:saved_mapping_ids]) %>
         <%= render partial: 'mappings/saved_mappings_modal',
           locals: {
-            site: mappings_from_ids.first.site, # we *might* be able to use @site, but we may be on a page where it isn't loaded
+            site: @site,
             operation: flash[:saved_operation],
             message: flash[:success],
             mappings: mappings_from_ids,


### PR DESCRIPTION
The previous fix: b33cd31 triggered an error if the changes you had made affected zero mappings, whether you were on a site-specific page or not.

With this change, the modal will only be displayed on pages for a site.
