### PR TITLE
Fix collation for some columns

### DIFF
--- a/db/migrate/20140611144610_fix_collation_woes.rb
+++ b/db/migrate/20140611144610_fix_collation_woes.rb
@@ -1,0 +1,21 @@
+class FixCollationWoes < ActiveRecord::Migration
+  def up
+    statements = [
+      'ALTER TABLE mappings_batch_entries MODIFY path varchar(2048) COLLATE utf8_unicode_ci;',
+
+      'ALTER TABLE mappings_batches MODIFY new_url varchar(255) COLLATE utf8_unicode_ci;',
+      'ALTER TABLE mappings_batches MODIFY tag_list varchar(255) COLLATE utf8_unicode_ci;',
+      'ALTER TABLE mappings_batches MODIFY state varchar(255) COLLATE utf8_unicode_ci DEFAULT "unqueued";',
+      'ALTER TABLE mappings_batches MODIFY type varchar(255) COLLATE utf8_unicode_ci;',
+
+      'ALTER TABLE sessions MODIFY session_id varchar(255) COLLATE utf8_unicode_ci NOT NULL;',
+      'ALTER TABLE sessions MODIFY data text COLLATE utf8_unicode_ci;',
+    ]
+    statements.each do |statement|
+      ActiveRecord::Base.connection.execute(statement)
+    end
+  end
+
+  def down
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -83,29 +83,29 @@ CREATE TABLE `mappings` (
 
 CREATE TABLE `mappings_batch_entries` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `path` varchar(2048) DEFAULT NULL,
+  `path` varchar(2048) COLLATE utf8_unicode_ci DEFAULT NULL,
   `mappings_batch_id` int(11) DEFAULT NULL,
   `mapping_id` int(11) DEFAULT NULL,
   `processed` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `index_mappings_batch_entries_on_mappings_batch_id` (`mappings_batch_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 CREATE TABLE `mappings_batches` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `tag_list` varchar(255) DEFAULT NULL,
-  `new_url` varchar(255) DEFAULT NULL,
+  `tag_list` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `new_url` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `update_existing` tinyint(1) DEFAULT NULL,
   `user_id` int(11) DEFAULT NULL,
   `site_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `state` varchar(255) DEFAULT 'unqueued',
+  `state` varchar(255) COLLATE utf8_unicode_ci DEFAULT 'unqueued',
   `seen_outcome` tinyint(1) DEFAULT '0',
-  `type` varchar(255) DEFAULT NULL,
+  `type` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_mappings_batches_on_user_id_and_site_id` (`user_id`,`site_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 CREATE TABLE `mappings_staging` (
   `old_url` mediumtext COLLATE utf8_unicode_ci,
@@ -148,7 +148,7 @@ CREATE TABLE `organisations_sites` (
   `site_id` int(11) NOT NULL,
   `organisation_id` int(11) NOT NULL,
   UNIQUE KEY `index_organisations_sites_on_site_id_and_organisation_id` (`site_id`,`organisation_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 CREATE TABLE `schema_migrations` (
   `version` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
@@ -157,14 +157,14 @@ CREATE TABLE `schema_migrations` (
 
 CREATE TABLE `sessions` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `session_id` varchar(255) NOT NULL,
-  `data` text,
+  `session_id` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `data` text COLLATE utf8_unicode_ci,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
   KEY `index_sessions_on_session_id` (`session_id`),
   KEY `index_sessions_on_updated_at` (`updated_at`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 CREATE TABLE `sites` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -349,3 +349,5 @@ INSERT INTO schema_migrations (version) VALUES ('20140529130515');
 INSERT INTO schema_migrations (version) VALUES ('20140529164329');
 
 INSERT INTO schema_migrations (version) VALUES ('20140606155408');
+
+INSERT INTO schema_migrations (version) VALUES ('20140611144610');


### PR DESCRIPTION
These columns were created whilst their tables had the utf8_general_ci
collation, and had preserved this setting on the columns even after we
had manually altered the collation at the table level. The migration here
alters the text and varchar columns on those tables to be consistent with
the other InnoDB tables.

The history of how we got into this state is in this commit message:

```
https://github.gds/gds/puppet/commit/310eb6370c893a849a5a0944e4243a031ff93cba
```

That change was deployed a few weeks ago, and since then the
whitelisted_hosts table has been correctly created with utf8_unicode_ci,
so collation for new tables should be fine in future. The following tables
had been created with utf8_general_ci and were manually altered to utf8_unicode_ci:
- mappings_batch_entries
- mappings_batches
- organisations_sites
- sessions

Those tables now have the correct table-level collation, but text and
varchar columns in those tables still had the wrong collation at the
column level. A new varchar column created on one of those tables since
the table collation was fixed does have the correct collation (type on
mappings_batches).

Collation in itself doesn't make any difference for these four tables:
we don't sort by any of their text columns and even if we did, most of
them store ASCII-only text which would be sorted identically between the
two collations in question anyway. We only want this fixed so that we can
have a predictable and consistent db/structure.sql, and the update to that
file here should put us back into a world of happiness and consistency.
