### PR TITLE
Record history when creating mappings from hits

### DIFF
--- a/lib/transition/import/mappings_from_host_paths.rb
+++ b/lib/transition/import/mappings_from_host_paths.rb
@@ -7,14 +7,23 @@ module Transition
 
       def self.refresh!(site)
         start 'Creating mappings from HostPaths' do
-          site_paths = site.host_paths.where('mapping_id is null').group('c14n_path_hash').pluck(:path)
-          site_paths.map do |uncanonicalized_path|
-            # Try to create them (there may be duplicates in the set and they may
-            # already exist).
-            if site.mappings.create(path: uncanonicalized_path, http_status: '410')
-              $stderr.print '.'
+          Transition::History.as_a_user(user) do
+            site_paths = site.host_paths.where('mapping_id is null').group('c14n_path_hash').pluck(:path)
+            site_paths.map do |uncanonicalized_path|
+              # Try to create them (there may be duplicates in the set and they may
+              # already exist).
+              if site.mappings.create(path: uncanonicalized_path, http_status: '410')
+                $stderr.print '.'
+              end
             end
           end
+        end
+      end
+
+      def self.user
+        User.where(email: 'logs-mappings-robot@dummy.com').first_or_create! do |user|
+          user.name  = 'Logs mappings robot'
+          user.is_robot = true
         end
       end
     end

--- a/spec/lib/transition/import/mappings_from_host_paths_spec.rb
+++ b/spec/lib/transition/import/mappings_from_host_paths_spec.rb
@@ -46,6 +46,14 @@ describe Transition::Import::MappingsFromHostPaths do
       @host_path.mapping_id.should be_nil
     end
 
+    describe 'should create a history entry', versioning: true do
+      let(:mapping) { @site.mappings.first }
+      subject { mapping.versions.first }
+
+      its(:item_id)   { should eql(mapping.id) }
+      its(:whodunnit) { should eql('Logs mappings robot') }
+    end
+
     context 'another site has HostPaths' do
       before do
         @another_site = create(:site)


### PR DESCRIPTION
This rake task is currently broken because the Mapping model validates that a user is set to be recorded as the creator.
