### PR TITLE
Change the remove_global_http_status_column migration to be reversible

### DIFF
--- a/db/migrate/20140618092821_remove_global_http_status_column.rb
+++ b/db/migrate/20140618092821_remove_global_http_status_column.rb
@@ -1,5 +1,9 @@
 class RemoveGlobalHTTPStatusColumn < ActiveRecord::Migration
-  def change
+  def up
     remove_column :sites, :global_http_status
+  end
+
+  def down
+    add_column :sites, :global_http_status, :string, :limit => 3
   end
 end


### PR DESCRIPTION
- Following me making this only a `change` migration in #319, a discussion
  happened in which it was decided that it is important that it is
  reversible, otherwise things break in the event of an aborted deploy
  if the column removed does not rollback to exist again.
