### PR TITLE
Fix hits pagination links

### DIFF
--- a/app/controllers/hits_controller.rb
+++ b/app/controllers/hits_controller.rb
@@ -27,7 +27,6 @@ class HitsController < ApplicationController
   end
 
   def category
-    # Category - one of %w(archives redirect errors) (see routes.rb)
     @category = View::Hits::Category[params[:category]].tap do |c|
       c.hits   = hits_in_period.by_path_and_status.send(c.to_sym).page(params[:page]).order('count DESC')
       c.points = totals_in_period.by_date_and_status.send(c.to_sym)

--- a/app/helpers/hits_helper.rb
+++ b/app/helpers/hits_helper.rb
@@ -103,15 +103,19 @@ module HitsHelper
   # Send the correct routing message for the current category and period
   def current_category_in_period_path(period)
     if @site
-      # Common or garden site-based hits
-      send "#{params[:category] || 'summary'}_site_hits_path",
-           period: period.query_slug,
-           site_id: @site.abbr
+      # Hits for a specific site
+      if params[:category]
+        category_site_hits_path(@site, category: params[:category], period: period.query_slug)
+      else
+        summary_site_hits_path(@site, period: period.query_slug)
+      end
     else
       # Universal analytics
-      category = "_#{params[:category]}" if params[:category]
-      send "hits#{category}_path",
-           period: period.query_slug
+      if params[:category]
+        hits_category_path(category: params[:category], period: period.query_slug)
+      else
+        hits_path(period: period.query_slug)
+      end
     end
   end
 end

--- a/app/models/view/hits/category.rb
+++ b/app/models/view/hits/category.rb
@@ -71,14 +71,6 @@ module View
       def plural
         name == 'all' ? 'hits' : name.pluralize
       end
-
-      def path_method
-        name == 'all' ? :site_hits_path : "#{name}_site_hits_path".to_sym
-      end
-
-      def path_method_universal
-        name == 'all' ? :hits_path : "hits_#{name}_path".to_sym
-      end
     end
   end
 end

--- a/app/views/hits/_hits_tabs.html.erb
+++ b/app/views/hits/_hits_tabs.html.erb
@@ -1,12 +1,10 @@
-<% period = { period: @period.query_slug } %>
-
 <%= bootstrap_flavour_tabs(
       {
-        'Summary'    => summary_site_hits_path(@site, period),
-        'All hits'   => site_hits_path(@site, period),
-        'Errors'     => errors_site_hits_path(@site, period),
-        'Archives'   => archives_site_hits_path(@site, period),
-        'Redirects'  => redirects_site_hits_path(@site, period)
+        'Summary'    => summary_site_hits_path(@site, period: @period.query_slug),
+        'All hits'   => site_hits_path(@site, period: @period.query_slug),
+        'Errors'     => category_site_hits_path(@site, period: @period.query_slug, category: 'errors'),
+        'Archives'   => category_site_hits_path(@site, period: @period.query_slug, category: 'archives'),
+        'Redirects'  => category_site_hits_path(@site, period: @period.query_slug, category: 'redirects')
       }, active: active
     )
 %>

--- a/app/views/hits/_summary_section.html.erb
+++ b/app/views/hits/_summary_section.html.erb
@@ -2,7 +2,7 @@
   <%= render partial: 'category_title', locals: {category: category} %>
   <% if category.hits.any? %>
     <%= render partial: 'hits_table', locals: { hits: category.hits} %>
-    <%= link_to "See all #{category.name}", (send category.path_method, @site, period: @period.query_slug) %>
+    <%= link_to "See all #{category.name}", category_site_hits_path(@site, category: category.name, period: @period.query_slug) %>
   <% else %>
     <p class="no-content no-content-bordered">
       There are no known <%= category.name.pluralize %> for <%= @site.abbr %> <%= @period.no_content %>.

--- a/app/views/hits/_universal_hits_tabs.html.erb
+++ b/app/views/hits/_universal_hits_tabs.html.erb
@@ -1,10 +1,9 @@
-<% period = { period: @period.query_slug } %>
 <%= bootstrap_flavour_tabs(
       {
-        'Summary'    => hits_path(period),
-        'Errors'     => hits_errors_path(period),
-        'Archives'   => hits_archives_path(period),
-        'Redirects'  => hits_redirects_path(period)
+        'Summary'    => hits_path(period: @period.query_slug),
+        'Errors'     => hits_category_path(period: @period.query_slug, category: 'errors'),
+        'Archives'   => hits_category_path(period: @period.query_slug, category: 'archives'),
+        'Redirects'  => hits_category_path(period: @period.query_slug, category: 'redirects')
       }, active: active
     )
 %>

--- a/app/views/hits/universal_summary.html.erb
+++ b/app/views/hits/universal_summary.html.erb
@@ -17,7 +17,7 @@
       <%= render partial: 'category_title', locals: {category: category} %>
       <% if category.hits.any? %>
         <%= render partial: 'universal_hits_table', locals: { hits: category.hits } %>
-        <%= link_to "See all #{category.name}", (send category.path_method_universal, period: @period.query_slug) %>
+        <%= link_to "See all #{category.name}", hits_category_path(category: category.name, period: @period.query_slug) %>
       <% end %>
     </section>
   <% end  %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,9 +16,7 @@ Transition::Application.routes.draw do
 
   get 'mappings/find_global', to: 'mappings#find_global'
   get 'hits', to: 'hits#universal_summary'
-  get 'hits/redirects', to: 'hits#universal_category', defaults: { category: 'redirects' }
-  get 'hits/errors',    to: 'hits#universal_category', defaults: { category: 'errors' }
-  get 'hits/archives',  to: 'hits#universal_category', defaults: { category: 'archives' }
+  get 'hits/category', to: 'hits#universal_category'
 
   get 'leaderboard', to: 'leaderboard#index'
 
@@ -52,9 +50,7 @@ Transition::Application.routes.draw do
     resources :hits, only: [:index] do
       collection do
         get 'summary'
-        get 'redirects', to: 'hits#category', defaults: { category: 'redirects' }
-        get 'errors',    to: 'hits#category', defaults: { category: 'errors' }
-        get 'archives',  to: 'hits#category', defaults: { category: 'archives' }
+        get 'category'
       end
     end
   end

--- a/spec/helpers/hits_helper_spec.rb
+++ b/spec/helpers/hits_helper_spec.rb
@@ -96,8 +96,8 @@ describe HitsHelper do
 
       context 'when a category is set' do
         let(:params) { { category: 'errors' } }
-        it 'links to that site/period hits/errors path with the period' do
-          path.should == '/sites/site_abbr/hits/errors?period=yesterday'
+        it 'links to the category and period for the site' do
+          path.should == '/sites/site_abbr/hits/category?category=errors&period=yesterday'
         end
 
         context 'when the time period is default' do
@@ -106,8 +106,8 @@ describe HitsHelper do
               period.stub(:query_slug).and_return(nil)
             end
           end
-          it 'links to the current category without a query' do
-            path.should == '/sites/site_abbr/hits/errors'
+          it 'links to the category without the period for the site' do
+            path.should == '/sites/site_abbr/hits/category?category=errors'
           end
         end
       end
@@ -116,14 +116,14 @@ describe HitsHelper do
     context 'when no site is present (universal analytics)' do
       let(:site) { nil }
 
-      it 'links to the main hits/errors path with the period' do
+      it 'links to the universal hits with the period' do
         path.should == '/hits?period=yesterday'
       end
 
       context 'when a category is set' do
         let(:params) { { category: 'errors' } }
-        it 'links to the main hits/errors path with the period' do
-          path.should == '/hits/errors?period=yesterday'
+        it 'links to the universal hits with the category and period' do
+          path.should == '/hits/category?category=errors&period=yesterday'
         end
 
         context 'when the time period is default' do
@@ -132,8 +132,8 @@ describe HitsHelper do
               period.stub(:query_slug).and_return(nil)
             end
           end
-          it 'links to the current category without a query' do
-            path.should == '/hits/errors'
+          it 'links to the universal hits current category without the period' do
+            path.should == '/hits/category?category=errors'
           end
         end
       end

--- a/spec/models/view/hits/category_spec.rb
+++ b/spec/models/view/hits/category_spec.rb
@@ -16,8 +16,6 @@ describe View::Hits::Category do
       its(:to_sym)             { should == :all }
       its(:color)              { should == '#333' }
       its(:plural)             { should == 'hits' }
-      its(:path_method)        { should == :site_hits_path }
-      its(:path_method_universal) { should == :hits_path }
     end
 
     describe 'indexing' do
@@ -31,7 +29,6 @@ describe View::Hits::Category do
       its(:to_sym)      { should == :errors }
       its(:color)       { should == '#e99' }
       its(:plural)      { should == 'errors' }
-      its(:path_method) { should == :errors_site_hits_path }
 
       describe 'the polyfill of points when points= is called' do
         context 'valid data' do


### PR DESCRIPTION
I think these have been broken since we upgraded to Rails 4.x and the way that
these routes were implemented was no longer supported.

This way is less code, less metaprogramming and easier to follow.

This bug drove me nuts when trying to add missing mappings to Directgov, I assume it does the same for other users.
