### PR TITLE
Don't let the browser show a cached transition page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
 
   before_filter :require_signin_permission!
+  before_filter :set_cache_buster
 
   protect_from_forgery
 
@@ -21,6 +22,13 @@ class ApplicationController < ActionController::Base
     @custom_header = options[:header]
     @custom_body = options[:body]
     render "errors/error_#{status}", status: status, layout: 'error_page'
+  end
+
+  # http://stackoverflow.com/questions/711418/how-to-prevent-browser-page-caching-in-rails
+  def set_cache_buster
+    response.headers["Cache-Control"] = "no-cache, no-store, max-age=0, must-revalidate"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
   end
 
 private


### PR DESCRIPTION
In user research users have often been confused by the inconsistent state of mappings, hits and flash messages when using the back button. This PR is to address ticket #68870422.

This may be a contentious change, which is one of the reasons I've opened the PR for some discussion about the problem.
- Avoid showing a user an inaccurate mappings list when a user hits back
- Avoid showing flash messages multiple times when a user hits back
- Avoid showing incorrect summary tables on hits pages after editing mappings
