### PR TITLE
Don't strip out trailing slashes when filtering

### DIFF
--- a/app/controllers/mappings_controller.rb
+++ b/app/controllers/mappings_controller.rb
@@ -58,6 +58,13 @@ class MappingsController < ApplicationController
       @path_contains = View::Mappings::canonical_filter(@site, params[:path_contains])
       if @path_contains.present?
         @filtered = true
+
+        # Canonicalisation removes trailing slashes, which in this case
+        # can be an important part of the search string. Put them back.
+        if params[:path_contains].end_with?('/')
+          @path_contains = @path_contains + '/'
+        end
+
         @mappings = @mappings.filtered_by_path(@path_contains)
       end
     end

--- a/spec/controllers/mappings_controller_spec.rb
+++ b/spec/controllers/mappings_controller_spec.rb
@@ -46,6 +46,11 @@ describe MappingsController do
         assigns(:mappings).should == [mapping_a]
       end
 
+      it 'canonicalizes filter input but leaves trailing slashes alone' do
+        get :index, site_id: site.abbr, path_contains: '/A/'
+        assigns(:path_contains).should == '/a/'
+      end
+
       it 'filters mappings by new_url' do
         get :index, site_id: site.abbr, new_url_contains: 'f.co/1'
         assigns(:mappings).should == [mapping_a]


### PR DESCRIPTION
- Fix #68376922
- Or more specifically, put trailing slashes back after canonicalising

An example of the original problem:
“When trying to filter path on /sta/, it filters on /sta. As a result, "/statistics" ends up included in my "/sta/" mappings list, when all I want is /sta/ things for the Standards and Testing Agency”
