### PR TITLE
Use only instead of except to limit routes used

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Transition::Application.routes.draw do
   resources :sites, only: [:show] do
 
     get 'mappings/find', as: 'mapping_find'
-    resources :mappings, except: [:new, :create, :destroy] do
+    resources :mappings, only: [:index, :edit, :update] do
       resources :versions, only: [:index]
 
       collection do
@@ -51,6 +51,6 @@ Transition::Application.routes.draw do
   end
 
   namespace :admin do
-    resources :whitelisted_hosts, except: [:edit, :update, :delete]
+    resources :whitelisted_hosts, only: [:index, :new, :create]
   end
 end


### PR DESCRIPTION
It looks as though we were accidentally allowing the destroy route
to exist for whitelisted hosts, because we were excluding delete
instead of destroy. This fixes that issue.
