### PR TITLE
Improve mappings post create hits hook

### DIFF
--- a/app/models/mapping.rb
+++ b/app/models/mapping.rb
@@ -168,9 +168,10 @@ protected
   end
 
   def update_hit_relations
-    new_hits_hashes = site.host_paths.where(c14n_path_hash: path_hash)
-                                     .pluck(:path_hash)
+    host_paths = site.host_paths.where(c14n_path_hash: path_hash)
+    new_hits_hashes = host_paths.pluck(:path_hash)
 
     site.hits.where(path_hash: new_hits_hashes).update_all(mapping_id: self.id)
+    host_paths.update_all(mapping_id: self.id)
   end
 end

--- a/spec/models/mapping_spec.rb
+++ b/spec/models/mapping_spec.rb
@@ -252,7 +252,13 @@ describe Mapping do
 
     describe 'the linkage to hits' do
       let!(:hit_on_uncanonicalized) { create :hit, path: uncanonicalized_path, host: site.default_host }
+      let!(:host_path_on_uncanonicalized) { create :host_path, path: uncanonicalized_path, host: site.default_host }
+
       let!(:hit_on_canonicalized)   { create :hit, path: canonicalized_path, host: site.default_host }
+      let!(:host_path_on_canonicalized) { create :host_path, path: canonicalized_path, host: site.default_host }
+
+      let!(:unrelated_hit) { create :hit, path: '/just-zis-guy', host: site.default_host }
+      let!(:unrelated_host_path) { create :host_path, path: '/just-zis-guy', host: site.default_host }
 
       context 'when creating a new mapping', need_mapping_callbacks: true do
         before do
@@ -266,6 +272,23 @@ describe Mapping do
 
         it 'links the canonicalized hit to the mapping' do
           hit_on_canonicalized.reload.mapping.should == mapping
+        end
+
+        it 'links the uncanonicalized host_path to the mapping' do
+          host_path_on_uncanonicalized.reload.mapping.should == mapping
+
+        end
+
+        it 'link the canonicalized host_path to the mapping' do
+          host_path_on_canonicalized.reload.mapping.should == mapping
+        end
+
+        it 'should leave an unrelated hit alone' do
+          unrelated_hit.reload.mapping.should be_nil
+        end
+
+        it 'should leave an unrelated host_path alone' do
+          unrelated_host_path.reload.mapping.should be_nil
         end
       end
     end


### PR DESCRIPTION
I have:
- made the code more efficient
- connected HostPaths, not just Hits when a mapping is created

I'm not totally sure there's a tangible benefit to connecting Mappings to HostPaths, but it is nice to be consistent. We may come to assume/rely on that they are connected when a mapping is created...
