### PR TITLE
Handle rows with just a separator in import

### DIFF
--- a/app/models/import_batch.rb
+++ b/app/models/import_batch.rb
@@ -76,7 +76,8 @@ private
 
       rows_by_path = {}
       CSV.parse(raw_csv, col_sep: separator).each.with_index(1) do |csv_row, line_number|
-        next unless csv_row.present?  # Blank lines are parsed as []
+        # Blank lines are parsed as []. Rows with just a separator are parsed as [nil, nil]
+        next unless csv_row.present? && csv_row[0].present?
 
         row = Transition::Import::CSV::ImportBatchRow.new(site, line_number, csv_row)
         next if row.ignorable?

--- a/spec/models/import_batch_spec.rb
+++ b/spec/models/import_batch_spec.rb
@@ -182,6 +182,20 @@ describe ImportBatch do
       end
     end
 
+    context 'with lines containing only a separator' do
+      let(:raw_csv) { <<-CSV.strip_heredoc
+                        /old,https://www.gov.uk/new
+                        ,
+                      CSV
+                    }
+
+      it 'should ignore those lines' do
+        mappings_batch.entries.count.should == 1
+        entry = mappings_batch.entries.first
+        entry.path.should == '/old'
+      end
+    end
+
     context 'archives' do
       let(:raw_csv) { <<-CSV.strip_heredoc
                   /old,TNA


### PR DESCRIPTION
This was triggering an error when ImportBatchRow tried to call strip on the
first entry in a row which it assumes is a string, but in this case was nil.
