### PR TITLE
Only show background messages on the right site

### DIFF
--- a/app/controllers/background_bulk_add_message_controller_mixin.rb
+++ b/app/controllers/background_bulk_add_message_controller_mixin.rb
@@ -1,6 +1,10 @@
 module BackgroundBulkAddMessageControllerMixin
   def set_background_bulk_add_status_message
-    @reportable_batch = current_user.mappings_batches.reportable.order(:updated_at).last
+    @reportable_batch = current_user.mappings_batches
+                                    .where(site_id: @site.id)
+                                    .reportable
+                                    .order(:updated_at)
+                                    .last
 
     # Assumes that the user only cares about the most recent in-progress batch
     if @reportable_batch

--- a/spec/controllers/mappings_controller_spec.rb
+++ b/spec/controllers/mappings_controller_spec.rb
@@ -561,6 +561,18 @@ describe MappingsController do
         flash.now[:batch_progress].should be_nil
       end
     end
+
+    context 'the batch is for another site' do
+      let!(:mappings_batch) { create(:mappings_batch, site: create(:site), user: admin_bob, state: 'succeeded') }
+      before do
+        login_as(admin_bob)
+        get :index, site_id: site
+      end
+
+      it 'should not show' do
+        flash.now[:batch_progress].should be_nil
+      end
+    end
   end
 
   describe 'rejecting an invalid or missing authenticity (CSRF) token' do


### PR DESCRIPTION
We were showing flash messages for batches on mappings/hits pages for other
sites, which would be misleading to the user.
