### PR TITLE
Upgrade gds-sso to 9.2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rails', '3.2.18'
 gem 'unicorn', '4.6.2'
 gem 'mysql2', '0.3.13'
 gem 'optic14n', '2.0.0'     # Ideally version should be synced with bouncer
-gem 'gds-sso', '9.2.0'
+gem 'gds-sso', '9.2.5'
 gem 'govuk_admin_template', '0.0.5'
 gem 'plek', '1.2.0'
 gem 'htmlentities', '4.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
       null_logger
       plek
       rest-client (~> 1.6.3)
-    gds-sso (9.2.0)
+    gds-sso (9.2.5)
       omniauth-gds (>= 3.0.0)
       rack-accept (~> 0.4.4)
       rails (>= 3.0.0)
@@ -112,7 +112,7 @@ GEM
       rails (>= 3.2.0)
     gretel (3.0.5)
       rails (>= 3.2.0)
-    hashie (2.0.5)
+    hashie (2.1.1)
     hike (1.2.3)
     htmlentities (4.3.1)
     i18n (0.6.9)
@@ -297,7 +297,7 @@ DEPENDENCIES
   database_cleaner (= 1.0.1)
   factory_girl_rails (= 4.1.0)
   gds-api-adapters (= 7.14.0)
-  gds-sso (= 9.2.0)
+  gds-sso (= 9.2.5)
   google-api-client (= 0.6.4)
   govuk_admin_template (= 0.0.5)
   gretel (= 3.0.5)


### PR DESCRIPTION
- This fixes a problem where we were seeing duplicate users created in
  Preview when we signed in to Transition, because Transition's
  database is synced to preview each night but Signon's isn't. The SSO
  gem wasn't recognising us as already having a user, but this bug was
  fixed in this later version of the gem.
- All our tests still pass, so this looks good.
