### PR TITLE
Display the unresolved mapping count delimited with a comma

### DIFF
--- a/app/views/sites/_mappings.html.erb
+++ b/app/views/sites/_mappings.html.erb
@@ -19,7 +19,7 @@
             <%= link_to 'Paths needing a decision', site_mappings_path(@site, type: 'unresolved'), class: 'no-visit' %>
           </h4>
           <p class="list-group-item-text text-muted">
-            <strong><%= @unresolved_mappings_count %> paths</strong> are unresolved – that’s <strong><%= site_unresolved_mappings_percentage(@site) %> of mappings</strong>.<br />
+            <strong><%= number_with_delimiter(@unresolved_mappings_count) %> paths</strong> are unresolved – that’s <strong><%= site_unresolved_mappings_percentage(@site) %> of mappings</strong>.<br />
             (After transition, mappings without a type will be archived by default.)
           </p>
         </div>


### PR DESCRIPTION
- For example, 10000 as 10,000. This standardizes the display on the
  site dashboard with the other sections.
