### PR TITLE
Only show special redirect strategy before site is live

### DIFF
--- a/app/views/sites/_transition_status.html.erb
+++ b/app/views/sites/_transition_status.html.erb
@@ -1,10 +1,12 @@
 <%= site.transition_status.to_s.capitalize.dasherize %>
-<% if site.special_redirect_strategy == 'supplier' %>
-  <span class="text-muted">
-    <i data-toggle="tooltip" title="Site is managed by an external supplier" class="glyphicon glyphicon-question-sign"></i>
-  </span>
-<% elsif site.special_redirect_strategy == 'via_aka' %>
-  <span class="text-muted">
-    <i data-toggle="tooltip" title="Site is partially redirected via an aka domain" class="glyphicon glyphicon-question-sign"></i>
-  </span>
+<% if site.transition_status == :indeterminate %>
+  <% if site.special_redirect_strategy == 'supplier' %>
+    <span class="text-muted">
+      <i data-toggle="tooltip" title="Site is managed by an external supplier" class="glyphicon glyphicon-question-sign"></i>
+    </span>
+  <% elsif site.special_redirect_strategy == 'via_aka' %>
+    <span class="text-muted">
+      <i data-toggle="tooltip" title="Site is partially redirected via an aka domain" class="glyphicon glyphicon-question-sign"></i>
+    </span>
+  <% end %>
 <% end %>


### PR DESCRIPTION
This fixes a bug where the '?' and tooltip were still being shown
for sites which had previously been partially transitioned once
they were fully transitioned.
