### PR TITLE
Link to /hosts for admins

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,6 +27,9 @@
     <li <% if current_page?(admin_whitelisted_hosts_path) %> class="active" <% end %>>
       <%= link_to 'Redirection whitelist', admin_whitelisted_hosts_path %>
     </li>
+    <li>
+      <%= link_to 'Hosts', hosts_path %>
+    </li>
   <% end %>
   <li <% if current_page?(glossary_index_path) %> class="active" <% end %>>
     <%= link_to 'Glossary', glossary_index_path %>


### PR DESCRIPTION
This is useful for us to quickly hunt and filter for hostnames in the app.

At the moment, you have to know the URL to get to it.

This doesn't help the header wrapping problem, but doesn't make it worse.
