### PR TITLE
Really restrict viewing of the leaderboard to only GDS Editors

### DIFF
--- a/app/controllers/leaderboard_controller.rb
+++ b/app/controllers/leaderboard_controller.rb
@@ -1,4 +1,7 @@
 class LeaderboardController < ApplicationController
   def index
+    if !current_user.gds_editor?
+      redirect_to root_path, flash: { notice: "Only GDS Editors can access the leaderboard." }
+    end
   end
 end

--- a/features/leaderboard.feature
+++ b/features/leaderboard.feature
@@ -8,3 +8,9 @@ Feature: Leaderboard
   Given I have logged in as a GDS Editor
   When I visit the leaderboard page
   Then I should see the header "Department leaderboard"
+
+  Scenario: Visit the leaderboard page without GDS Editor permission
+  Given I have logged in as a member of DCLG
+  When I visit the leaderboard page
+  Then I should be redirected to the homepage
+  And I should see "Only GDS Editors can access the leaderboard."


### PR DESCRIPTION
- Currently, anyone with any permissions guessing the `/leaderboard`
  route can view the leaderboard as the GDS editor permission check only
  hides the menu option. Hide the page as a whole for those people not
  GDS Editors.
