### PR TITLE
Update the aria-valuenow on batch upload

### DIFF
--- a/app/assets/javascripts/modules/batch_progress.js
+++ b/app/assets/javascripts/modules/batch_progress.js
@@ -36,6 +36,7 @@
         percent = (progress.done/progress.total * 100).toFixed(0);
         percentDone.text(percent);
         bar.css('width', percent + '%');
+        bar.attr('aria-valuenow', percent);
         timeout = setTimeout(requestProgress, 1000);
       }
 

--- a/spec/javascripts/spec/batch_progress.spec.js
+++ b/spec/javascripts/spec/batch_progress.spec.js
@@ -50,6 +50,10 @@ describe('A batch progress module', function() {
       expect(element.find('.js-progress-bar').attr('style')).toMatch('width: 10%;');
     });
 
+    it('updates the aria value now attribute', function() {
+      expect(element.find('.js-progress-bar').attr('aria-valuenow')).toMatch(10);
+    });
+
     it('updates the count of done mappings', function() {
       expect(element.find('.js-progress-message').text()).toBe('1 of 10 mappings added');
     });


### PR DESCRIPTION
- Bootstrap styles based on `aria-valuenow="0"`, which we weren’t updating, so those transparent styles were persisting.
- Rather than overwriting those styles with something more specific we should  be updating the aria value for accessibility.
