### PR TITLE
Set global_http_status from global_type even if it is already set

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -41,8 +41,7 @@ class Site < ActiveRecord::Base
   end
 
   def set_global_http_status_from_global_type
-    # If the global_http_status isn't supported, leave it as it is.
-    self.global_http_status ||= SUPPORTED_GLOBAL_TYPES_TO_GLOBAL_HTTP_STATUSES[global_type]
+    self.global_http_status = SUPPORTED_GLOBAL_TYPES_TO_GLOBAL_HTTP_STATUSES[global_type]
   end
 
   def global_redirect?

--- a/spec/lib/transition/import/site_yaml_file_spec.rb
+++ b/spec/lib/transition/import/site_yaml_file_spec.rb
@@ -63,6 +63,10 @@ describe Transition::Import::SiteYamlFile do
         its(:tna_timestamp)         { should be_a(Time) }
         its(:homepage)              { should eql('https://www.gov.uk/government/organisations/attorney-update-office') }
         its(:extra_organisations)   { should eql([tsol]) }
+        its(:global_type)           { should be_nil }
+        its(:global_http_status)    { should be_nil }
+        its(:global_new_url)        { should be_nil }
+        its(:global_redirect_append_path) { should eql(false) }
       end
     end
   end


### PR DESCRIPTION
Now that the site yaml import sets `global_type` only, it is the source
of truth, and so if a global status is removed from the site yaml the
change of `global_type` to `nil` should also set `global_http_status` to `nil`,
rather than leaving it as the original value. If it had been a redirect,
the `global_new_url` would have been removed by the import so the redirect
would error with the current behaviour of Bouncer (still using the old
column).
