### PR TITLE
Remove the global_http_status column

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,10 +1,5 @@
 class Site < ActiveRecord::Base
 
-  SUPPORTED_GLOBAL_TYPES_TO_GLOBAL_HTTP_STATUSES = {
-    'redirect' => '301',
-    'archive'  => '410'
-  }
-
   belongs_to :organisation
 
   has_many :hosts
@@ -17,7 +12,6 @@ class Site < ActiveRecord::Base
                            join_table: 'organisations_sites',
                            class_name: 'Organisation'
 
-  before_validation :set_global_http_status_from_global_type
   validates_presence_of :abbr
   validates_presence_of :tna_timestamp
   validates_presence_of :organisation
@@ -38,10 +32,6 @@ class Site < ActiveRecord::Base
 
   def to_param
     abbr
-  end
-
-  def set_global_http_status_from_global_type
-    self.global_http_status = SUPPORTED_GLOBAL_TYPES_TO_GLOBAL_HTTP_STATUSES[global_type]
   end
 
   def global_redirect?

--- a/db/migrate/20140618092821_remove_global_http_status_column.rb
+++ b/db/migrate/20140618092821_remove_global_http_status_column.rb
@@ -1,0 +1,5 @@
+class RemoveGlobalHTTPStatusColumn < ActiveRecord::Migration
+  def change
+    remove_column :sites, :global_http_status
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -175,7 +175,6 @@ CREATE TABLE `sites` (
   `homepage` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `global_http_status` varchar(3) COLLATE utf8_unicode_ci DEFAULT NULL,
   `global_new_url` text COLLATE utf8_unicode_ci,
   `managed_by_transition` tinyint(1) NOT NULL DEFAULT '1',
   `launch_date` date DEFAULT NULL,
@@ -351,3 +350,5 @@ INSERT INTO schema_migrations (version) VALUES ('20140529164329');
 INSERT INTO schema_migrations (version) VALUES ('20140606155408');
 
 INSERT INTO schema_migrations (version) VALUES ('20140611144610');
+
+INSERT INTO schema_migrations (version) VALUES ('20140618092821');

--- a/spec/lib/transition/import/site_yaml_file_spec.rb
+++ b/spec/lib/transition/import/site_yaml_file_spec.rb
@@ -34,7 +34,6 @@ describe Transition::Import::SiteYamlFile do
       its(:organisation)          { should eql(ago) }
       its(:extra_organisations)   { should eql([bv, tsol]) }
       its(:global_type)           { should eql('redirect') }
-      its(:global_http_status)    { should eql('301') }
       its(:global_new_url)        { should eql('https://www.gov.uk/a-new-world') }
       its(:global_redirect_append_path) { should eql(true) }
 
@@ -64,7 +63,6 @@ describe Transition::Import::SiteYamlFile do
         its(:homepage)              { should eql('https://www.gov.uk/government/organisations/attorney-update-office') }
         its(:extra_organisations)   { should eql([tsol]) }
         its(:global_type)           { should be_nil }
-        its(:global_http_status)    { should be_nil }
         its(:global_new_url)        { should be_nil }
         its(:global_redirect_append_path) { should eql(false) }
       end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -20,10 +20,6 @@ describe Site do
       it 'should validate presence of global_new_url' do
         site.errors[:global_new_url].should == ['can\'t be blank']
       end
-
-      it 'should set the global_http_status column from global_type' do
-        site.global_http_status.should == '301'
-      end
     end
 
     context 'global redirect with path appended' do


### PR DESCRIPTION
- This is the third and final part of using `type` instead of `http_status`
  globally.
- I got a collation diff - I've `git add -p` only the parts of my
  `db/structure.sql` file relevant to adding this new migration.
