### PR TITLE
Explicitly exclude aka hosts from default_host

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -24,7 +24,7 @@ class Site < ActiveRecord::Base
   end
 
   def default_host
-    hosts.first
+    hosts.excluding_aka.first
   end
 
   def transition_status

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -80,14 +80,18 @@ describe Site do
 
   # given that hosts are site aliases
   describe '#default_host' do
-    let(:hosts) { [create(:host), create(:host)] }
-    subject(:site) do
-      create(:site_without_host) do |site|
-        site.hosts = hosts
-      end
+    let(:site) { create :site_without_host }
+
+    before do
+      create(:host, hostname: 'aka.f.com', site: site)
+      create(:host, hostname: 'www.f.com', site: site)
     end
 
-    its(:default_host) { should eql(hosts.first) }
+    subject(:default_host) do
+      site.default_host
+    end
+
+    its(:hostname) { should eql('www.f.com') }
   end
 
   describe '#canonical_path' do


### PR DESCRIPTION
Whilst we are currently protected from this problem because we have a
predictable insertion order (canonical host THEN aka host), this isn't totally
reliable and we might change the way hosts are created in the future.
