### PR TITLE
Add lib to autoload

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,7 +22,7 @@ module Transition
     # -- all .rb files in that directory are automatically loaded.
 
     # Custom directories with classes and modules you want to be autoloadable.
-    # config.autoload_paths += %W(#{config.root}/extras)
+    config.autoload_paths += %W(#{config.root}/lib)
 
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.


### PR DESCRIPTION
This fixes an undefined constant Transition::OffSiteRedirectChecker in MappingsController when bulk adding in development and should make @jennyd happy.

There's lots of detail on autoload here: http://urbanautomaton.com/blog/2013/08/27/rails-autoloading-hell/
