### PR TITLE
Make tests quieter

### DIFF
--- a/features/support/quiet_imports.rb
+++ b/features/support/quiet_imports.rb
@@ -1,0 +1,3 @@
+require 'transition/import/console_job_wrapper'
+
+Transition::Import::ConsoleJobWrapper.active = false

--- a/lib/transition/google/results_pager.rb
+++ b/lib/transition/google/results_pager.rb
@@ -1,4 +1,5 @@
 require 'transition/google/api_client'
+require 'transition/import/console_job_wrapper'
 
 module Transition
   module Google
@@ -6,6 +7,7 @@ module Transition
     # Treats pages of GA results as a single enumerable of rows
     class ResultsPager
       include Enumerable
+      include Transition::Import::ConsoleJobWrapper
 
       attr_accessor :parameters, :client
 
@@ -31,7 +33,7 @@ module Transition
 
       def each(start_index = 1, &block)
         parameters.merge!('start-index' => start_index) unless start_index == 1
-        $stderr.puts "Getting start-index=#{start_index}, page size #{parameters['max-results']}"
+        console_puts "Getting start-index=#{start_index}, page size #{parameters['max-results']}"
 
         result = client.execute!(api_method: @analytics.data.ga.get, parameters: parameters)
 

--- a/lib/transition/import/console_job_wrapper.rb
+++ b/lib/transition/import/console_job_wrapper.rb
@@ -1,16 +1,38 @@
 module Transition
   module Import
     module ConsoleJobWrapper
+      class NullConsole
+        [:print, :puts].each { |sym| define_method(sym) {|*_|} }
+      end
+
+      def self.active=(value)
+        @active = value
+      end
+
+      def self.active?
+        @active.nil? ? true : @active
+      end
+
+      def console
+        @console ||= ConsoleJobWrapper.active? ? $stderr : NullConsole.new
+      end
+
+      def console_puts(*args)
+        console.puts *args
+      end
+
+      def console_print(*args)
+        console.print *args
+      end
+
       ##
       # Common idiom of doing a thing, then printing a done message on the same line
-      def start(message, options = {doing: '...', done: 'done', console: $stderr})
+      def start(message, options = {doing: '...', done: 'done'})
         return unless block_given?
 
-        console = options.delete(:console)
-
-        console.print "#{message} #{options[:doing]} "
+        console_print "#{message} #{options[:doing]} "
         yield
-        console.puts "#{options[:done]}"
+        console_puts "#{options[:done]}"
       end
     end
   end

--- a/lib/transition/import/daily_hit_totals.rb
+++ b/lib/transition/import/daily_hit_totals.rb
@@ -1,6 +1,10 @@
+require 'transition/import/console_job_wrapper'
+
 module Transition
   module Import
     class DailyHitTotals
+      extend ConsoleJobWrapper
+
       PRECOMPUTE_TOTALS_FROM_HITS = <<-mySQL
         INSERT INTO daily_hit_totals (host_id, http_status, `count`, total_on)
         (
@@ -12,11 +16,11 @@ module Transition
       mySQL
 
       def self.from_hits!
-        $stderr.print 'Refreshing daily hit totals from hits ... '
-        [ PRECOMPUTE_TOTALS_FROM_HITS ].each do |statement|
-          ActiveRecord::Base.connection.execute(statement)
+        start 'Refreshing daily hit totals from hits' do
+          [ PRECOMPUTE_TOTALS_FROM_HITS ].each do |statement|
+            ActiveRecord::Base.connection.execute(statement)
+          end
         end
-        $stderr.puts 'done.'
       end
     end
   end

--- a/lib/transition/import/hits.rb
+++ b/lib/transition/import/hits.rb
@@ -1,6 +1,10 @@
+require 'transition/import/console_job_wrapper'
+
 module Transition
   module Import
     class Hits
+      extend ConsoleJobWrapper
+
       # Lines should probably never be removed from this, only added.
       PATHS_TO_IGNORE = [
         # Generic site furniture
@@ -105,15 +109,15 @@ module Transition
       mySQL
 
       def self.from_redirector_tsv_file!(filename)
-        $stderr.print "Importing #{filename} ... "
-        [
-          TRUNCATE,
-          LOAD_DATA.sub('$filename$', "'#{File.expand_path(filename)}'"),
-          INSERT_FROM_STAGING
-        ].flatten.each do |statement|
-          ActiveRecord::Base.connection.execute(statement)
+        start "Importing #{filename}" do
+          [
+            TRUNCATE,
+            LOAD_DATA.sub('$filename$', "'#{File.expand_path(filename)}'"),
+            INSERT_FROM_STAGING
+          ].flatten.each do |statement|
+            ActiveRecord::Base.connection.execute(statement)
+          end
         end
-        $stderr.puts 'done.'
       end
 
       def self.from_redirector_mask!(filemask)
@@ -129,7 +133,7 @@ module Transition
           ActiveRecord::Base.connection.execute('SET autocommit=1')
         end
 
-        $stderr.puts "#{done} hits files imported."
+        console_puts "#{done} hits files imported."
       end
     end
   end

--- a/lib/transition/import/mappings_from_host_paths.rb
+++ b/lib/transition/import/mappings_from_host_paths.rb
@@ -13,7 +13,7 @@ module Transition
               # Try to create them (there may be duplicates in the set and they may
               # already exist).
               if site.mappings.create(path: uncanonicalized_path, type: 'unresolved')
-                $stderr.print '.'
+                console_print '.'
               end
             end
           end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,4 +69,8 @@ RSpec.configure do |config|
   config.before(:each) do
     Sidekiq::Worker.clear_all
   end
+
+  config.before(:suite) do
+    Transition::Import::ConsoleJobWrapper.active = false
+  end
 end


### PR DESCRIPTION
- Transition::Import was quite noisy, printing as it did to `$stderr` a lot
- Add a global `#active=` to allow printing of messages to null console
- Remove unused option to print anywhere else but `$stderr`
- Add `#console_puts` and `#console_prints` to route these messages through
- extend class-method using import classes to use these. Don't use
  any raw `puts`/`print`
