### PR TITLE
Make separator_detector_spec idiomatic

### DIFF
--- a/spec/lib/transition/csv_separator_detector_spec.rb
+++ b/spec/lib/transition/csv_separator_detector_spec.rb
@@ -1,47 +1,44 @@
 require 'spec_helper'
 
 describe Transition::CSVSeparatorDetector do
-  def make_a_detector(rows)
-    Transition::CSVSeparatorDetector.new(rows)
-  end
+  let(:detector) { Transition::CSVSeparatorDetector.new(rows) }
 
   describe '#separator_count' do
-    it 'should be 1 when there is only one row with one separator' do
-      detector = make_a_detector(['/a,'])
-      detector.separator_count(',').should == 1
+    context 'when there is only one row with one separator' do
+      let(:rows) { ['/a,'] }
+      specify    { detector.separator_count(',').should == 1 }
     end
 
-    it 'should be 1 when only one of two rows has the separator' do
-      detector = make_a_detector(['/a', '/b,TNA'])
-      detector.separator_count(',').should == 1
+    context 'when only one of two rows has the separator' do
+      let(:rows) { ['/a', '/b,TNA'] }
+      specify    { detector.separator_count(',').should == 1 }
     end
 
-    it 'ignores other separators and only counts the given one' do
-      detector = make_a_detector(["/a\tTNA", '/b,TNA', '/c,', '/d,'])
-      detector.separator_count(',').should == 3
+    context 'when there are other separators' do
+      let(:rows) { ["/a\tTNA", '/b,TNA', '/c,', '/d,'] }
+
+      it 'ignores them and only counts the majority separator' do
+        detector.separator_count(',').should == 3
+      end
     end
   end
 
   describe '#separator' do
+    subject { detector.separator }
+
     context 'when there are more commas than tabs in the rows' do
-      it 'is comma' do
-        detector = make_a_detector(["/a\tTNA", '/b,TNA', '/c,', '/d,'])
-        detector.separator.should == ','
-      end
+      let(:rows)       { ["/a\tTNA", '/b,TNA', '/c,', '/d,'] }
+      it('is a comma') { should == ',' }
     end
 
     context 'when there are more tabs than commas in the rows' do
-      it 'is tab' do
-        detector = make_a_detector(["/a\tTNA", "/b,\tTNA", "/c\t", '/d,'])
-        detector.separator.should == "\t"
-      end
+      let(:rows)     { ["/a\tTNA", "/b,\tTNA", "/c\t", '/d,'] }
+      it('is a tab') { should == "\t" }
     end
 
     context 'when there are equal numbers of tabs and commas' do
-      it 'is tab' do
-        detector = make_a_detector(["/a\tTNA", "/b\tTNA", '/c,', '/d,'])
-        detector.separator.should == "\t"
-      end
+      let(:rows)     { ["/a\tTNA", "/b\tTNA", '/c,', '/d,'] }
+      it('is a tab') { should == "\t" }
     end
   end
 end


### PR DESCRIPTION
- Make it closer in style to our other specs

This is pretty much just because I wanted to see what the difference is. There's a marked change in style from our other specs in here and I wanted to get a feel for how it would look in our "usual" RSpec-let-parameterised style and whether we're intentionally moving away from that. Not saying either is "better", but just wanted to see. Opinion time :dash: 
