### PR TITLE
Validate that abbr is slug-safe

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -12,10 +12,9 @@ class Site < ActiveRecord::Base
                            join_table: 'organisations_sites',
                            class_name: 'Organisation'
 
-  validates_presence_of :abbr
   validates_presence_of :tna_timestamp
   validates_presence_of :organisation
-  validates_uniqueness_of :abbr
+  validates :abbr, uniqueness: true, presence: true, format: { with: /\A[a-zA-Z0-9_\-]+\z/, message: 'can only contain alphanumeric characters, underscores and dashes' }
   validates_inclusion_of :special_redirect_strategy, in: %w{ via_aka supplier }, allow_nil: true
   validates :global_new_url, presence: { :if => :global_redirect? }
   validates :global_new_url, format: { without: /\?/,

--- a/spec/lib/transition/import/whitehall/mappings_csv_spec.rb
+++ b/spec/lib/transition/import/whitehall/mappings_csv_spec.rb
@@ -4,7 +4,7 @@ require 'transition/import/whitehall/mappings_csv'
 def csv_for(old_path, govuk_path, whitehall_state = 'published')
   StringIO.new(<<-END)
 Old URL,New URL,Admin URL,State
-http://www.dft.gov.uk#{old_path},https://www.gov.uk#{govuk_path},http://whitehall-admin/#{rand(1000)},#{whitehall_state}
+http://dft.gov.uk#{old_path},https://www.gov.uk#{govuk_path},http://whitehall-admin/#{rand(1000)},#{whitehall_state}
 END
 end
 
@@ -13,7 +13,7 @@ describe Transition::Import::Whitehall::MappingsCSV do
     let(:as_user) { create(:user, name: 'C-3PO', is_robot: true) }
 
     context 'site and host exists' do
-      let!(:site) { create(:site, abbr: 'www.dft', query_params: 'significant') }
+      let!(:site) { create(:site, abbr: 'dft', query_params: 'significant') }
 
       before do
         Transition::Import::Whitehall::MappingsCSV.new(as_user).from_csv(csv)
@@ -128,17 +128,17 @@ END
     end
 
     context 'site is not managed by transition' do
-      let!(:site) { create(:site, abbr: 'www.dft', managed_by_transition: false) }
+      let!(:site) { create(:site, abbr: 'dft', managed_by_transition: false) }
       let(:csv) { csv_for('/oldurl', '/new') }
 
       it 'logs it' do
-        Rails.logger.should_receive(:warn).with("Skipping mapping for a site managed by redirector in Whitehall URL CSV: 'www.dft.gov.uk'")
+        Rails.logger.should_receive(:warn).with("Skipping mapping for a site managed by redirector in Whitehall URL CSV: 'dft.gov.uk'")
         Transition::Import::Whitehall::MappingsCSV.new(as_user).from_csv(csv)
       end
     end
 
     context 'testing version recording', versioning: true do
-      let!(:site) { create(:site, abbr: 'www.dft', query_params: 'significant') }
+      let!(:site) { create(:site, abbr: 'dft', query_params: 'significant') }
       let(:csv) { csv_for('/oldurl', '/new') }
 
       before do
@@ -162,7 +162,7 @@ END
       let(:csv) { csv_for('/oldurl', '/amazing') }
 
       it 'logs an unknown host' do
-        Rails.logger.should_receive(:warn).with("Skipping mapping for unknown host in Whitehall URL CSV: 'www.dft.gov.uk'")
+        Rails.logger.should_receive(:warn).with("Skipping mapping for unknown host in Whitehall URL CSV: 'dft.gov.uk'")
         Transition::Import::Whitehall::MappingsCSV.new(as_user).from_csv(csv)
       end
     end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -12,6 +12,8 @@ describe Site do
     it { should validate_presence_of(:tna_timestamp) }
     it { should validate_presence_of(:organisation) }
     it { should ensure_inclusion_of(:special_redirect_strategy).in_array(['via_aka', 'supplier']) }
+    it { should allow_value("org_site1-Modifier").for(:abbr) }
+    it { should_not allow_value("org_www.site").for(:abbr) }
 
     context 'global redirect' do
       subject(:site) { build(:site, global_type: 'redirect') }


### PR DESCRIPTION
We currently have one which is `directgov_www.actonco2`. This is a problem
because Rails interprets the . as indicating a format, but it is a format it
doesn't support, so Rails returns 406 Not Acceptable.

The immediate fix is to change the abbr on that site, but this should prevent it happening again.

An alternative fix would be to tweak the Site#to_param to make abbr slug-safe,
but doing it this way means that the abbr is always the slug and vice versa.
