### PR TITLE
Connect to the database via localhost in dev and test

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -4,6 +4,7 @@ development:
   username: transition
   password: transition
   encoding: utf8
+  host: localhost
   local_infile: true
 
 # Warning: The database defined as "test" will be erased and
@@ -15,6 +16,7 @@ test: &test
   username: transition
   password: transition
   encoding: utf8
+  host: localhost
   local_infile: true
 
 production:


### PR DESCRIPTION
Doing this for postgres means that we don't need to add any pg_hba.conf
rules in dev for the app to be able to authenticate as the transition
role, because one of the default rules already allows it. Using host
authentication for postgres will also make dev more similar to production.

This works for mysql in dev too, so we might as well do this on master
to minimise the diff for postgres branches.

This file is overwritten on deployment so this change makes no difference
for production.
