### PR TITLE
Be explicit about popular tag ordering

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -99,7 +99,7 @@ class Site < ActiveRecord::Base
       .joins('INNER JOIN mappings ON mappings.id = taggings.taggable_id')
       .where('mappings.site_id = ?', id)
       .group('tags.name')
-      .order('count DESC')
+      .order('count DESC, tags.name')
       .limit(limit)
       .map(&:name)
   end

--- a/features/step_definitions/mappings_assertion_steps.rb
+++ b/features/step_definitions/mappings_assertion_steps.rb
@@ -29,7 +29,8 @@ end
 
 Then(/^I should see the most popular tags for this site$/) do
   within '.filters .dropdown-menu' do
-    should_have_links_to_tags(%w(fee fi fo fum fiddle))
+    expect(page).to have_selector('a.tag', count: 10)
+    should_have_links_to_tags(%w(fiddle fum archive dead di do dying fee fi fo))
   end
 end
 


### PR DESCRIPTION
- COUNT first, then name
- Fixes intermittent failure where order was unknown and would push out
  tags with equal count
- Also, tighten up the criteria for "Then I should see popular tags" step. Now
  checks count as well as fuller list. We weren't testing what we thought we were!
