### PR TITLE
Only validate New URL in whitelist for redirects

### DIFF
--- a/app/models/mapping.rb
+++ b/app/models/mapping.rb
@@ -44,7 +44,7 @@ class Mapping < ActiveRecord::Base
 
   validates :new_url, :suggested_url, :archive_url, length: { maximum: (64.kilobytes - 1) }, non_blank_url: true
   validates :new_url, presence: { if: :redirect?, message: 'required when mapping is a redirect' }
-  validates :new_url, host_in_whitelist: true
+  validates :new_url, host_in_whitelist: { if: :redirect? }
   validates :archive_url, national_archives_url: true
 
   scope :with_hit_count, -> {

--- a/spec/models/mapping_spec.rb
+++ b/spec/models/mapping_spec.rb
@@ -142,6 +142,16 @@ describe Mapping do
 
           it { should be_valid }
         end
+
+        context 'mapping is not a redirect' do
+          subject(:mapping) { build(:archived, new_url: 'http://evil.com') }
+
+          it { should be_valid }
+          it 'still saves the value that would be invalid if it was a redirect' do
+            mapping.save
+            mapping.reload.new_url.should == 'http://evil.com'
+          end
+        end
       end
 
       context 'path is blank' do


### PR DESCRIPTION
Other validations of New URL are only done if the type is a redirect. This means that if you typed in something invalid for New URL and then changed the type to Archive, it won't reject the change you actually wanted and complain about the value of a field which we have hidden from view with JavaScript.

Mad propz to @jennyd for spotting this.
