### PR TITLE
Make MappingsFromHostPaths use #each for a large array

### DIFF
--- a/lib/transition/import/mappings_from_host_paths.rb
+++ b/lib/transition/import/mappings_from_host_paths.rb
@@ -9,7 +9,7 @@ module Transition
         start 'Creating mappings from HostPaths' do
           Transition::History.as_a_user(user) do
             site_paths = site.host_paths.where('mapping_id is null').group('c14n_path_hash').pluck(:path)
-            site_paths.map do |uncanonicalized_path|
+            site_paths.each do |uncanonicalized_path|
               # Try to create them (there may be duplicates in the set and they may
               # already exist).
               if site.mappings.create(path: uncanonicalized_path, http_status: '410')


### PR DESCRIPTION
- Was using #map, which would allocate a large array we didn't use
