### PR TITLE
Remove redundant http_status code

### DIFF
--- a/app/helpers/versions_helper.rb
+++ b/app/helpers/versions_helper.rb
@@ -5,22 +5,11 @@ module VersionsHelper
     value.blank? ? '<blank>' : value
   end
 
-  # We will always have old versions in the database which record changes to the
-  # http_status column on mappings, and so will always need to display those
-  # versions as well as displaying changes to the new type column. We should not
-  # have any versions which record changes to both at the same time, because
-  # we have told PaperTrail to skip the http_status field at the same time as
-  # adding the type column.
-  def friendly_changeset_title_for_type(changeset)
-    if changeset['type']
-      new_value = changeset['type'][1]
-    elsif changeset['http_status']
-      new_value = changeset['http_status'][1]
-    end
-
-    if ['301', 'redirect'].include? new_value
+  def friendly_changeset_title_for_type(value)
+    case value
+    when 'redirect'
       'Switched mapping to a Redirect'
-    elsif ['410', 'archive'].include? new_value
+    when 'archive'
       'Switched mapping to an Archive'
     else
       'Switched mapping type'
@@ -30,8 +19,8 @@ module VersionsHelper
   def friendly_changeset_title(changeset)
     if changeset['id']
       'Mapping created'
-    elsif changeset['type'] || changeset['http_status']
-      friendly_changeset_title_for_type(changeset)
+    elsif changeset['type']
+      friendly_changeset_title_for_type(changeset['type'][1])
     elsif changeset.length == 1
       first = changeset.first[0].titleize
       first = 'Alternative Archive URL' if first == 'Archive URL'
@@ -43,20 +32,10 @@ module VersionsHelper
 
   def friendly_field_name(field)
     case field
-    when 'http_status'
-      'Type'
     when 'archive_url'
       'Alternative Archive URL'
     else
       field.titleize
-    end
-  end
-
-  def http_status_name(http_status)
-    if http_status == '301'
-      'Redirect'
-    elsif http_status == '410'
-      'Archive'
     end
   end
 
@@ -67,9 +46,6 @@ module VersionsHelper
     if field == 'type'
       old_value = change[0].titleize unless change[0].blank?
       new_value = change[1].titleize unless change[1].blank?
-    elsif field == 'http_status'
-      old_value = http_status_name(change[0]) unless change[0].blank?
-      new_value = http_status_name(change[1]) unless change[1].blank?
     end
 
     "#{old_value} → #{new_value}"

--- a/spec/helpers/versions_helper_spec.rb
+++ b/spec/helpers/versions_helper_spec.rb
@@ -4,9 +4,6 @@ require 'spec_helper'
 describe VersionsHelper do
   describe '#friendly_field_name' do
     specify { helper.friendly_field_name('type').should == 'Type' }
-    # We will always need to be able to display versions which contain
-    # http_status and/or type.
-    specify { helper.friendly_field_name('http_status').should == 'Type' }
 
     specify { helper.friendly_field_name('archive_url').should == 'Alternative Archive URL' }
 
@@ -14,13 +11,11 @@ describe VersionsHelper do
   end
 
   describe '#friendly_changeset_title_for_type' do
-    specify { helper.friendly_changeset_title_for_type({'type' => ['redirect', 'archive']}).should == 'Switched mapping to an Archive' }
-    specify { helper.friendly_changeset_title_for_type({'http_status' => ['301', '410']}).should == 'Switched mapping to an Archive' }
+    specify { helper.friendly_changeset_title_for_type('archive').should == 'Switched mapping to an Archive' }
 
-    specify { helper.friendly_changeset_title_for_type({'type' => ['archive', 'redirect']}).should == 'Switched mapping to a Redirect' }
-    specify { helper.friendly_changeset_title_for_type({'http_status' => ['410', '301']}).should == 'Switched mapping to a Redirect' }
+    specify { helper.friendly_changeset_title_for_type('redirect').should == 'Switched mapping to a Redirect' }
 
-    specify { helper.friendly_changeset_title_for_type({ }).should == 'Switched mapping type' }
+    specify { helper.friendly_changeset_title_for_type('foo').should == 'Switched mapping type' }
   end
 
   describe '#friendly_changeset_title' do
@@ -35,27 +30,13 @@ describe VersionsHelper do
     specify { helper.friendly_changeset_title({'type' => ['redirect', 'archive']}).should == 'Switched mapping to an Archive' }
   end
 
-  describe '#http_status_name' do
-    context 'status is \'301\'' do
-      subject { helper.http_status_name('301') }
-      it { should eql('Redirect') }
-    end
-
-    context 'status is \'410\'' do
-      subject { helper.http_status_name('410') }
-      it { should eql('Archive') }
-    end
-  end
-
   describe '#friendly_changeset_old_to_new' do
     specify { helper.friendly_changeset_old_to_new('misc', ['old', 'new']).should == 'old → new' }
 
     specify { helper.friendly_changeset_old_to_new('misc', ['', 'new']).should == '<blank> → new' }
 
     specify { helper.friendly_changeset_old_to_new('type', ['archive', 'redirect']).should == 'Archive → Redirect' }
-    specify { helper.friendly_changeset_old_to_new('http_status', ['410', '301']).should == 'Archive → Redirect' }
 
     specify { helper.friendly_changeset_old_to_new('type', ['', 'redirect']).should == '<blank> → Redirect' }
-    specify { helper.friendly_changeset_old_to_new('http_status', ['', '301']).should == '<blank> → Redirect' }
   end
 end


### PR DESCRIPTION
We've rewritten history in the versions table to pretend that it was always Mapping.type, not Mapping.http_status.
