### PR TITLE
Validate the host part of the hostnames added to transition

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -8,6 +8,7 @@ class Host < ActiveRecord::Base
 
   validates :hostname, presence: true
   validates :site, presence: true
+  validate :valid_hostname
   validate :canonical_host_id_xor_aka_present
 
   scope :excluding_aka, where('hostname not like "aka%"')
@@ -45,6 +46,14 @@ class Host < ActiveRecord::Base
     end
     if aka? && canonical_host_id.blank?
       errors[:canonical_host_id] << 'can\'t be blank for an aka host'
+    end
+  end
+
+  def valid_hostname
+    if hostname
+      if URI.parse("http://#{hostname}").host != hostname
+        errors[:valid_hostname] << 'is an invalid hostname'
+      end
     end
   end
 end

--- a/features/mapping_pagination.feature
+++ b/features/mapping_pagination.feature
@@ -10,7 +10,7 @@ Feature: Paginated mappings
     When I visit the path /sites/bis_lowpay
     And I click the link called "Mappings"
     Then I should see the header "0 mappings"
-    And the page title should be "Mappings | bis_lowpay.gov.uk | GOV.UK Transition"
+    And the page title should be "Mappings | bis-lowpay.gov.uk | GOV.UK Transition"
     And I should see "0 mappings"
 
   Scenario: There are mappings for a site and we visit page 1
@@ -24,7 +24,7 @@ Feature: Paginated mappings
     When I visit the path /sites/bis_lowpay
     And I click the link called "Mappings"
     Then I should see the header "3 mappings"
-    And  I should see "bis_lowpay"
+    And  I should see "bis-lowpay"
     And  I should see a mappings table with 2 rows
     And  I should see 1 as the current page
     And  I should see links top and bottom to page 2

--- a/features/site.feature
+++ b/features/site.feature
@@ -66,7 +66,7 @@ Scenario: Visit a globally redirected site's page
   And a site moj_academy exists
   And the site is globally redirected
   When I visit this site page
-  Then I should see "All paths from moj_academy.gov.uk"
+  Then I should see "All paths from moj-academy.gov.uk"
   Then I should see "redirect to"
   And I should not see a link to view the site's mappings
 
@@ -75,7 +75,7 @@ Scenario: Visit a globally archived site's page
   And a site defra_etr exists
   And the site is globally archived
   When I visit this site page
-  Then I should see "All paths from defra_etr.gov.uk"
+  Then I should see "All paths from defra-etr.gov.uk"
   Then I should see "have been archived"
   And I should not see a link to view the site's mappings
 

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -11,7 +11,7 @@ FactoryGirl.define do
 
     factory :site do # default site comes with a host {abbr}.gov.uk
       after(:build) do |site|
-        site.hosts << FactoryGirl.build(:host, hostname: "#{site.abbr}.gov.uk", site: site)
+        site.hosts << FactoryGirl.build(:host, hostname: "#{site.abbr.gsub('_','-')}.gov.uk", site: site)
       end
     end
   end

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -38,6 +38,15 @@ describe Host do
         end
       end
     end
+
+    describe 'hostnames' do
+      subject(:host) { build :host, hostname: 'rarfoo.gov.uk/foo/' }
+
+      its(:valid?) { should be_false }
+      it 'should have an error for invalid hostname' do
+        host.errors_on(:valid_hostname).should include('is an invalid hostname')
+      end
+    end
   end
 
   describe 'scopes' do

--- a/spec/models/mapping_spec.rb
+++ b/spec/models/mapping_spec.rb
@@ -30,9 +30,9 @@ describe Mapping do
   describe 'url generation (based on mapping path and site host)' do
     subject(:mapping) { create :mapping, site: create(:site, abbr: 'cic_regulator'), path: '/some-path' }
 
-    its(:old_url)                    { should == 'http://cic_regulator.gov.uk/some-path' }
-    its(:national_archive_url)       { should == 'http://webarchive.nationalarchives.gov.uk/20120816224015/http://cic_regulator.gov.uk/some-path' }
-    its(:national_archive_index_url) { should == 'http://webarchive.nationalarchives.gov.uk/*/http://cic_regulator.gov.uk/some-path' }
+    its(:old_url)                    { should == 'http://cic-regulator.gov.uk/some-path' }
+    its(:national_archive_url)       { should == 'http://webarchive.nationalarchives.gov.uk/20120816224015/http://cic-regulator.gov.uk/some-path' }
+    its(:national_archive_index_url) { should == 'http://webarchive.nationalarchives.gov.uk/*/http://cic-regulator.gov.uk/some-path' }
   end
 
   describe 'validations' do


### PR DESCRIPTION
- Use URI.parse, making this essentially the same as the redirector
  change in https://github.com/alphagov/redirector/pull/608. As
  fallout from using URI.parse, change the site abbreviations from
  containing underscores to containing dashes in the test factories,
  because URI.parse does not handle hostnames with underscores in
  them. This means also changing the test data where site
  abbreviations with underscores are referenced, so they all still
  pass.
