### PR TITLE
Fix jenkins.sh to report test failures

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash -xe
 export RAILS_ENV=test
 export DISPLAY=":99"
 


### PR DESCRIPTION
When I added the task to check for bad time handling in 6db125f8bfa7241d50bff876ef736e45cc0763e0
it meant that the last command was no longer specs/cucumber, so the exit status
was zero as long as the time check passed. This meant that Jenkins CI thought
the build was successful when it was failing.

Rather than move the time-handling around, let's make it more robust and tell
the script to exit (with non-zero) if any command returns non-zero.
