### PR TITLE
Allow entered text to be used as a tag

### DIFF
--- a/app/assets/javascripts/tagging.js
+++ b/app/assets/javascripts/tagging.js
@@ -11,6 +11,7 @@
     ready: function(options) {
       $('.js-tag-list').select2({
         tags: options['autocompleteWith'],
+        selectOnBlur: true,
         tokenSeparators: [','],
         initSelection: function (input, setTags) {
           setTags(


### PR DESCRIPTION
In user research a common problem with tagging was discovered. Users would enter text into the input field then click away or on the submit button. The default behaviour would hide the tag drop down and lear the tag input. So forms were being submitted without the intended tags.
- Use the select2 option “selectOnBlur” to turn user input into a tag on blur
