### PR TITLE
Add missing leading slash when canonicalising

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -55,12 +55,15 @@ class Site < ActiveRecord::Base
   end
 
   def canonical_path(path_or_url)
-    if path_or_url =~ Transition::PathOrURL::STARTS_WITH_HTTP_SCHEME
+    if Transition::PathOrURL.starts_with_http_scheme?(path_or_url)
       url = path_or_url
+    elsif !path_or_url.starts_with?('/') &&
+        Transition::PathOrURL.starts_with_a_domain?(path_or_url)
+      url = 'http://' + path_or_url
     else
       # BLURI takes a full URL, but we only care about the path. There's no
       # benefit in making an extra query to get a real hostname for the site.
-      url = 'http://www.example.com' + path_or_url
+      url = File.join('http://www.example.com', path_or_url)
     end
 
     bluri = BLURI(url).canonicalize!(allow_query: query_params.split(":"))

--- a/app/models/view/mappings/canonical_filter.rb
+++ b/app/models/view/mappings/canonical_filter.rb
@@ -33,9 +33,16 @@ module View
       end
 
       def canonical_substring
-        # Canonicalization requires a path. Canonicalize a substring
-        # by pretending the substring is a path, then remove the leading '/'
-        @site.canonical_path('/' + @filter)[1..-1]
+        if @filter.starts_with?('/')
+          @site.canonical_path(@filter)
+        else
+          # Pretend that this string is a well-formed path so it can be
+          # canonicalised, by adding a leading slash. Then remove it afterwards.
+          # Otherwise we would be assuming that the filter value was meant to
+          # have a leading slash, which may not be the case - the user might
+          # have meant to supply a fragment of a directory name.
+          @site.canonical_path('/' + @filter)[1..-1]
+        end
       end
 
       def path?

--- a/features/mapping_create_multiple.feature
+++ b/features/mapping_create_multiple.feature
@@ -18,12 +18,12 @@ Feature: Create mappings
     Then the page title should be "Confirm new mappings"
     And I should see options to keep or overwrite the existing mappings
     And I should see the canonicalized paths "/needs/canonicalizing, /a, /r"
-    But I should not see "noslash"
+    But I should see "/noslash"
     And I should see "/a currently archived"
     And I should see "/r currently redirects to http://somewhere.gov.uk"
     When I save my changes
-    Then I should see "1 mapping created" in a modal window
-    And I should see a table with 1 saved mapping in the modal
+    Then I should see "2 mappings created" in a modal window
+    And I should see a table with 2 saved mappings in the modal
     And I should see "/needs/canonicalizing" in a modal window
     And an analytics event with "bulk-add-redirect-ignore-existing" has fired
 
@@ -75,11 +75,11 @@ Feature: Create mappings
     And a site bis exists
     And I visit the path /sites/bis/mappings
     And I go to create some mappings
-    When I make the new mapping paths "noslash" redirect to __INVALID_URL__
+    When I make the new mapping paths "/" redirect to __INVALID_URL__
     And I continue
     Then I should see "Enter at least one valid path or full URL"
     And I should see a highlighted "Old URLs" label and field
-    And the "Old URLs" value should be "noslash"
+    And the "Old URLs" value should be "/"
     And I should see "Enter a valid URL to redirect to"
     And I should see a highlighted "Redirect to" label and field
     And the "Redirect to" value should be "http://__INVALID_URL__"

--- a/lib/transition/import/csv/import_batch_row.rb
+++ b/lib/transition/import/csv/import_batch_row.rb
@@ -18,7 +18,7 @@ module Transition
         end
 
         def data_row?
-          @old_value.starts_with?('/') || @old_value =~ Transition::PathOrURL::STARTS_WITH_HTTP_SCHEME
+          @old_value.starts_with?('/') || Transition::PathOrURL.starts_with_http_scheme?(@old_value)
         end
 
         def type

--- a/lib/transition/path_or_url.rb
+++ b/lib/transition/path_or_url.rb
@@ -1,0 +1,31 @@
+module Transition
+  class PathOrURL
+    STARTS_WITH_HTTP_SCHEME = %r{^https?://}
+
+    # TLDs for Hosts in transition
+    TLDS = %w{
+        .co.uk
+        .com
+        .gov.uk
+        .ie
+        .info
+        .mod.uk
+        .net
+        .org
+        .org.uk
+        .police.uk
+        .tv
+      }
+
+    def self.starts_with_http_scheme?(path_or_url)
+       path_or_url =~ STARTS_WITH_HTTP_SCHEME
+    end
+
+    def self.starts_with_a_domain?(path_or_url)
+      first_part = path_or_url.split('/').first
+
+      escaped_tlds = TLDS.map { |tld| Regexp.escape(tld) }
+      first_part =~ Regexp.new("#{escaped_tlds.join('|')}$")
+    end
+  end
+end

--- a/lib/transition/path_or_url/starts_with_http_scheme.rb
+++ b/lib/transition/path_or_url/starts_with_http_scheme.rb
@@ -1,5 +1,0 @@
-module Transition
-  module PathOrURL
-    STARTS_WITH_HTTP_SCHEME = %r{^https?://}
-  end
-end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -219,6 +219,21 @@ describe Site do
       @raw_path = '/'
       subject.should eql('')
     end
+
+    it "inserts a missing first slash" do
+      @raw_path = 'foo'
+      subject.should eql('/foo')
+    end
+
+    it "inserts a missing first slash, unless the first part appears to be a domain" do
+      @raw_path = 'www.a.gov.uk/foo'
+      subject.should eql('/foo')
+    end
+
+    it "handles absolute URLs" do
+      @raw_path = 'http://www.a.gov.uk/foo'
+      subject.should eql('/foo')
+    end
   end
 
   describe '#hit_total_count', truncate_everything: true do


### PR DESCRIPTION
This means that for a path-like input such as:
  first-level/second-level

we no longer trash it to make:
  /second-level

we instead make it into:
  /first-level/second-level

On the other hand it does mean that other things accidentally pasted into a
paths field will be turned into paths...
