### PR TITLE
Update type validation specs

### DIFF
--- a/spec/models/mapping_spec.rb
+++ b/spec/models/mapping_spec.rb
@@ -48,7 +48,7 @@ describe Mapping do
     it { should validate_presence_of(:path) }
 
     it { should validate_presence_of(:type) }
-    it { should ensure_inclusion_of(:type).in_array(['redirect', 'archive']) }
+    it { should ensure_inclusion_of(:type).in_array(Mapping::SUPPORTED_TYPES) }
 
     describe 'home pages (which are handled by Site)' do
       subject(:homepage_mapping) { build(:mapping, path: '/') }

--- a/spec/models/mappings_batch_spec.rb
+++ b/spec/models/mappings_batch_spec.rb
@@ -5,7 +5,7 @@ describe MappingsBatch do
     it { should validate_presence_of(:user) }
     it { should validate_presence_of(:site) }
     it { should validate_presence_of(:paths).with_message('Enter at least one valid path') }
-    it { should ensure_inclusion_of(:type).in_array(['redirect', 'archive']) }
+    it { should ensure_inclusion_of(:type).in_array(Mapping::SUPPORTED_TYPES) }
     it { should ensure_inclusion_of(:state).in_array(MappingsBatch::PROCESSING_STATES) }
 
     describe 'paths includes URLs for another site' do


### PR DESCRIPTION
Two tests using ensure_validation_of were still passing even though they
didn't have 'unresolved' in the array which should match the supported
types of mappings. Since they continue to pass as long as all elements
of the array the matcher receives are valid (even if the array is empty),
I think the clearest thing to do here is to just pass it Mapping::SUPPORTED_TYPES.
