### PR TITLE
Improve jump to mapping copy without js

### DIFF
--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -6,8 +6,8 @@
   <h1>
     Organisations
   </h1>
-  <p class="lead text-muted normal">
-    Use a URL to <a href="#" class="if-no-js-hide link-muted" data-module="mousetrap-trigger" data-keys="g m">jump to a site or mapping</a> or find your organisation below.
+  <p class="if-no-js-hide lead text-muted normal">
+    Use a URL to <a href="#" class="link-muted" data-module="mousetrap-trigger" data-keys="g m">jump to a site or mapping</a> or find your organisation below.
   </p>
 </div>
 


### PR DESCRIPTION
Currently, when JS is disabled the link disappears and the copy doesn’t read correctly. Instead, hide the whole paragraph.
