### PR TITLE
Set hit_count on mapping create

### DIFF
--- a/app/models/mapping.rb
+++ b/app/models/mapping.rb
@@ -25,6 +25,8 @@ class Mapping < ActiveRecord::Base
   } ]
 
   belongs_to :site
+  has_many :hits
+
   validates :site, presence: true
   validates :path,
             length: { maximum: 1024 },
@@ -165,5 +167,7 @@ protected
 
     site.hits.where(path_hash: new_hits_hashes).update_all(mapping_id: self.id)
     host_paths.update_all(mapping_id: self.id)
+
+    self.update_column(:hit_count, hits.sum('count'))
   end
 end

--- a/spec/models/mapping_spec.rb
+++ b/spec/models/mapping_spec.rb
@@ -306,6 +306,10 @@ describe Mapping do
           host_path_on_canonicalized.reload.mapping.should == mapping
         end
 
+        it 'updates the hit_count' do
+          mapping.hit_count.should == 40
+        end
+
         it 'should leave an unrelated hit alone' do
           unrelated_hit.reload.mapping.should be_nil
         end


### PR DESCRIPTION
At the moment, after you create a mapping, it will have a hit_count of zero,
even if there are hits.

Before we denormalised hit counts onto mappings this wasn't necessary as it
was calculated on the fly.
