### PR TITLE
Enable `MappingsController#find_global` to find a site without a scheme

### DIFF
--- a/app/controllers/mappings_controller.rb
+++ b/app/controllers/mappings_controller.rb
@@ -128,10 +128,14 @@ class MappingsController < ApplicationController
     # This allows finding a mapping without knowing the site first.
     render_error(400) and return unless params[:url].present?
 
+    if !Transition::PathOrURL.starts_with_http_scheme?(params[:url])
+      url = 'http://' + params[:url] # Add a dummy scheme
+    else
+      url = params[:url]
+    end
+
     begin
-      url = Addressable::URI.parse(params[:url])
-      render_error(400) and
-        return unless url.scheme == "http" || url.scheme == "https"
+      url = Addressable::URI.parse(url)
     rescue Addressable::URI::InvalidURIError
       render_error(400) and return
     end

--- a/features/mapping_edit.feature
+++ b/features/mapping_edit.feature
@@ -65,3 +65,9 @@ Feature: Edit a site's mapping
     When I visit the path /sites/bis
     And I jump to the mapping "http://bis.gov.uk/about"
     Then I should see "Edit mapping"
+
+  @javascript
+  Scenario: Jumping to a site mapping without specifying a site scheme
+    When I visit the path /sites/bis
+    And I jump to the mapping "bis.gov.uk/about"
+    Then I should see "Edit mapping"

--- a/spec/controllers/mappings_controller_spec.rb
+++ b/spec/controllers/mappings_controller_spec.rb
@@ -110,9 +110,10 @@ describe MappingsController do
     end
 
     context 'when the URL isn\'t an HTTP(S) URL' do
-      it 'returns a 400 error' do
-        get :find_global, url: "huihguifbelgfebigf"
-        expect(response.status).to eq(400)
+      let!(:host) { create :host, hostname: 'example.com' }
+      it 'prefixes http:// to the beginning of the string and checks if it is a site' do
+        get :find_global, url: 'example.com/hello'
+        expect(response.status).to redirect_to site_mapping_find_url(host.site, path: '/hello')
       end
     end
 


### PR DESCRIPTION
- Now `foo.com/bar` works, not just `http[s]://foo.com/bar`, in the "Go
  to Mapping" dialog and other places where
  `MappingsController#find_global` is called.
