### PR TITLE
Allow the CNAME to display on multiple lines

### DIFF
--- a/app/views/sites/_configuration.html.erb
+++ b/app/views/sites/_configuration.html.erb
@@ -42,7 +42,9 @@
                   <span class="text-muted">Unknown</span>
                 <% end %>
               </td>
-              <td><%= host.cname || host.ip_address || 'Unknown' %></td>
+              <td>
+                <span class="breakable"><%= host.cname || host.ip_address || 'Unknown' %></span>
+              </td>
               <td>
                 <% if host.aka_host %>
                   <% if host.aka_host.redirected_by_gds? %>


### PR DESCRIPTION
- Long CNAMEs like
  `redirector-cdn-ssl-businesslink.production.govuk.service.gov.uk` were
  causing the configuration table on the site dashboard to stretch
  beyond the margins of the container box.

Before:
![screen shot 2014-09-11 at 14 13 37](https://cloud.githubusercontent.com/assets/355033/4250236/4b3b028a-3a81-11e4-918d-d72e642bc58e.png)

After:

![screen shot 2014-09-12 at 14 33 48](https://cloud.githubusercontent.com/assets/355033/4250255/7769e484-3a81-11e4-8699-453f2557e5c1.png)
