### PR TITLE
Really test that the jump to mapping dialog finds a site

### DIFF
--- a/features/site.feature
+++ b/features/site.feature
@@ -93,12 +93,23 @@ Scenario: Visit the page of an non-existent site
 
 @javascript
 Scenario: Jumping to a site
+  Given I have logged in as a member of DCLG
+  And a site bis exists
   When I visit the home page
-  And I jump to the site or mapping "http://www.bis.gov.uk"
-  Then I should see "www.bis.gov.uk"
+  And I jump to the site or mapping "http://bis.gov.uk"
+  Then I should see the header "bis.gov.uk"
 
 @javascript
 Scenario: Jumping to a site appending a / but nothing after it
+  Given I have logged in as a member of DCLG
+  And a site bis exists
   When I visit the home page
-  And I jump to the site or mapping "http://www.bis.gov.uk/"
-  Then I should see "www.bis.gov.uk"
+  And I jump to the site or mapping "http://bis.gov.uk/"
+  Then I should see the header "bis.gov.uk"
+
+@javascript
+Scenario: Jumping to a non-existent site
+  Given I have logged in as a member of DCLG
+  When I visit the home page
+  And I jump to the site or mapping "http://not-a-site.gov.uk"
+  Then I should see the header "Unknown site"


### PR DESCRIPTION
- Before, this was only testing for the presence of the site host in
  any form, which would have matched on the error page's `<p>` tag and
  passed. We don't want it to match an error page, we want to know that
  the site has been found, so test for the site host in header text.
- Add a test for the "Unknown site" error page case.
- Remove www. in the test data to be consistent with the factory—I'd got confused with the thing I did for finding non-www sites.
