### PR TITLE
Make unresolved filter incompatible with new url

### DIFF
--- a/app/models/view/mappings/filter.rb
+++ b/app/models/view/mappings/filter.rb
@@ -42,7 +42,7 @@ module View
       end
 
       def incompatible?
-        params[:type] == 'archive' && new_url_contains.present?
+        ['archive', 'unresolved'].include?(params[:type]) && new_url_contains.present?
       end
 
       def query

--- a/app/views/mappings/_filters.html.erb
+++ b/app/views/mappings/_filters.html.erb
@@ -33,7 +33,7 @@
       </header>
       <% if @filter.incompatible? %>
         <div class="alert alert-warning">
-          Your archive filter has been removed. Filtering by new URL is only possible with redirects.
+          Your <%= params[:type] %> filter has been removed. Filtering by new URL is only possible with redirects.
         </div>
       <% end %>
       <% if @filter.path_contains.present? || @filter.new_url_contains.present? || @filter.tags.any? %>

--- a/spec/models/view/mappings/filter_spec.rb
+++ b/spec/models/view/mappings/filter_spec.rb
@@ -23,6 +23,17 @@ module View
         it         { should be_active }
       end
 
+      context 'an incompatible params unresolved filter' do
+        let(:params) { {
+          type:             'unresolved',
+          new_url_contains: 'something'
+        } }
+
+        its(:type) { should be_nil }
+        it         { should be_incompatible }
+        it         { should be_active }
+      end
+
       context 'unrecognised types don\'t count' do
         let(:params) { { type: 'banana-cake' } }
         its(:type)   { should be_nil }


### PR DESCRIPTION
Unresolved is just like Archived in this context: they can't have New URLs, so filtering by it will never work.
