### PR TITLE
Rails 4 knows about Postgres extensions

### DIFF
--- a/db/migrate/20140613165318_add_postgres_crypto.rb
+++ b/db/migrate/20140613165318_add_postgres_crypto.rb
@@ -1,13 +1,9 @@
 class AddPostgresCrypto < ActiveRecord::Migration
   def up
-    execute <<-postgreSQL
-      CREATE EXTENSION IF NOT EXISTS pgcrypto
-    postgreSQL
+    enable_extension 'pgcrypto'
   end
 
   def down
-    execute <<-postgreSQL
-      DROP EXTENSION IF EXISTS pgcrypto
-    postgreSQL
+    disable_extension 'pgcrypto'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,114 +9,118 @@
 # from scratch. The latter is a flawed and unsustainable approach (the more migrations
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
-# It's strongly recommended to check this file into your version control system.
+# It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140724164511) do
+ActiveRecord::Schema.define(version: 20140724164511) do
 
-  create_table "daily_hit_totals", :force => true do |t|
-    t.integer "host_id",                  :null => false
-    t.string  "http_status", :limit => 3, :null => false
-    t.integer "count",                    :null => false
-    t.date    "total_on",                 :null => false
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+  enable_extension "pgcrypto"
+
+  create_table "daily_hit_totals", force: true do |t|
+    t.integer "host_id",               null: false
+    t.string  "http_status", limit: 3, null: false
+    t.integer "count",                 null: false
+    t.date    "total_on",              null: false
   end
 
-  add_index "daily_hit_totals", ["host_id", "total_on", "http_status"], :name => "index_daily_hit_totals_on_host_id_and_total_on_and_http_status", :unique => true
+  add_index "daily_hit_totals", ["host_id", "total_on", "http_status"], name: "index_daily_hit_totals_on_host_id_and_total_on_and_http_status", unique: true, using: :btree
 
-  create_table "hits", :force => true do |t|
-    t.integer "host_id",                   :null => false
-    t.text    "path",                      :null => false
-    t.string  "path_hash",   :limit => 40, :null => false
-    t.string  "http_status", :limit => 3,  :null => false
-    t.integer "count",                     :null => false
-    t.date    "hit_on",                    :null => false
+  create_table "hits", force: true do |t|
+    t.integer "host_id",                null: false
+    t.text    "path",                   null: false
+    t.string  "path_hash",   limit: 40, null: false
+    t.string  "http_status", limit: 3,  null: false
+    t.integer "count",                  null: false
+    t.date    "hit_on",                 null: false
     t.integer "mapping_id"
   end
 
-  add_index "hits", ["host_id", "hit_on", "http_status"], :name => "index_hits_on_host_id_and_hit_on_and_http_status"
-  add_index "hits", ["host_id", "path", "hit_on", "http_status"], :name => "index_hits_on_host_id_and_path_and_hit_on_and_http_status", :unique => true
+  add_index "hits", ["host_id", "hit_on", "http_status"], name: "index_hits_on_host_id_and_hit_on_and_http_status", using: :btree
+  add_index "hits", ["host_id", "path", "hit_on", "http_status"], name: "index_hits_on_host_id_and_path_and_hit_on_and_http_status", unique: true, using: :btree
 
-  create_table "hits_staging", :id => false, :force => true do |t|
+  create_table "hits_staging", id: false, force: true do |t|
     t.string  "hostname"
     t.text    "path"
-    t.string  "http_status", :limit => 3
+    t.string  "http_status", limit: 3
     t.integer "count"
     t.date    "hit_on"
   end
 
-  create_table "host_paths", :force => true do |t|
-    t.string  "path",           :limit => 2048
+  create_table "host_paths", force: true do |t|
+    t.string  "path",           limit: 2048
     t.string  "path_hash"
     t.string  "c14n_path_hash"
     t.integer "host_id"
     t.integer "mapping_id"
   end
 
-  add_index "host_paths", ["c14n_path_hash"], :name => "index_host_paths_on_c14n_path_hash"
-  add_index "host_paths", ["host_id", "path_hash"], :name => "index_host_paths_on_host_id_and_path_hash", :unique => true
-  add_index "host_paths", ["mapping_id"], :name => "index_host_paths_on_mapping_id"
+  add_index "host_paths", ["c14n_path_hash"], name: "index_host_paths_on_c14n_path_hash", using: :btree
+  add_index "host_paths", ["host_id", "path_hash"], name: "index_host_paths_on_host_id_and_path_hash", unique: true, using: :btree
+  add_index "host_paths", ["mapping_id"], name: "index_host_paths_on_mapping_id", using: :btree
 
-  create_table "hosts", :force => true do |t|
-    t.integer  "site_id",           :null => false
-    t.string   "hostname",          :null => false
+  create_table "hosts", force: true do |t|
+    t.integer  "site_id",           null: false
+    t.string   "hostname",          null: false
     t.integer  "ttl"
     t.string   "cname"
     t.string   "live_cname"
-    t.datetime "created_at",        :null => false
-    t.datetime "updated_at",        :null => false
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
     t.string   "ip_address"
     t.integer  "canonical_host_id"
   end
 
-  add_index "hosts", ["canonical_host_id"], :name => "index_hosts_on_canonical_host_id"
-  add_index "hosts", ["hostname"], :name => "index_hosts_on_host", :unique => true
-  add_index "hosts", ["site_id"], :name => "index_hosts_on_site_id"
+  add_index "hosts", ["canonical_host_id"], name: "index_hosts_on_canonical_host_id", using: :btree
+  add_index "hosts", ["hostname"], name: "index_hosts_on_host", unique: true, using: :btree
+  add_index "hosts", ["site_id"], name: "index_hosts_on_site_id", using: :btree
 
-  create_table "mappings", :force => true do |t|
-    t.integer "site_id",                                            :null => false
-    t.string  "path",            :limit => 1024,                    :null => false
-    t.string  "path_hash",       :limit => 40,                      :null => false
+  create_table "mappings", force: true do |t|
+    t.integer "site_id",                                      null: false
+    t.string  "path",            limit: 1024,                 null: false
+    t.string  "path_hash",       limit: 40,                   null: false
     t.text    "new_url"
     t.text    "suggested_url"
     t.text    "archive_url"
-    t.boolean "from_redirector",                 :default => false
-    t.string  "type",                                               :null => false
+    t.boolean "from_redirector",              default: false
+    t.string  "type",                                         null: false
     t.integer "hit_count"
   end
 
-  add_index "mappings", ["hit_count"], :name => "index_mappings_on_hit_count"
-  add_index "mappings", ["site_id", "path_hash"], :name => "index_mappings_on_site_id_and_path_hash", :unique => true
-  add_index "mappings", ["site_id", "type"], :name => "index_mappings_on_site_id_and_type"
-  add_index "mappings", ["site_id"], :name => "index_mappings_on_site_id"
+  add_index "mappings", ["hit_count"], name: "index_mappings_on_hit_count", using: :btree
+  add_index "mappings", ["site_id", "path_hash"], name: "index_mappings_on_site_id_and_path_hash", unique: true, using: :btree
+  add_index "mappings", ["site_id", "type"], name: "index_mappings_on_site_id_and_type", using: :btree
+  add_index "mappings", ["site_id"], name: "index_mappings_on_site_id", using: :btree
 
-  create_table "mappings_batch_entries", :force => true do |t|
-    t.string  "path",              :limit => 2048
+  create_table "mappings_batch_entries", force: true do |t|
+    t.string  "path",              limit: 2048
     t.integer "mappings_batch_id"
     t.integer "mapping_id"
-    t.boolean "processed",                         :default => false
+    t.boolean "processed",                      default: false
     t.string  "klass"
     t.string  "new_url"
     t.string  "type"
   end
 
-  add_index "mappings_batch_entries", ["mappings_batch_id"], :name => "index_mappings_batch_entries_on_mappings_batch_id"
+  add_index "mappings_batch_entries", ["mappings_batch_id"], name: "index_mappings_batch_entries_on_mappings_batch_id", using: :btree
 
-  create_table "mappings_batches", :force => true do |t|
+  create_table "mappings_batches", force: true do |t|
     t.string   "tag_list"
     t.string   "new_url"
     t.boolean  "update_existing"
     t.integer  "user_id"
     t.integer  "site_id"
-    t.datetime "created_at",                              :null => false
-    t.datetime "updated_at",                              :null => false
-    t.string   "state",           :default => "unqueued"
-    t.boolean  "seen_outcome",    :default => false
+    t.datetime "created_at",                           null: false
+    t.datetime "updated_at",                           null: false
+    t.string   "state",           default: "unqueued"
+    t.boolean  "seen_outcome",    default: false
     t.string   "type"
     t.string   "klass"
   end
 
-  add_index "mappings_batches", ["user_id", "site_id"], :name => "index_mappings_batches_on_user_id_and_site_id"
+  add_index "mappings_batches", ["user_id", "site_id"], name: "index_mappings_batches_on_user_id_and_site_id", using: :btree
 
-  create_table "mappings_staging", :id => false, :force => true do |t|
+  create_table "mappings_staging", id: false, force: true do |t|
     t.text   "old_url"
     t.text   "new_url"
     t.string "host"
@@ -127,104 +131,104 @@ ActiveRecord::Schema.define(:version => 20140724164511) do
     t.string "type"
   end
 
-  create_table "organisational_relationships", :force => true do |t|
+  create_table "organisational_relationships", force: true do |t|
     t.integer "parent_organisation_id"
     t.integer "child_organisation_id"
   end
 
-  add_index "organisational_relationships", ["child_organisation_id"], :name => "index_organisational_relationships_on_child_organisation_id"
-  add_index "organisational_relationships", ["parent_organisation_id"], :name => "index_organisational_relationships_on_parent_organisation_id"
+  add_index "organisational_relationships", ["child_organisation_id"], name: "index_organisational_relationships_on_child_organisation_id", using: :btree
+  add_index "organisational_relationships", ["parent_organisation_id"], name: "index_organisational_relationships_on_parent_organisation_id", using: :btree
 
-  create_table "organisations", :force => true do |t|
-    t.string   "title",                        :null => false
+  create_table "organisations", force: true do |t|
+    t.string   "title",                     null: false
     t.string   "homepage"
     t.string   "furl"
-    t.datetime "created_at",                   :null => false
-    t.datetime "updated_at",                   :null => false
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
     t.string   "css"
-    t.string   "ga_profile_id",  :limit => 16
+    t.string   "ga_profile_id",  limit: 16
     t.string   "whitehall_slug"
     t.string   "whitehall_type"
     t.string   "abbreviation"
   end
 
-  add_index "organisations", ["title"], :name => "index_organisations_on_title"
-  add_index "organisations", ["whitehall_slug"], :name => "index_organisations_on_whitehall_slug", :unique => true
+  add_index "organisations", ["title"], name: "index_organisations_on_title", using: :btree
+  add_index "organisations", ["whitehall_slug"], name: "index_organisations_on_whitehall_slug", unique: true, using: :btree
 
-  create_table "organisations_sites", :id => false, :force => true do |t|
-    t.integer "site_id",         :null => false
-    t.integer "organisation_id", :null => false
+  create_table "organisations_sites", id: false, force: true do |t|
+    t.integer "site_id",         null: false
+    t.integer "organisation_id", null: false
   end
 
-  add_index "organisations_sites", ["site_id", "organisation_id"], :name => "index_organisations_sites_on_site_id_and_organisation_id", :unique => true
+  add_index "organisations_sites", ["site_id", "organisation_id"], name: "index_organisations_sites_on_site_id_and_organisation_id", unique: true, using: :btree
 
-  create_table "sessions", :force => true do |t|
-    t.string   "session_id", :null => false
+  create_table "sessions", force: true do |t|
+    t.string   "session_id", null: false
     t.text     "data"
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  add_index "sessions", ["session_id"], :name => "index_sessions_on_session_id"
-  add_index "sessions", ["updated_at"], :name => "index_sessions_on_updated_at"
+  add_index "sessions", ["session_id"], name: "index_sessions_on_session_id", using: :btree
+  add_index "sessions", ["updated_at"], name: "index_sessions_on_updated_at", using: :btree
 
-  create_table "sites", :force => true do |t|
-    t.integer  "organisation_id",                                :null => false
-    t.string   "abbr",                                           :null => false
+  create_table "sites", force: true do |t|
+    t.integer  "organisation_id",                             null: false
+    t.string   "abbr",                                        null: false
     t.string   "query_params"
-    t.datetime "tna_timestamp",                                  :null => false
+    t.datetime "tna_timestamp",                               null: false
     t.string   "homepage"
-    t.datetime "created_at",                                     :null => false
-    t.datetime "updated_at",                                     :null => false
+    t.datetime "created_at",                                  null: false
+    t.datetime "updated_at",                                  null: false
     t.text     "global_new_url"
-    t.boolean  "managed_by_transition",       :default => true,  :null => false
+    t.boolean  "managed_by_transition",       default: true,  null: false
     t.date     "launch_date"
     t.string   "special_redirect_strategy"
-    t.boolean  "global_redirect_append_path", :default => false, :null => false
+    t.boolean  "global_redirect_append_path", default: false, null: false
     t.string   "global_type"
     t.string   "homepage_title"
     t.string   "homepage_furl"
   end
 
-  add_index "sites", ["abbr"], :name => "index_sites_on_site", :unique => true
-  add_index "sites", ["organisation_id"], :name => "index_sites_on_organisation_id"
+  add_index "sites", ["abbr"], name: "index_sites_on_site", unique: true, using: :btree
+  add_index "sites", ["organisation_id"], name: "index_sites_on_organisation_id", using: :btree
 
-  create_table "taggings", :force => true do |t|
+  create_table "taggings", force: true do |t|
     t.integer  "tag_id"
     t.integer  "taggable_id"
     t.string   "taggable_type"
     t.integer  "tagger_id"
     t.string   "tagger_type"
-    t.string   "context",       :limit => 128
+    t.string   "context",       limit: 128
     t.datetime "created_at"
   end
 
-  add_index "taggings", ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], :name => "taggings_idx", :unique => true
-  add_index "taggings", ["taggable_type", "taggable_id"], :name => "index_taggings_on_taggable_type_and_taggable_id"
+  add_index "taggings", ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true, using: :btree
+  add_index "taggings", ["taggable_type", "taggable_id"], name: "index_taggings_on_taggable_type_and_taggable_id", using: :btree
 
-  create_table "tags", :force => true do |t|
+  create_table "tags", force: true do |t|
     t.string  "name"
-    t.integer "taggings_count", :default => 0
+    t.integer "taggings_count", default: 0
   end
 
-  add_index "tags", ["name"], :name => "index_tags_on_name", :unique => true
+  add_index "tags", ["name"], name: "index_tags_on_name", unique: true, using: :btree
 
-  create_table "users", :force => true do |t|
+  create_table "users", force: true do |t|
     t.string   "name"
     t.string   "email"
     t.string   "uid"
     t.text     "permissions"
-    t.boolean  "remotely_signed_out", :default => false
-    t.datetime "created_at",                             :null => false
-    t.datetime "updated_at",                             :null => false
+    t.boolean  "remotely_signed_out", default: false
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
     t.string   "organisation_slug"
-    t.boolean  "is_robot",            :default => false
+    t.boolean  "is_robot",            default: false
   end
 
-  create_table "versions", :force => true do |t|
-    t.string   "item_type",      :null => false
-    t.integer  "item_id",        :null => false
-    t.string   "event",          :null => false
+  create_table "versions", force: true do |t|
+    t.string   "item_type",      null: false
+    t.integer  "item_id",        null: false
+    t.string   "event",          null: false
     t.string   "whodunnit"
     t.integer  "user_id"
     t.text     "object_changes"
@@ -232,14 +236,14 @@ ActiveRecord::Schema.define(:version => 20140724164511) do
     t.datetime "created_at"
   end
 
-  add_index "versions", ["item_type", "item_id"], :name => "index_versions_on_item_type_and_item_id"
+  add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
 
-  create_table "whitelisted_hosts", :force => true do |t|
-    t.string   "hostname",   :null => false
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
+  create_table "whitelisted_hosts", force: true do |t|
+    t.string   "hostname",   null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  add_index "whitelisted_hosts", ["hostname"], :name => "index_whitelisted_hosts_on_hostname", :unique => true
+  add_index "whitelisted_hosts", ["hostname"], name: "index_whitelisted_hosts_on_hostname", unique: true, using: :btree
 
 end

--- a/spec/support/postgres_helper.rb
+++ b/spec/support/postgres_helper.rb
@@ -1,6 +1,0 @@
-RSpec.configure do |config|
-  config.before(:suite) do
-    # Extension does not get propagated to schema.rb
-    ActiveRecord::Base.connection.execute('CREATE EXTENSION if NOT EXISTS pgcrypto')
-  end
-end


### PR DESCRIPTION
- So use the idiomatic migration commands (taking advantage of the fact
  there's non-dev PG DB at time of writing to re-use the original migration)
- Remove the now-redundant explicit SQL support for specs

**NB** there's more in the schema diff than you might expect; Rails 4 also changed the default option hash style from `:hashrocket => 'thing'` to `not_a_hashrocket: 'thing'`
