### PR TITLE
Set redis namespace in redis.yml

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,7 +2,7 @@ redis_config = YAML.load_file(File.join(Rails.root, "config", "redis.yml"))
 
 redis_config_for_sidekiq = {
   :url => "redis://#{redis_config['host']}:#{redis_config['port']}/0",
-  :namespace => "transition"
+  :namespace => redis_config['namespace'],
 }
 
 Sidekiq.configure_server do |config|

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,2 +1,3 @@
 host: 127.0.0.1
 port: 6379
+namespace: 'transition'


### PR DESCRIPTION
This means that we can set a different namespace for transition-postgres
on deployment. We will still have the same namespace on postgres branches
in dev, but that is simple to temporarily change locally and doesn't
affect production.
