### PR TITLE
Tidy up bulk add success messages

### DIFF
--- a/app/models/view/mappings/bulk_adder.rb
+++ b/app/models/view/mappings/bulk_adder.rb
@@ -125,8 +125,8 @@ module View
         @modified_mappings
       end
 
-      def tagged_with(opts = {and: false})
-        %(#{opts[:and] ? ' and ' : ''}tagged with "#{tag_list.join(', ')}") if tag_list.any?
+      def tagged_with(opts = {all: false, and: false})
+        %(#{opts[:all] ? '. All ' : ''}#{opts[:and] ? ' and ' : ''}tagged with "#{tag_list.join(', ')}") if tag_list.any?
       end
 
       def mappings_created
@@ -142,11 +142,15 @@ module View
           I18n.t('mappings.bulk.add.success.all_created',
                  created: mappings_created,
                  tagged_with: tagged_with(and: true))
+        elsif created_count.zero?
+          I18n.t('mappings.bulk.add.success.all_updated',
+                 updated: mappings_updated,
+                 tagged_with: tagged_with(and: true))
         else
           I18n.t('mappings.bulk.add.success.some_updated',
                  created: mappings_created,
                  updated: mappings_updated,
-                 tagged_with: tagged_with)
+                 tagged_with: tagged_with(all: true))
         end
       end
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,8 +17,9 @@ en:
         paths_empty: 'Enter at least one valid path'
         hosts_invalid: 'One or more of the URLs entered are not part of this site'
         success:
-          all_created: '%{created}%{tagged_with}.'
-          some_updated: '%{created} and %{updated}. All %{tagged_with}.'
+          all_created: '%{created}%{tagged_with}'
+          all_updated: '%{updated}%{tagged_with}'
+          some_updated: '%{created} and %{updated}%{tagged_with}.'
       edit:
         mappings_empty: 'No mappings were selected'
         tag_list_empty: "No tags were given"

--- a/features/hits_all.feature
+++ b/features/hits_all.feature
@@ -49,7 +49,7 @@ Scenario: Add mapping for a hit
   When I make the mapping an archive
   And I continue
   And I save my changes
-  Then I should see "1 mapping created." in a modal window
+  Then I should see "1 mapping created" in a modal window
   And I should be on the site's hits summary page
 
 Scenario: Edit mapping from a hit

--- a/features/mapping_create_multiple.feature
+++ b/features/mapping_create_multiple.feature
@@ -23,7 +23,7 @@ Feature: Create mappings
     And I should see "/a currently archived"
     And I should see "/r currently redirects to http://somewhere.good"
     When I save my changes
-    Then I should see "1 mapping created." in a modal window
+    Then I should see "1 mapping created" in a modal window
     And I should see a table with 1 saved mapping in the modal
     And I should see "/needs/canonicalizing" in a modal window
     And an analytics event with "bulk-add-redirect-ignore-existing" has fired

--- a/features/step_definitions/mappings_assertion_steps.rb
+++ b/features/step_definitions/mappings_assertion_steps.rb
@@ -149,7 +149,7 @@ end
 Then(/^I should see that all were tagged "([^"]*)"$/) do |tag_list|
   within '.alert-success', :match => :first do
     expect(page).to have_content(
-      %(0 mappings created and 3 mappings updated. All tagged with "#{tag_list}")
+      %(3 mappings updated and tagged with "#{tag_list}")
     )
   end
 end

--- a/spec/models/view/bulk_adder_spec.rb
+++ b/spec/models/view/bulk_adder_spec.rb
@@ -374,17 +374,37 @@ describe View::Mappings::BulkAdder do
       it { should eql('3 mappings created and 1 mapping updated. All tagged with "fee, fi, fo".') }
     end
 
+    context 'when updating only existing mappings' do
+      let!(:existing_mappings) do
+        create(:mapping, site: site, path: '/might-exist', http_status: '410')
+        create(:mapping, site: site, path: '/a', http_status: '410')
+        create(:mapping, site: site, path: '/b', http_status: '410')
+        create(:mapping, site: site, path: '/c', http_status: '410')
+      end
+
+      before { bulk_adder.create_or_update! }
+
+      context 'when updating and tagging' do
+        it { should eql('4 mappings updated and tagged with "fee, fi, fo"') }
+      end
+
+      context 'when not tagging' do
+        before { params.delete(:tag_list) }
+        it { should eql('4 mappings updated') }
+      end
+    end
+
     context 'there are no pre-existing mappings' do
       before  { bulk_adder.create_or_update! }
 
       context 'when creating some mappings and updating none' do
-        it { should eql('4 mappings created and tagged with "fee, fi, fo".') }
+        it { should eql('4 mappings created and tagged with "fee, fi, fo"') }
       end
 
       context 'when creating some mappings, updating none and tagging none' do
         before { params.delete(:tag_list) }
 
-        it { should eql('4 mappings created.') }
+        it { should eql('4 mappings created') }
       end
     end
   end


### PR DESCRIPTION
- When all are updated, don’t mention “0 created”
- When both updating and creating, don’t show a broken tagged message
  (“1 updated and 1 created. All .”)
- When tagging, conditionally append “All ” to the start of the
  tagged_with string
- When only “1 mapping updated”, remove the full stop as the message is
  effectively a title.
