### PR TITLE
Remove the threshold of 10 for hits import

### DIFF
--- a/lib/transition/google/tsv_generator.rb
+++ b/lib/transition/google/tsv_generator.rb
@@ -28,7 +28,7 @@ module Transition
       def generate!
         stdfile.puts HEADER
         results_pager.each do |hostname, path, count|
-          stdfile.puts "#{HIT_NEVER_STR}\t#{count}\t000\t#{hostname}\t#{path}"
+          stdfile.puts "#{HIT_NEVER_STR}\t#{count}\t000\t#{hostname}\t#{path}" if count >= 10
         end
       end
     end

--- a/lib/transition/import/hits.rb
+++ b/lib/transition/import/hits.rb
@@ -99,7 +99,6 @@ module Transition
         SELECT h.id, st.path, SHA1(st.path), st.http_status, st.count, st.hit_on
         FROM   hits_staging st
         INNER JOIN hosts h on h.hostname = st.hostname
-        WHERE  st.count >= 10
         AND    st.path NOT IN (#{ PATHS_TO_IGNORE.map { |path| "'" + path + "'" }.join(', ') })
         AND    st.path NOT REGEXP '#{ PATTERNS_TO_IGNORE.join('|') }'
         ON DUPLICATE KEY UPDATE hits.count=st.count

--- a/spec/fixtures/hits/businesslink_2012-10-14.tsv
+++ b/spec/fixtures/hits/businesslink_2012-10-14.tsv
@@ -1,6 +1,6 @@
 date	count	status	host	path
 2012-10-14	21	301	www.businesslink.gov.uk	/
 2012-10-14	12	404	www.businesslink.gov.uk	/about-nothing
-2012-10-14	9	404	www.businesslink.gov.uk	/too-few-count
+2012-10-14	9	404	www.businesslink.gov.uk	/previously-too-few-count
 2012-10-14	11	301	online.businesslink.gov.uk	/unknown-host
 2012-10-14	10	503	tariff.businesslink.gov.uk	/unknown-host

--- a/spec/lib/transition/google/ingester_spec.rb
+++ b/spec/lib/transition/google/ingester_spec.rb
@@ -27,7 +27,7 @@ describe Transition::Google::UrlIngester, truncate_everything: true do
   end
 
   context 'an org with a profile id exists' do
-    it 'ingests only hits for known hosts' do
+    it 'ingests only hits for known hosts above a threshold of 10' do
       create :site, abbr: 'dpm',
              organisation: create(:organisation, whitehall_slug: 'dpm')
       ingester.ingest!

--- a/spec/lib/transition/google/tsv_generator_spec.rb
+++ b/spec/lib/transition/google/tsv_generator_spec.rb
@@ -5,7 +5,8 @@ describe Transition::Google::TSVGenerator do
   let(:hostpath_rows) { [
     ['host.gov.uk', '/path', 30],
     ['host.gov.uk', '/path2', 20],
-    ['nohost.gov.uk', '/path', 10]
+    ['nohost.gov.uk', '/path', 10],
+    ['nohost.gov.uk', '/too-few', 9],
   ]}
   
   let(:results_pager) { hostpath_rows.each }
@@ -19,6 +20,8 @@ describe Transition::Google::TSVGenerator do
     stdfile.should_receive(:puts).with("1970-01-01\t30\t000\thost.gov.uk\t/path")
     stdfile.should_receive(:puts).with("1970-01-01\t20\t000\thost.gov.uk\t/path2")
     stdfile.should_receive(:puts).with("1970-01-01\t10\t000\tnohost.gov.uk\t/path")
+
+    stdfile.should_not_receive(:puts).with("1970-01-01\t9\t000\tnohost.gov.uk\t/too-few")
 
     tsv_generator.generate!
   end

--- a/spec/lib/transition/import/hits_spec.rb
+++ b/spec/lib/transition/import/hits_spec.rb
@@ -14,15 +14,16 @@ describe Transition::Import::Hits do
       end
 
       it 'has imported hits' do
-        Hit.count.should == 2
+        Hit.count.should == 3
       end
 
       it "has not imported hits for hosts we don't know about" do
         Hit.where(path: '/unknown-host').any?.should be_false
       end
 
-      it 'has not imported hits with a count less than ten' do
-        Hit.where(path: '/too-few-count').any?.should be_false
+      it 'imports hits with any count, ' \
+         'relying on upstream processing for per-day thresholds' do
+        Hit.where(path: '/previously-too-few-count').any?.should be_true
       end
 
       describe 'the first hit' do
@@ -106,7 +107,7 @@ describe Transition::Import::Hits do
     end
 
     it 'imports hits from the combined files for the known hosts' do
-      Hit.count.should == 3
+      Hit.count.should == 4
     end
   end
 end


### PR DESCRIPTION
- Moves the responsibility for filtering to upstream TSV generators
- We have such a generator in the shape of the Google Analytics importer.
  Make it responsible for applying its own filter at the same time.
