### PR TITLE
Eliminate unnecessary break

### DIFF
--- a/app/views/sites/_global_type.html.erb
+++ b/app/views/sites/_global_type.html.erb
@@ -5,8 +5,8 @@
           All paths from <%= @site.default_host.hostname %><br />
            <span class=\"text-muted\">redirect to <%= @site.global_new_url %></span>
         <% elsif @site.global_archive? %>
-          All paths from <%= @site.default_host.hostname %> 
-           <span class=\"text-muted\">have been archived</span>
+          All paths from <%= @site.default_host.hostname %>
+           <span class=\"text-muted\"> have been archived</span>
         <% end %>
       </p>
       <p class="text-muted remove-bottom-margin">


### PR DESCRIPTION
The text breaks a bit oddly with a global archive and the hard break. Removing so it flows more smoothly.
