### PR TITLE
Make validation messages on New URL consistent

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,8 @@ en:
     attributes:
       whitelisted_host:
         hostname: Domain
+      mapping:
+        new_url: 'The URL to redirect to'
       mappings_batch:
         paths: Old URLs
   mappings:

--- a/features/mapping_edit.feature
+++ b/features/mapping_edit.feature
@@ -53,7 +53,7 @@ Feature: Edit a site's mapping
     When I make the mapping a redirect to http:////not-a-url
     And I save the mapping
     Then I should still be editing a mapping
-    And I should see "New URL is not a URL"
+    And I should see "The URL to redirect to is not a URL"
 
   @allow-rescue
   Scenario: Visit the page of an non-existent mapping


### PR DESCRIPTION
The form labels this field as 'Redirects to', but the validation messages were
referring to it as 'New URL'. 'Redirects to is not a URL' reads a little
awkwardly, so let's make it consistent with existing validation messages on
bulk add.
