### PR TITLE
Add titles and furls to sites

### DIFF
--- a/db/migrate/20140724164511_add_title_and_furl_to_site.rb
+++ b/db/migrate/20140724164511_add_title_and_furl_to_site.rb
@@ -1,0 +1,6 @@
+class AddTitleAndFurlToSite < ActiveRecord::Migration
+  def change
+    add_column :sites, :homepage_title, :string
+    add_column :sites, :homepage_furl, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -187,6 +187,8 @@ CREATE TABLE `sites` (
   `special_redirect_strategy` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `global_redirect_append_path` tinyint(1) NOT NULL DEFAULT '0',
   `global_type` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `homepage_title` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `homepage_furl` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_sites_on_site` (`abbr`),
   KEY `index_sites_on_organisation_id` (`organisation_id`)
@@ -362,3 +364,5 @@ INSERT INTO schema_migrations (version) VALUES ('20140618092821');
 INSERT INTO schema_migrations (version) VALUES ('20140618145219');
 
 INSERT INTO schema_migrations (version) VALUES ('20140623135055');
+
+INSERT INTO schema_migrations (version) VALUES ('20140724164511');

--- a/lib/transition/import/site_yaml_file.rb
+++ b/lib/transition/import/site_yaml_file.rb
@@ -83,6 +83,8 @@ module Transition
           site.global_new_url        = global_new_url
           site.global_redirect_append_path = global_redirect_append_path
           site.homepage              = yaml['homepage']
+          site.homepage_title        = yaml['homepage_title']
+          site.homepage_furl         = yaml['homepage_furl']
           site.managed_by_transition = managed_by_transition?
 
           site.save!

--- a/spec/fixtures/sites/someyaml/ago.yml
+++ b/spec/fixtures/sites/someyaml/ago.yml
@@ -4,8 +4,7 @@ whitehall_slug: attorney-generals-office
 host: www.attorneygeneral.gov.uk
 redirection_date: 13th December 2012
 tna_timestamp: 20120816224015
-title: Attorney General&#39;s Office
-furl: www.gov.uk/ago
+homepage_furl: www.gov.uk/ago
 homepage: https://www.gov.uk/government/organisations/attorney-generals-office
 aliases:
 - www.attorney-general.gov.uk

--- a/spec/fixtures/sites/updates/ago.yml
+++ b/spec/fixtures/sites/updates/ago.yml
@@ -4,8 +4,8 @@ whitehall_slug: attorney-update-office
 host: www.attorneygeneral.gov.uk
 redirection_date: 13th December 2014
 tna_timestamp: 20120816224015
-title: Attorney General&#39;s Office
-furl: www.gov.uk/ago-update
+homepage_title: Now has a &#39;s custom title
+homepage_furl: www.gov.uk/ago-update
 homepage: https://www.gov.uk/government/organisations/attorney-update-office
 aliases:
 - www.attorney-general.gov.uk

--- a/spec/lib/transition/import/site_yaml_file_spec.rb
+++ b/spec/lib/transition/import/site_yaml_file_spec.rb
@@ -30,6 +30,7 @@ describe Transition::Import::SiteYamlFile do
       its(:launch_date)           { should eql(Date.new(2012, 12, 13)) }
       its(:tna_timestamp)         { should be_a(Time) }
       its(:homepage)              { should eql('https://www.gov.uk/government/organisations/attorney-generals-office') }
+      its(:homepage_furl)         { should eql('www.gov.uk/ago') }
       its(:managed_by_transition) { should eql(false) }
       its(:organisation)          { should eql(ago) }
       its(:extra_organisations)   { should eql([bv, tsol]) }
@@ -62,6 +63,7 @@ describe Transition::Import::SiteYamlFile do
         its(:launch_date)           { should eql(Date.new(2014, 12, 13)) }
         its(:tna_timestamp)         { should be_a(Time) }
         its(:homepage)              { should eql('https://www.gov.uk/government/organisations/attorney-update-office') }
+        its(:homepage_title)        { should eql('Now has a &#39;s custom title') }
         its(:extra_organisations)   { should eql([tsol]) }
         its(:global_type)           { should be_nil }
         its(:global_new_url)        { should be_nil }


### PR DESCRIPTION
Sites can already have homepages which differ from their owning organisation's homepage. Given that the furl attribute is simply a shorter form of the full URL for a site, it follows that they have furls too.

We are currently inconsistent with how we apply the (new) homepage for a site.
- If you look at the site in Transition, it says the new homepage is the one
  specified for that site in Redirector.
- If you visit the old homepage, you get redirected to the site's new
  homepage, which is correct.
- However, if you visit a page with an archive/unresolved mapping, it links
  to the organisation's new homepage, which is unhelpful or even
  inappropriate.

Therefore, we should change Bouncer's archive behaviour so that it links to the site's new homepage. To make it consistent, we then need to make it use the furl (if any) and a title which describes the site, rather than the organisation. The site's title might often be the same as the organisation's name.

With a related PR in Bouncer, this is an alternative to https://github.com/alphagov/bouncer/pull/81 
