### PR TITLE
Make an RSpec test consistent with the others of its type

### DIFF
--- a/spec/controllers/mappings_controller_spec.rb
+++ b/spec/controllers/mappings_controller_spec.rb
@@ -113,7 +113,7 @@ describe MappingsController do
       let!(:host) { create :host, hostname: 'example.com' }
       it 'prefixes http:// to the beginning of the string and checks if it is a site' do
         get :find_global, url: 'example.com/hello'
-        expect(response.status).to redirect_to site_mapping_find_url(host.site, path: '/hello')
+        expect(response).to redirect_to site_mapping_find_url(host.site, path: '/hello')
       end
     end
 


### PR DESCRIPTION
- This was testing for `response.status` redirecting to a URL. I'm not
  sure how this worked, unless `redirect_to` passes its status code back
  and it was receiving that, but in any case it looks wrong at first
  glance, and we should be consistent with the other redirect_to tests
  in this file and others.
