### PR TITLE
Put transition date on analytics graph

### DIFF
--- a/app/assets/javascripts/hits.js
+++ b/app/assets/javascripts/hits.js
@@ -44,6 +44,7 @@
                 height: '80%'
               },
               colors: colors,
+              annotations: {style: 'line', stemColor: 'black'},
               focusTarget: 'category' // Highlights all trends in a single tooltip, hovering
                                       // anywhere in the space above or below a point
             };

--- a/app/helpers/hits_helper.rb
+++ b/app/helpers/hits_helper.rb
@@ -27,13 +27,22 @@ module HitsHelper
   #          {label: 'Errors', type: 'number'},
   #          {label: 'Archive', type: 'number'}],
   #   rows: [
-  #          {c:[{v: 'Date(2012, 11, 10)'}, {v: 10000, f:'10,000'}, {v: 20000, f:'20,000'}]},
-  #          {c:[{v: 'Date(2012, 11, 11)'}, {v: 1000,  f:'1,000'}, {v: 2000, f:'2,000'}]},
+  #          {c:[{v: 'Date(2012, 11, 10)'}, {v: ''}, {v: 10000, f:'10,000'}, {v: 20000, f:'20,000'}]},
+  #          {c:[{v: 'Date(2012, 11, 11)'}, {v: ''}, {v: 1000,  f:'1,000'}, {v: 2000, f:'2,000'}]},
   #         ]
   # }
-  def google_data_table(categories)
+  #
+  # Example showing a vertical line on x-axis
+  # https://groups.google.com/forum/#!topic/google-visualization-api/cfG-iqZSfds
+  # http://savedbythegoog.appspot.com/?id=7e54024673afee6264407cc6c21f99f3a6b160ad
+  #
+  def google_data_table(categories, site = nil)
+    transition_date = site && site.transition_status == :live ? site.launch_date : nil
     dates = {}
-    cols  = [{ label: 'Date', type: 'date' }]
+    cols  = [
+        { label: 'Date', type: 'date' },
+        { label: 'Transition date line', type: 'string', p: {role: 'annotation'}}
+      ]
 
     categories.each do |category|
       cols << { label: category.title, type: 'number' }
@@ -49,6 +58,7 @@ module HitsHelper
       rows << {
         c: [
              { v: "Date(#{date.year}, #{date.month - 1}, #{date.day})" },
+             { v: date == transition_date ? 'Transition' : ''},
              *categories.map do |c|
                count_for_category = category_counts[c.name] || 0
                { v: count_for_category, f: number_with_delimiter(count_for_category) }

--- a/app/views/hits/_hits_graph.html.erb
+++ b/app/views/hits/_hits_graph.html.erb
@@ -1,5 +1,5 @@
 <script src="https://www.google.com/jsapi"></script>
 <div class="hits-graph js-hits-graph" aria-hidden="true"></div>
 <script>
-  GOVUK.Hits.plot(<%= google_data_table(point_categories) %>, <%= colors(point_categories) %>);
+  GOVUK.Hits.plot(<%= google_data_table(point_categories, @site) %>, <%= colors(point_categories) %>);
 </script>

--- a/spec/helpers/hits_helper_spec.rb
+++ b/spec/helpers/hits_helper_spec.rb
@@ -51,13 +51,26 @@ describe HitsHelper do
       ]
     }
 
-    subject(:array) { helper.google_data_table(categories) }
+    let(:live_site_that_transitioned_on_2012_12_30) do
+       site = build(:site, launch_date: Date.new(2012,12,30))
+       site.hosts << build(:host, cname: 'redirector-cdn.production.govuk.service.gov.uk')
+       site.save
+       site
+    end
+
+    subject(:array) { helper.google_data_table(categories, live_site_that_transitioned_on_2012_12_30) }
 
     it { should be_a(String) }
     it { should include('{"label":"Date","type":"date"}') }
     it { should include('{"label":"Archives","type":"number"},{"label":"Errors","type":"number"},{"label":"Redirects","type":"number"}') }
-    it { should include('{"c":[{"v":"Date(2012, 11, 31)"},{"v":3,"f":"3"},{"v":3,"f":"3"},{"v":0,"f":"0"}]}') }
-    it { should include('{"c":[{"v":"Date(2012, 11, 30)"},{"v":1000,"f":"1,000"},{"v":4,"f":"4"},{"v":4,"f":"4"}]}') }
     it { should_not include('nil') }
+
+    describe 'it includes a normal data row' do
+      it { should include('{"c":[{"v":"Date(2012, 11, 31)"},{"v":""},{"v":3,"f":"3"},{"v":3,"f":"3"},{"v":0,"f":"0"}]}') }
+    end
+
+    describe 'it includes an annotation on the transition date' do
+      it { should include('{"c":[{"v":"Date(2012, 11, 30)"},{"v":"Transition"},{"v":1000,"f":"1,000"},{"v":4,"f":"4"},{"v":4,"f":"4"}]}') }
+    end
   end
 end


### PR DESCRIPTION
- Show a line on the analytics graph on the date at which the site mappings went live
- Only show a line when site is live and the graph spans the date of transition

![screen shot 2014-04-17 at 16 15 29](https://cloud.githubusercontent.com/assets/319055/2734864/4ace2814-c659-11e3-9fac-18a61a42bb74.png)
![screen shot 2014-04-17 at 16 15 43](https://cloud.githubusercontent.com/assets/319055/2734863/4acdb3ca-c659-11e3-831f-05c24350bc1b.png)
