### PR TITLE
Rename 'admin' to 'GDS Editor'

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,12 +7,12 @@ class User < ActiveRecord::Base
 
   attr_accessible :uid, :email, :name, :permissions, :organisation_slug, as: :oauth
 
-  def admin?
-    permissions.include?('admin')
+  def gds_editor?
+    permissions.include?('GDS Editor')
   end
 
   def can_edit_site?(site_to_edit)
-    admin? ||
+    gds_editor? ||
       own_organisation == site_to_edit.organisation ||
       site_to_edit.organisation.parent_organisations.include?(own_organisation) ||
       site_to_edit.extra_organisations.include?(own_organisation) &&

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,7 @@
       <%= link_to organisation_with_abbreviation(current_user.own_organisation), organisation_path(current_user.own_organisation), title: 'Your organisation' %>
     </li>
   <% end %>
-  <% if current_user.admin? %>
+  <% if current_user.gds_editor? %>
     <li <% if current_page?(hits_path) %> class="active" <% end %>>
       <%= link_to 'Universal analytics', hits_path %>
     </li>

--- a/db/migrate/20140529164329_rename_admin_permission_to_gds_editor.rb
+++ b/db/migrate/20140529164329_rename_admin_permission_to_gds_editor.rb
@@ -1,0 +1,19 @@
+class RenameAdminPermissionToGdsEditor < ActiveRecord::Migration
+  class User < ActiveRecord::Base
+    serialize :permissions, Array
+  end
+
+  def up
+    User.where("permissions like '%admin%'").each do |user|
+      user.permissions = user.permissions.map { |string| (string == 'admin') ? 'GDS Editor' : string }
+      user.save
+    end
+  end
+
+  def down
+    User.where("permissions like '%GDS Editor%'").each do |user|
+      user.permissions = user.permissions.map { |string| (string == 'GDS Editor') ? 'admin' : string }
+      user.save
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -328,3 +328,5 @@ INSERT INTO schema_migrations (version) VALUES ('20140515135431');
 INSERT INTO schema_migrations (version) VALUES ('20140520154514');
 
 INSERT INTO schema_migrations (version) VALUES ('20140523100338');
+
+INSERT INTO schema_migrations (version) VALUES ('20140529164329');

--- a/features/hits_all.feature
+++ b/features/hits_all.feature
@@ -4,7 +4,7 @@ Feature: All traffic for site
   So that I can see what to fix next and can fix it
 
 Scenario: Hits exist and are ordered for a site
-  Given I have logged in as an admin
+  Given I have logged in as a GDS Editor
   And the date is 19/10/12
   And these hits exist for the Attorney General's office site:
     | http_status | path | hit_on   | count |
@@ -28,13 +28,13 @@ Scenario: Hits exist and are ordered for a site
   But I should not see hits for the Cabinet Office site
 
 Scenario: No hits exist
-  Given I have logged in as an admin
+  Given I have logged in as a GDS Editor
   And no hits exist for the Attorney General's office site
   When I visit the associated site's hits
   Then I should see "We don’t have any traffic data for ago"
 
 Scenario: Add mapping for a hit
-  Given I have logged in as an admin
+  Given I have logged in as a GDS Editor
   And the date is 19/10/12
   And these hits exist for the Attorney General's office site:
     | http_status | path | hit_on   | count |
@@ -53,7 +53,7 @@ Scenario: Add mapping for a hit
   And I should be on the site's hits summary page
 
 Scenario: Edit mapping from a hit
-  Given I have logged in as an admin
+  Given I have logged in as a GDS Editor
   And the date is 19/10/12
   And these hits exist for the Attorney General's office site:
     | http_status | path | hit_on   | count |

--- a/features/hits_and_mappings.feature
+++ b/features/hits_and_mappings.feature
@@ -1,7 +1,7 @@
 Feature: Hits relate to mappings
 
 Scenario: Some hits have mappings and some don't
-  Given I have logged in as an admin
+  Given I have logged in as a GDS Editor
   Given some hits for the Attorney General's site have mappings and some don't:
     | path                      | status_when_hit | mapping_is_now |
     | /error                    | 404             |                |

--- a/features/hits_summary.feature
+++ b/features/hits_summary.feature
@@ -5,7 +5,7 @@ Feature: Summary traffic for site
   So that I can more easily decide what to fix next based on performance
 
 Background: I start at the summary page
-  Given I have logged in as an admin
+  Given I have logged in as a GDS Editor
   And the date is 19/10/12
   And these hits exist for the Attorney General's office site:
     | http_status | path | hit_on   | count |
@@ -124,6 +124,6 @@ Scenario: No hits exist at all
 
 @allow-rescue
 Scenario: Visit the hits summary page for an non-existent site
-  Given I have logged in as an admin
+  Given I have logged in as a GDS Editor
   And I visit the path /sites/not_a_site/hits/summary
   Then I should see our custom 404 page

--- a/features/hits_universal.feature
+++ b/features/hits_universal.feature
@@ -4,7 +4,7 @@ Feature: Analytics for all sites
   So that I can see what the worst errors and most popular archives are
 
 Background: There are hits from many sites
-  Given I have logged in as an admin
+  Given I have logged in as a GDS Editor
   And some hits exist for the Attorney General, Cabinet Office and FCO sites:
   | http_status | path | hit_on   | count |
   | 301         | /    | 17/10/12 | 100   |

--- a/features/mapping_create_multiple.feature
+++ b/features/mapping_create_multiple.feature
@@ -5,7 +5,7 @@ Feature: Create mappings
 
   @javascript
   Scenario:
-    Given I have logged in as an admin
+    Given I have logged in as a GDS Editor
     And there is a site called bis belonging to an organisation bis with these mappings:
       | type     | path | new_url               |
       | redirect | /r   | http://somewhere.good |
@@ -29,7 +29,7 @@ Feature: Create mappings
 
   @javascript
   Scenario: Creating a large batch (that will be processed in the background)
-    Given I have logged in as an admin
+    Given I have logged in as a GDS Editor
     And there is a site called bis belonging to an organisation bis with these mappings:
       | type     | path | new_url               |
       | redirect | /r   | http://somewhere.good |
@@ -55,7 +55,7 @@ Feature: Create mappings
     Then I should see "You don't have permission to edit mappings for"
 
   Scenario: Errors shown for invalid inputs
-    Given I have logged in as an admin
+    Given I have logged in as a GDS Editor
     And a site bis exists
     And I visit the path /sites/bis/mappings
     And I go to create some mappings

--- a/features/mapping_edit.feature
+++ b/features/mapping_edit.feature
@@ -4,7 +4,7 @@ Feature: Edit a site's mapping
   so that the mapping begins to send people to the right place
 
   Background:
-    Given I have logged in as an admin
+    Given I have logged in as a GDS Editor
     And an archive mapping exists for the bis site with the path /about
     And I visit the path /sites/bis/mappings?fake_param=1
     And I go to edit the first mapping

--- a/features/mapping_edit_multiple.feature
+++ b/features/mapping_edit_multiple.feature
@@ -4,7 +4,7 @@ Feature: Editing multiple mappings for a site
   so that I can efficiently improve the quality of mappings
 
   Background:
-    Given I have logged in as an admin
+    Given I have logged in as a GDS Editor
     And there is a site called directgov belonging to an organisation directgov with these mappings:
       | type     | path             | new_url                                 |
       | redirect | /a               | http://gov.uk/directgov                 |

--- a/features/mapping_filter.feature
+++ b/features/mapping_filter.feature
@@ -4,7 +4,7 @@ Feature: Filter mappings
   so that I can get to the things I need to change faster
 
   Background:
-    Given I have logged in as an admin
+    Given I have logged in as a GDS Editor
     And there is a site called directgov belonging to an organisation directgov with these mappings:
       | type     | path             | new_url                 | tags             |
       | archive  | /about/corporate |                         | fee, fum, fiddle |
@@ -77,7 +77,7 @@ Feature: Filter mappings
     And I should see "0 mappings"
 
   Scenario: Filtering by clicking tags
-    Given I have logged in as an admin
+    Given I have logged in as a GDS Editor
     And I click the first tag "fum"
     Then I should see mappings tagged with "fum"
     And I should see the highlighted tag "fum"

--- a/features/mapping_history.feature
+++ b/features/mapping_history.feature
@@ -4,7 +4,7 @@ Feature: History of edits to a mapping
   So that people can be held accountable for changes
 
   Background: Bob has made a good mapping bad. Oh, Bob.
-    Given I have logged in as an admin called "Bob"
+    Given I have logged in as a GDS Editor called "Bob"
     And there is a site called directgov belonging to an organisation directgov with these mappings:
       | type     | path             | new_url                                 |
       | redirect | /about/corporate | http://somewhere.good                   |

--- a/features/mapping_index.feature
+++ b/features/mapping_index.feature
@@ -4,19 +4,19 @@ Feature: Mappings index
   so that I know there are some
 
   Scenario: Looking at a default list of mappings
-    Given I have logged in as an admin
+    Given I have logged in as a GDS Editor
     And a site has lots of mappings
     When I visit the site's mappings
     Then I should not see a column with hits information
 
   @allow-rescue
   Scenario: Visit the mappings index page for an non-existent site
-    Given I have logged in as an admin
+    Given I have logged in as a GDS Editor
     And I visit the path /sites/not_a_site/mappings/
     Then I should see our custom 404 page
 
   Scenario: Visit the mappings index page for a globally redirected site
-    Given I have logged in as an admin
+    Given I have logged in as a GDS Editor
     And a site moj_academy exists
     And the site is globally redirected
     When I visit the path /sites/moj_academy/mappings/
@@ -24,7 +24,7 @@ Feature: Mappings index
     And I should see "This site has been entirely redirected."
 
   Scenario: Visit the mappings index page for a globally archived site
-    Given I have logged in as an admin
+    Given I have logged in as a GDS Editor
     And a site defra_etr exists
     And the site is globally archived
     When I visit the path /sites/defra_etr/mappings/
@@ -32,7 +32,7 @@ Feature: Mappings index
     And I should see "This site has been entirely archived."
 
   Scenario: Visit the mappings index page for a site that I can edit the mappings for and which has an AKA domain configured and which is not already live
-    Given I have logged in as an admin
+    Given I have logged in as a GDS Editor
     And a site bis exists
     And an archive mapping exists for the site with the path /about
     And there is a working AKA domain for "bis.gov.uk"

--- a/features/mapping_pagination.feature
+++ b/features/mapping_pagination.feature
@@ -4,7 +4,7 @@ Feature: Paginated mappings
   so that I can find one to edit
 
   Scenario: There are no mappings for a site
-    Given I have logged in as an admin
+    Given I have logged in as a GDS Editor
     And there is a site called bis_lowpay belonging to an organisation bis with these mappings:
       | type     | path             | new_url           |
     When I visit the path /sites/bis_lowpay
@@ -14,7 +14,7 @@ Feature: Paginated mappings
     And I should see "0 mappings"
 
   Scenario: There are mappings for a site and we visit page 1
-    Given I have logged in as an admin
+    Given I have logged in as a GDS Editor
     And there is a site called bis_lowpay belonging to an organisation bis with these mappings:
       | type     | path             | new_url           |
       | archive  | /about/corporate |                   |
@@ -30,7 +30,7 @@ Feature: Paginated mappings
     And  I should see links top and bottom to page 2
 
   Scenario: There are mappings for a site and we visit page 2
-    Given I have logged in as an admin
+    Given I have logged in as a GDS Editor
     And there is a site called bis_lowpay belonging to an organisation bis with these mappings:
       | type     | path             | new_url           |
       | archive  | /about/corporate |                   |

--- a/features/mapping_priority.feature
+++ b/features/mapping_priority.feature
@@ -5,7 +5,7 @@ Feature: Mappings priority
   And so that I'm not confused by the seemingly inconsistent nature of hits
 
   Background:
-    Given I have logged in as an admin
+    Given I have logged in as a GDS Editor
 
   Scenario: There are lots of hits for a site's hosts
     Given a site has lots of mappings and lots of hits

--- a/features/mapping_tag.feature
+++ b/features/mapping_tag.feature
@@ -4,7 +4,7 @@ Feature: The tagging of mappings
   so that I can identify groups of mappings for specific needs or workflows
 
 Scenario: Adding tags to a mapping
-  Given I have logged in as an admin
+  Given I have logged in as a GDS Editor
   And a mapping exists for the site ukba
   When I edit that mapping
   And I associate the tags "fee, fi, FO" with the mapping
@@ -13,7 +13,7 @@ Scenario: Adding tags to a mapping
   And the mapping should have the tags "fee, fi, fo"
 
 Scenario: Adding tags when bulk adding mappings
-  Given I have logged in as an admin
+  Given I have logged in as a GDS Editor
   And a site "ukba" exists with these tagged mappings:
   | path  | tags     |
   | /1    | fee, fum |
@@ -28,7 +28,7 @@ Scenario: Adding tags when bulk adding mappings
   And the mappings should all have the tags "fee, fi, fo, fum"
 
 Scenario: Bulk adding tags to existing mappings
-  Given I have logged in as an admin
+  Given I have logged in as a GDS Editor
   And a site "ukba" exists with these tagged mappings:
   | path  | tags             |
   | /1    | fee, fum, fiddle |
@@ -45,7 +45,7 @@ Scenario: Bulk adding tags to existing mappings
 
 @javascript
 Scenario: Bulk adding tags to existing mappings (JS)
-  Given I have logged in as an admin
+  Given I have logged in as a GDS Editor
   And a site "ukba" exists with these tagged mappings:
   | path  | tags             |
   | /1    | fee, fum, fiddle |
@@ -65,7 +65,7 @@ Scenario: Bulk adding tags to existing mappings (JS)
 
 @javascript
 Scenario: Autocompleting popular tags
-  Given I have logged in as an admin
+  Given I have logged in as a GDS Editor
   And a site "foo" exists with these tagged mappings:
   | path  | tags              |
   | /1    | from another site |

--- a/features/organisation.feature
+++ b/features/organisation.feature
@@ -4,7 +4,7 @@ Feature: View organisation
   so that I can work on their mappings
 
   Scenario: Visit an organisation page
-    Given I have logged in as an admin
+    Given I have logged in as a GDS Editor
     And there is a bis organisation named UK Atomic Energy Authority abbreviated ukaea with these sites:
       | abbr       | homepage                                                               |
       | bis_ukaea  | https://www.gov.uk/government/organisations/uk-atomic-energy-authority |
@@ -15,7 +15,7 @@ Feature: View organisation
     And I should see all the old homepages for the sites of the given organisation
 
   Scenario: Organisation page with sites in each transition state
-    Given I have logged in as an admin
+    Given I have logged in as a GDS Editor
     And there is an organisation with the whitehall_slug "ukaea"
     And the organisation has a site with a host with a GOV.UK cname
     And the organisation has a site with a host with a third-party cname
@@ -29,7 +29,7 @@ Feature: View organisation
     And there should be a tooltip which includes "partially redirected"
 
   Scenario: An organisation being trusted by another to edit its mappings
-    Given I have logged in as an admin
+    Given I have logged in as a GDS Editor
     And an organisation is trusted to edit the mappings of another organisation's site
     And that organisation also has its own site
     When I visit the organisation's page
@@ -38,6 +38,6 @@ Feature: View organisation
 
   @allow-rescue
   Scenario: Visit the page of an non-existent organisation
-    Given I have logged in as an admin
+    Given I have logged in as a GDS Editor
     When I visit the path /organisations/not-an-org
     Then I should see our custom 404 page

--- a/features/organisations.feature
+++ b/features/organisations.feature
@@ -4,7 +4,7 @@ Feature: List organisations
   so that I can get to the mappings for a site
 
   Background:
-    Given I have logged in as an admin
+    Given I have logged in as a GDS Editor
     And there are these organisations with sites:
       | whitehall_slug | title                                          |
       | bis            | Department for Business, Innovation and Skills |

--- a/features/site.feature
+++ b/features/site.feature
@@ -5,7 +5,7 @@ Feature: The site dashboard
   so that I can manage mappings without creating errors
 
 Scenario: Visit a pre-transition site's page
-  Given I have logged in as an admin
+  Given I have logged in as a GDS Editor
   Given the date is 29/11/12
   And www.attorney-general.gov.uk site with abbr ago launches on 13/12/12 with the following aliases:
     | alias                     |
@@ -22,7 +22,7 @@ Scenario: Visit a pre-transition site's page
   And I should see "This tool requires AKA Domains to be set up"
 
 Scenario: Visit a pre-transition site's page
-  Given I have logged in as an admin
+  Given I have logged in as a GDS Editor
   Given the date is 29/11/12
   And www.attorney-general.gov.uk site with abbr ago launches on 13/12/12 with the following aliases:
     | alias                     |
@@ -32,7 +32,7 @@ Scenario: Visit a pre-transition site's page
   And I should see a link to the side by side browser
 
 Scenario: Visit a post-transition site's page
-  Given I have logged in as an admin
+  Given I have logged in as a GDS Editor
   Given the date is 15/12/12
   And www.attorney-general.gov.uk site with abbr ago launched on 13/12/12 with the following aliases:
     | alias                     |
@@ -43,7 +43,7 @@ Scenario: Visit a post-transition site's page
   And I should not see a link to the side by side browser
 
 Scenario: Mappings by tag
-  Given I have logged in as an admin
+  Given I have logged in as a GDS Editor
   And a site "ukba" exists with these tagged mappings:
   | path  | tags                          |
   | /1    | 1, 2, 3, 4, 5, 6, 7, 8 ,9, 10 |
@@ -62,7 +62,7 @@ Scenario: I belong to a different organisation
   But I should not be able to edit the site's mappings
 
 Scenario: Visit a globally redirected site's page
-  Given I have logged in as an admin
+  Given I have logged in as a GDS Editor
   And a site moj_academy exists
   And the site is globally redirected
   When I visit this site page
@@ -71,7 +71,7 @@ Scenario: Visit a globally redirected site's page
   And I should not see a link to view the site's mappings
 
 Scenario: Visit the page for a site globally redirected, where the path is appended
-  Given I have logged in as an admin
+  Given I have logged in as a GDS Editor
   And a site moj_academy exists
   And the site is globally redirected with the path appended
   When I visit this site page
@@ -81,7 +81,7 @@ Scenario: Visit the page for a site globally redirected, where the path is appen
   And I should not see a link to view the site's mappings
 
 Scenario: Visit a globally archived site's page
-  Given I have logged in as an admin
+  Given I have logged in as a GDS Editor
   And a site defra_etr exists
   And the site is globally archived
   When I visit this site page
@@ -91,6 +91,6 @@ Scenario: Visit a globally archived site's page
 
 @allow-rescue
 Scenario: Visit the page of an non-existent site
-  Given I have logged in as an admin
+  Given I have logged in as a GDS Editor
   When I visit the path /sites/not_a_site
   Then I should see our custom 404 page

--- a/features/step_definitions/authentication_steps.rb
+++ b/features/step_definitions/authentication_steps.rb
@@ -1,5 +1,5 @@
-Given(/^I have logged in as an admin$/) do
-  GDS::SSO.test_user = create(:admin)
+Given(/^I have logged in as a GDS Editor$/) do
+  GDS::SSO.test_user = create(:gds_editor)
 end
 
 Given(/^I have logged in as a member of DCLG$/) do
@@ -12,11 +12,11 @@ Given(/^I have logged in as a member of DCLG$/) do
 end
 
 Given(/^I log in as a SIRO$/) do
-  GDS::SSO.test_user = create(:admin)
+  GDS::SSO.test_user = create(:gds_editor)
 end
 
-Given(/^I have logged in as an admin called "([^"]*)"$/) do |name|
-  GDS::SSO.test_user = create(:admin, name: name)
+Given(/^I have logged in as a GDS Editor called "([^"]*)"$/) do |name|
+  GDS::SSO.test_user = create(:gds_editor, name: name)
 end
 
 Given(/^I have logged in as a member of another organisation$/) do

--- a/features/top_navigation.feature
+++ b/features/top_navigation.feature
@@ -7,6 +7,6 @@ Feature: Top Navigation
 
   @allow-rescue
   Scenario: Visit a non-existent page, matching no routes
-    Given I have logged in as an admin
+    Given I have logged in as a GDS Editor
     When I visit the path /totes/no/routes/here
     Then I should see our custom 404 page

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,8 +4,8 @@ FactoryGirl.define do
     sequence(:email) {|n| "person-#{n}@example.com" }
     permissions { ["signin"] }
 
-    factory :admin do
-      permissions { ["signin", "admin"] }
+    factory :gds_editor do
+      permissions { ["signin", "GDS Editor"] }
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,17 +22,17 @@ describe User do
     end
   end
 
-  describe 'admin?' do
+  describe 'gds_editor?' do
     context 'doesn\'t have permission' do
       subject(:user) { create(:user, permissions: ["signin"])}
 
-      its(:admin?) { should be_false }
+      its(:gds_editor?) { should be_false }
     end
 
     context 'has relevant permission' do
-      subject(:user) { create(:admin) }
+      subject(:user) { create(:gds_editor) }
 
-      its(:admin?) { should be_true }
+      its(:gds_editor?) { should be_true }
     end
   end
 
@@ -40,9 +40,9 @@ describe User do
     let(:ministry_of_funk) { create(:organisation, whitehall_slug: "ministry-of-funk") }
     let(:agency_of_soul)   { create(:organisation, whitehall_slug: "agency-of-soul", parent_organisations: [ministry_of_funk]) }
 
-    context 'user is an admin' do
+    context 'user is an gds_editor' do
       let(:generic_site) { create(:site) }
-      subject(:user)     { create(:admin) }
+      subject(:user)     { create(:gds_editor) }
 
       it 'lets them edit anything' do
         user.can_edit_site?(generic_site).should be_true


### PR DESCRIPTION
We currently use 'admin' to mean 'can edit any site'. We want to add the ability to edit things which are beyond mappings (specifically, the redirection host whitelist) which we don't want to give to everyone who is an currently an admin.

We can migrate the data in signon with this script:

``` ruby
application = Doorkeeper::Application.find_by_name('transition')

# update the available permissions list
supported_permission = application.supported_permissions.find_by_name('admin')
supported_permission.name = 'GDS Editor'
supported_permission.save

# update the users
application.permissions.where("permissions like '%admin%'").each do |permission|
    permission.permissions = permission.permissions.map { |string| (string == 'admin') ? 'GDS Editor' : string }
    permission.save
end
```

The timing isn't too critical. I've tested it in development and we can test again in preview.

"GDS Editor" matches the language for Whitehall, which I think is helpful.
