### PR TITLE
Kill two bugs with one bird

### DIFF
--- a/app/views/mappings/_tags.html.erb
+++ b/app/views/mappings/_tags.html.erb
@@ -4,10 +4,14 @@
     <% mapping.taggings.each do |tagging| %>
       <% tag = tagging.tag.to_s %>
       <li>
-        <% if @filter.tags.include?(tag) %>
-          <span class="tag tag-active"><%= tag %></span>
+        <% if @filter %>
+          <% if @filter.tags.include?(tag) %>
+            <span class="tag tag-active"><%= tag %></span>
+          <% else %>
+            <%= link_to tag, @filter.query.with_tag(tag), class: 'tag' %>
+          <% end %>
         <% else %>
-          <%= link_to tag, @filter.query.with_tag(tag), class: 'tag' %>
+          <span class="tag"><%= tag %></span>
         <% end %>
       </li>
     <% end %>


### PR DESCRIPTION
- Stop `@filter` blowing up in the saved mappings modal because
  `_tags` assumes it's only ever being used from `MappingsController#index`
- Don't make the tags links when we're not on `MappingsController#index`
