### PR TITLE
Increase default limit of tags to show to 50

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -90,7 +90,7 @@ class Site < ActiveRecord::Base
   ##
   # Get the most-used tags for mappings for this site.
   # Returns an array of strings.
-  def most_used_tags(limit = 10)
+  def most_used_tags(limit = 50)
     # Assumes that only Mappings are taggable for a 25-30% speed boost.
     # Remove this assumption by qualifying the mappings join should
     # we need to tag anything else. This replaces ActsAsTaggableOn's

--- a/app/views/mappings/filter/_by_tag_menu.html.erb
+++ b/app/views/mappings/filter/_by_tag_menu.html.erb
@@ -1,4 +1,4 @@
-<% tags = @site.most_used_tags(10) %>
+<% tags = @site.most_used_tags %>
 <% if tags.any? %>
 <li class="if-no-js-hide <% if @filter.tags.any? %>selected-and-available<% end %>">
   <% if @filter.tags.any? %>

--- a/app/views/sites/_mappings.html.erb
+++ b/app/views/sites/_mappings.html.erb
@@ -23,7 +23,7 @@
           </p>
         </div>
       <% end %>
-      <% most_used_tags = @site.most_used_tags(10).to_a %>
+      <% most_used_tags = @site.most_used_tags %>
       <% if most_used_tags.any? %>
         <div class="list-group-item">
           <h4 class="list-group-item-heading">Mappings by tag</h4>

--- a/features/site.feature
+++ b/features/site.feature
@@ -44,14 +44,10 @@ Scenario: Visit a post-transition site's page
 
 Scenario: Mappings by tag
   Given I have logged in as a GDS Editor
-  And a site "ukba" exists with these tagged mappings:
-  | path  | tags                          |
-  | /1    | 1, 2, 3, 4, 5, 6, 7, 8 ,9, 10 |
-  | /2    | 1, 2, 3, 4, 5, 6, 7, 8 ,9, 10 |
-  | /3    | 12, 13, 14                    |
+  And a site "ukba" exists with mappings with lots of tags
   When I visit this site page
   Then I should see "Mappings by tag"
-  And I should see the top 10 most used tags "1, 2, 3, 4, 5, 6, 7, 8, 9, 10"
+  And I should see the top 50 most used tags
 
 Scenario: I belong to a different organisation
   Given I have logged in as a member of DCLG

--- a/features/step_definitions/mappings_fixture_steps.rb
+++ b/features/step_definitions/mappings_fixture_steps.rb
@@ -4,6 +4,16 @@ Given(/^a mapping exists for the site ukba$/) do
   @site.mappings = [@mapping]
 end
 
+Given(/^a site "([^"]*)" exists with mappings with lots of tags$/) do |site_abbr|
+  @site = create :site, abbr: site_abbr
+  [50, 51].each do |tag_count|
+    @site.mappings << create(:archived).tap do |mapping|
+      mapping.tag_list = (1..tag_count.to_i).to_a.to_s[1..-2]
+    end
+  end
+
+end
+
 Given(/^a site "([^"]*)" exists with these tagged mappings:$/) do |site_abbr, tagged_paths|
   @site = create :site, abbr: site_abbr
 

--- a/features/step_definitions/site_assertion_steps.rb
+++ b/features/step_definitions/site_assertion_steps.rb
@@ -77,6 +77,16 @@ Then(/^I should not see a link to the side by side browser$/) do
   expect(page).to_not have_selector('a[href*="www.attorney-general.gov.uk.side-by-side"]')
 end
 
+Then(/^I should see the top (\d+) most used tags$/) do |count|
+  expected_tags = (1..count.to_i).to_a.map(&:to_s)
+  within('.tag-list') do
+    expect(page).to have_selector('.tag', count: count)
+    expected_tags.each do |tag|
+      expect(page).to have_selector('.tag', text: tag)
+    end
+  end
+end
+
 Then(/^I should see the top (\d+) most used tags "([^"]*)"$/) do |count, tag_list|
   expected_tags = tag_list.split(',').map(&:strip)
   within('.tag-list') do


### PR DESCRIPTION
MOJ are using more than 10 tags, and since we limit the number of
tags which are shown in the dashboard and in the filter dropdown,
they had no way of getting back to the mappings tagged with the less
frequent tags. As a short-term measure we can increase the default
limit to 50, which shouldn't be unmanageable and it's likely that very
few sites have anything like this many tags anyway. As a more robust
solution we should make it possible to type in the tag filter dropdown
to find any tag, but that is a separate story.
