### PR TITLE
Simplify shared error messages template

### DIFF
--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,9 +1,7 @@
 <% if error_messages.present? %>
   <div class="alert alert-danger">
     <% if error_messages.size == 1 %>
-      <% error_messages.each do |message| %>
-        <p><%= message %></p>
-      <% end %>
+      <p><%= error_messages.first %></p>
     <% else %>
       <ul>
         <% error_messages.each do |message| %>


### PR DESCRIPTION
Just display the error if there is only one, rather than iterating
over the array anyway.
