### PR TITLE
URL hosts must contain at least one "."

### DIFF
--- a/app/validators/non_blank_url_validator.rb
+++ b/app/validators/non_blank_url_validator.rb
@@ -3,7 +3,7 @@ class NonBlankURLValidator < ActiveModel::EachValidator
     return if value.blank?
     valid_url = begin
       uri = URI.parse(value)
-      !uri.scheme.blank? && !uri.host.blank?
+      !uri.scheme.blank? && !uri.host.blank? && uri.host.include?(".")
     rescue URI::InvalidURIError
       false
     end

--- a/spec/models/mapping_spec.rb
+++ b/spec/models/mapping_spec.rb
@@ -94,6 +94,18 @@ describe Mapping do
         end
       end
 
+      context 'URLs with an invalid host (without a ".")' do
+        subject(:mapping) do
+          build(:mapping, http_status: '301', new_url: 'newurl', suggested_url: 'suggestedurl')
+        end
+
+        describe 'the errors' do
+          subject { mapping.errors }
+          its([:new_url])       { should == ['is not a URL'] }
+          its([:suggested_url]) { should == ['is not a URL'] }
+        end
+      end
+
       context 'Archive URL is not webarchive.nationalarchives.gov.uk' do
         subject(:mapping) { build(:archived, archive_url: 'http://malicious.com/foo')}
 


### PR DESCRIPTION
We started prepending http:// to the start of URL values so the user didn’t have to. This left a hole in our validation where “something” would become “http://something” and pass validation checks.
- Check host contains at least one period, mostly to prevent accidents
