### PR TITLE
Empty the migration which fixed MySQL collation

### DIFF
--- a/db/migrate/20140611144610_fix_collation_woes.rb
+++ b/db/migrate/20140611144610_fix_collation_woes.rb
@@ -1,0 +1,10 @@
+class FixCollationWoes < ActiveRecord::Migration
+  def up
+    # This migration fixed some collation inconsistencies for MySQL, but has
+    # been emptied on switching to PostgreSQL. The file remains so that we don't
+    # have a migration record in the database without a matching file.
+  end
+
+  def down
+  end
+end


### PR DESCRIPTION
This migration was used to fix some collation inconsistencies in
MySQL but we don't need its functionality on PostgreSQL. The migration
will remain in the schema_migrations table in the database, so we're
leaving this file in place but with empty methods to avoid the
potentially confusing '*********\* NO FILE **********' message shown by
`rake db:migrate:status`.
