### PR TITLE
Don't allow 500s from batch progress

### DIFF
--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -1,17 +1,13 @@
 class BatchesController < ApplicationController
-  before_filter :set_batch
-
   def show
+    @batch = current_user.mappings_batches.find(:first, params[:id])
+    render json: {}, status: 404 and return if @batch.nil?
+
     body = {
       done:  @batch.entries.processed.count,
       total: @batch.entries_to_process.count,
       past_participle: "#{@batch.verb}ed",
     }
     render json: body
-  end
-
-private
-  def set_batch
-    @batch = current_user.mappings_batches.find(params[:id])
   end
 end

--- a/spec/controllers/batches_controller_spec.rb
+++ b/spec/controllers/batches_controller_spec.rb
@@ -4,26 +4,36 @@ describe BatchesController do
   describe 'GET #show' do
     let(:user) { create(:user) }
     let(:site) { create(:site) }
-    let(:mappings_batch) { create(:bulk_add_batch, site: site, user: user) }
 
     before do
       login_as(user)
-      get :show, site_id: site.abbr, id: mappings_batch.id
+      get :show, site_id: site.abbr, id: batch_id
       @parsed_response = JSON.parse(response.body)
     end
 
+    context 'when the batch exists' do
+      let(:batch_id) { create(:bulk_add_batch, site: site, user: user).id }
 
-    it 'responds with the correct HTTP status code' do
-      expect(response.status).to be(200)
+      it 'responds with the correct HTTP status code' do
+        expect(response.status).to be(200)
+      end
+
+      it 'renders a JSON document' do
+        expected = {
+          'done' => 0,
+          'total' => 2,
+          'past_participle' => 'added'
+        }
+        @parsed_response.should == expected
+      end
     end
 
-    it 'renders a JSON document' do
-      expected = {
-        'done' => 0,
-        'total' => 2,
-        'past_participle' => 'added'
-      }
-      @parsed_response.should == expected
+    context 'when the batch does not exist' do
+      let(:batch_id) { 999999 }
+
+      it '404s (as a 500 often offends)' do
+        expect(response.status).to be(404)
+      end
     end
   end
 end


### PR DESCRIPTION
- This was causing uncaught errors during feature runs
- While they wouldn't fail the suite, it's damn confusing
  to see red in a green test suite
- No harm in doing the right thing and 404'ing a lost batch
- Also, remove before_filter, wasn't adding anything and was
  noisying up the place.
