### PR TITLE
Use single quotes instead of double quotes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'sidekiq', '3.0.0'
 
 # We use Errbit for tracking exceptions, which needs the airbrake gem. Config
 # for Errbit is in alphagov-deployment.
-gem "airbrake", "3.1.15"
+gem 'airbrake', '3.1.15'
 
 gem 'logstasher', '0.4.8'
 


### PR DESCRIPTION
- This makes the airbrake gem line consistent with all of the others - I
  found this when looking through to upgrade Rails to v4.x and there was
  no reason for it to be quoted differently.

(Apologies for such a tiny change in a PR. :footprints:)
