### PR TITLE
Remove redundant relationship

### DIFF
--- a/app/models/mappings_batch.rb
+++ b/app/models/mappings_batch.rb
@@ -14,7 +14,6 @@ class MappingsBatch < ActiveRecord::Base
 
   belongs_to :user
   belongs_to :site
-  has_many :mappings_batch_entries
   has_many :entries, foreign_key: :mappings_batch_id, class_name: 'MappingsBatchEntry', dependent: :delete_all
 
   validates :user, presence: true


### PR DESCRIPTION
The next line defines a short name for the same relationship. We only use the short version because nobody likes extra typing.
