### PR TITLE
Make the background colour of the import progress bar green again

### DIFF
--- a/app/assets/stylesheets/modal_background_batch.css.scss
+++ b/app/assets/stylesheets/modal_background_batch.css.scss
@@ -29,4 +29,8 @@
   .progress-bar {
     width: 0;
   }
+
+  .progress-bar-success {
+    background-color: #5cb85c;
+  }
 }


### PR DESCRIPTION
- This is a temporary solution while @fofr investigates why nothing is
  pulling this from Bootstrap - it was suggested I fix it like this
  rather than waiting for him. :-)
