### PR TITLE
Validate site homepage for presence and being a full URL

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -16,6 +16,7 @@ class Site < ActiveRecord::Base
 
   validates_presence_of :tna_timestamp
   validates_presence_of :organisation
+  validates :homepage, presence: true, non_blank_url: true
   validates :abbr, uniqueness: true, presence: true, format: { with: /\A[a-zA-Z0-9_\-]+\z/, message: 'can only contain alphanumeric characters, underscores and dashes' }
   validates_inclusion_of :special_redirect_strategy, in: %w{ via_aka supplier }, allow_nil: true
   validates :global_new_url, presence: { :if => :global_redirect? }

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -15,6 +15,22 @@ describe Site do
     it { should allow_value("org_site1-Modifier").for(:abbr) }
     it { should_not allow_value("org_www.site").for(:abbr) }
 
+    describe 'homepage' do
+      it { should validate_presence_of(:homepage) }
+
+      describe 'the homepage errors' do
+        subject(:site) do
+          build(:site, homepage: 'www.no-scheme.gov.uk')
+        end
+
+        before { site.should_not be_valid }
+
+        it 'should validate the homepage as a full URL' do
+          site.errors[:homepage].should == ['is not a URL']
+        end
+      end
+    end
+
     context 'global redirect' do
       subject(:site) { build(:site, global_type: 'redirect') }
 


### PR DESCRIPTION
We rely on the homepage being present and a full URL because we use
it for redirects. Bouncer returns 500 when a homepage has no scheme.
