### PR TITLE
Don't redisplay mappings progress messages

### DIFF
--- a/lib/transition/controller/mappings_progress.rb
+++ b/lib/transition/controller/mappings_progress.rb
@@ -13,6 +13,7 @@ module Transition
           end
           before_filter :set_saved_mappings, options
           before_filter :set_background_bulk_add_status_message, options
+          before_filter :prevent_caching, options
         end
       end
 
@@ -57,6 +58,21 @@ module Transition
           :alert
         else
           :info
+        end
+      end
+
+      def anything_to_display?
+        flash[:saved_mapping_ids].present? || @reportable_batch
+      end
+
+      def prevent_caching
+        # Disable caching on responses which include feedback on progress to
+        # avoid confusing users who hit the back button.
+        if anything_to_display?
+          # http://stackoverflow.com/questions/711418/how-to-prevent-browser-page-caching-in-rails
+          response.headers["Cache-Control"] = "no-cache, no-store, max-age=0, must-revalidate"
+          response.headers["Pragma"] = "no-cache"
+          response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
         end
       end
     end

--- a/spec/controllers/mappings_controller_spec.rb
+++ b/spec/controllers/mappings_controller_spec.rb
@@ -557,6 +557,12 @@ describe MappingsController do
         flash.now[:batch_progress].should eql(message: '0 of 2 mappings added', type: :success)
       end
 
+      it 'should prevent caching of the page' do
+        response.headers['Cache-Control'].should == 'no-cache, no-store, max-age=0, must-revalidate'
+        response.headers['Pragma'].should == 'no-cache'
+        response.headers['Expires'].should == 'Fri, 01 Jan 1990 00:00:00 GMT'
+      end
+
       it 'should record that the outcome of processing the batch has been seen' do
         mappings_batch.reload
         mappings_batch.seen_outcome.should == true
@@ -572,6 +578,12 @@ describe MappingsController do
 
       it 'should not show an outcome message' do
         flash.now[:batch_progress].should be_nil
+      end
+
+      it 'should not prevent caching of the page' do
+        response.headers['Cache-Control'].should be_nil
+        response.headers['Pragma'].should be_nil
+        response.headers['Expires'].should be_nil
       end
     end
 


### PR DESCRIPTION
Disable caching on responses which include feedback on progress to avoid showing the messages again and confusing users who hit the back button.

We don't want to disable caching on every page because:
- this would unnecessarily slow down the user experience
- values in forms would no longer be retained when a user hits the back button

Kudos to @fofr for the meat in this Pull Request pie. :meat_on_bone: :cake: 
