### PR TITLE
Tidy up the BulkAddBatch spec

### DIFF
--- a/spec/models/bulk_add_batch_spec.rb
+++ b/spec/models/bulk_add_batch_spec.rb
@@ -18,57 +18,61 @@ describe BulkAddBatch do
   describe 'validations' do
     it { should ensure_inclusion_of(:type).in_array(Mapping::SUPPORTED_TYPES) }
 
-    context 'when paths are empty after canonicalisation' do
-      subject(:mappings_batch) { build(:bulk_add_batch, paths: ['/']) }
-
+    context 'when the mappings batch is invalid' do
       before { mappings_batch.should_not be_valid }
-      it 'should declare it invalid' do
-        mappings_batch.errors[:canonical_paths].should == ['Enter at least one valid path or full URL']
+
+      context 'when paths are empty after canonicalisation' do
+        subject(:mappings_batch) { build(:bulk_add_batch, paths: ['/']) }
+
+        it 'should declare it invalid' do
+          mappings_batch.errors[:canonical_paths].should == ['Enter at least one valid path or full URL']
+        end
       end
-    end
 
-    context 'when it is a redirect' do
-      subject(:mappings_batch) { build(:bulk_add_batch, type: 'redirect') }
+      context 'when it is a redirect' do
+        subject(:mappings_batch) { build(:bulk_add_batch, type: 'redirect') }
 
-      before { mappings_batch.should_not be_valid }
-      it 'must have a new URL' do
-        mappings_batch.errors[:new_url].should == ['Enter a valid URL to redirect to']
+        it 'must have a new URL' do
+          mappings_batch.errors[:new_url].should == ['Enter a valid URL to redirect to']
+        end
       end
-    end
 
-    context 'when the new URL is too long' do
-      subject(:mappings_batch) { build(:bulk_add_batch, type: 'redirect', new_url: 'http://'.ljust(65536, 'x')) }
+      context 'when the new URL is too long' do
+        subject(:mappings_batch) { build(:bulk_add_batch, type: 'redirect', new_url: 'http://'.ljust(65536, 'x')) }
 
-      before { mappings_batch.should_not be_valid }
-      it 'is invalid' do
-        mappings_batch.errors[:new_url].should include('is too long (maximum is 65535 characters)')
+        it 'is invalid' do
+          mappings_batch.errors[:new_url].should include('is too long (maximum is 65535 characters)')
+        end
       end
-    end
 
-    context 'when the new URL is invalid' do
-      subject(:mappings_batch) { build(:bulk_add_batch, type: 'redirect', new_url: 'newurl') }
+      context 'when the new URL is invalid' do
+        subject(:mappings_batch) { build(:bulk_add_batch, type: 'redirect', new_url: 'newurl') }
 
-      before { mappings_batch.should_not be_valid }
-      it 'errors and asks for a valid one' do
-        mappings_batch.errors[:new_url].should include('Enter a valid URL to redirect to')
+        it 'errors and asks for a valid one' do
+          mappings_batch.errors[:new_url].should include('Enter a valid URL to redirect to')
+        end
       end
-    end
 
-    context 'when the new URL is not whitelisted' do
-      subject(:mappings_batch) { build(:bulk_add_batch, type: 'redirect', new_url: 'http://bad.com') }
+      context 'when the new URL is not whitelisted' do
+        subject(:mappings_batch) { build(:bulk_add_batch, type: 'redirect', new_url: 'http://bad.com') }
 
-      before { mappings_batch.should_not be_valid }
-      it 'errors and asks for a whitelisted one' do
-        mappings_batch.errors[:new_url].should include('The URL to redirect to must be on a whitelisted domain. Contact transition-dev@digital.cabinet-office.gov.uk for more information.')
+        it 'errors and asks for a whitelisted one' do
+          mappings_batch.errors[:new_url].should include('The URL to redirect to must be on a whitelisted domain. Contact transition-dev@digital.cabinet-office.gov.uk for more information.')
+        end
       end
-    end
 
-    context 'when the path list includes a URL for another site' do
-      subject(:mappings_batch) { build(:bulk_add_batch, paths: ['http://another.com/foo']) }
+      context 'when the path list includes a URL for another site' do
+        subject(:mappings_batch) { build(:bulk_add_batch, paths: ['http://another.com/foo']) }
 
-      before { mappings_batch.should_not be_valid }
-      it 'errors and asks for a URL that is part of the current site' do
-        mappings_batch.errors[:paths].should == ['One or more of the URLs entered are not part of this site']
+        it 'errors and asks for a URL that is part of the current site' do
+          mappings_batch.errors[:paths].should == ['One or more of the URLs entered are not part of this site']
+        end
+      end
+
+      context 'when a new URL given to paths is invalid' do
+        subject(:mappings_batch) { build(:bulk_add_batch, type: 'archive', paths: ['http://newurl/foo[1]']) }
+
+        it { should_not be_valid }
       end
     end
 
@@ -80,12 +84,6 @@ describe BulkAddBatch do
       end
 
       it { should be_valid }
-    end
-
-    context 'when a new URL given to paths is invalid' do
-      subject(:mappings_batch) { build(:bulk_add_batch, type: 'archive', paths: ['http://newurl/foo[1]']) }
-
-      it { should_not be_valid }
     end
   end
 


### PR DESCRIPTION
- Remove a redundant test.
- Change `describe` blocks to `context` blocks.
- Remove `before {}` noise by using one in a new `invalid` context.

(Paired with @rgarner on this.)
