### PR TITLE
Hide features that require AKA domains if none

### DIFF
--- a/app/views/sites/_tools.html.erb
+++ b/app/views/sites/_tools.html.erb
@@ -2,25 +2,33 @@
   <h3 class="panel-heading remove-top-margin">Tools</h3>
   <div class="panel-body">
     <h4 class="remove-top-margin">Side by side browser</h4>
-    <p>
-      Browse <i><%= site.default_host.hostname %></i> in the left panel, and, as you navigate, preview redirections and archives in the right panel.
-    </p>
-    <ul>
-      <li>
-        <a href="http://<%= site.default_host.hostname %>.side-by-side.alphagov.co.uk/__/#/">Open side by side browser</a>
-      </li>
-    </ul>
+    <% if site.default_host.aka_host && site.default_host.aka_host.redirected_by_gds? %>
+      <p>
+        Browse <i><%= site.default_host.hostname %></i> in the left panel, and, as you navigate, preview redirections and archives in the right panel.
+      </p>
+      <ul>
+        <li>
+          <a href="http://<%= site.default_host.hostname %>.side-by-side.alphagov.co.uk/__/#/">Open side by side browser</a>
+        </li>
+      </ul>
+    <% else %>
+      This tool requires <%= link_to 'AKA Domains', glossary_index_path(anchor: 'aka'), class: 'glossary-link' %> to be set up. Please contact your Transition Manager.
+    <% end %>
     <hr />
     <h4 class="remove-top-margin">Preview redirections</h4>
-    <p>
-      To test a redirection for a pre-transition website:
-    </p>
-    <ul>
-      <li>Drag this bookmarklet to your bookmarks bar</li>
-      <li>Visit a page on any transitioning site</li>
-      <li>Click the bookmarklet to preview the redirect</li>
-    </ul>
-    <a class="btn btn-default bookmarklet" title="Drag me to your bookmarks bar" data-toggle="tooltip" href="javascript:location%3Dlocation.href.replace(/:%5C/%5C//, '://aka-').replace(/-*www/,'')">Preview redirect</a>
+    <% if site.default_host.aka_host && site.default_host.aka_host.redirected_by_gds? %>
+      <p>
+        To test a redirection for a pre-transition website:
+      </p>
+      <ul>
+        <li>Drag this bookmarklet to your bookmarks bar</li>
+        <li>Visit a page on any transitioning site</li>
+        <li>Click the bookmarklet to preview the redirect</li>
+      </ul>
+      <a class="btn btn-default bookmarklet" title="Drag me to your bookmarks bar" data-toggle="tooltip" href="javascript:location%3Dlocation.href.replace(/:%5C/%5C//, '://aka-').replace(/-*www/,'')">Preview redirect</a>
+    <% else %>
+      This tool requires <%= link_to 'AKA Domains', glossary_index_path(anchor: 'aka'), class: 'glossary-link' %> to be set up. Please contact your Transition Manager.
+    <% end %>
     <hr />
     <h4 class="add-top-margin">National Archives checker</h4>
     <p>

--- a/features/site.feature
+++ b/features/site.feature
@@ -19,6 +19,16 @@ Scenario: Visit a pre-transition site's page
   And I should be able to edit the site's mappings
   And I should be able to view the site's analytics
   And I should see the site's configuration including all host aliases
+  And I should see "This feature requires AKA Domains to be set up"
+
+Scenario: Visit a pre-transition site's page
+  Given I have logged in as an admin
+  Given the date is 29/11/12
+  And www.attorney-general.gov.uk site with abbr ago launches on 13/12/12 with the following aliases:
+    | alias                     |
+    | www.lslo.gov.uk           |
+  And there is a working AKA domain for "www.attorney-general.gov.uk"
+  When I visit this site page
   And I should see a link to the side by side browser
 
 Scenario: Visit a post-transition site's page

--- a/features/step_definitions/fixture_steps.rb
+++ b/features/step_definitions/fixture_steps.rb
@@ -28,6 +28,14 @@ Given(/^there are (\d+) sites with hosts$/) do |site_count|
   end
 end
 
+Given(/^there is a working AKA domain for "(.*?)"$/) do |canonical_hostname|
+  canonical_host = Host.find_by_hostname(canonical_hostname)
+  host = create(:host, :with_govuk_cname,
+                hostname: canonical_host.aka_hostname,
+                canonical_host: canonical_host,
+                site: @site)
+end
+
 Given(/^that the first host's site does not exist$/) do
   Host.first.site.delete
 end


### PR DESCRIPTION
This will help user experience a little, and be an additional prompt for them to get AKA domains set up.

It doesn't help people who have been given a link to the side by side browser directly.
