### PR TITLE
Tidy up the temporary assignment of PG settings

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -17,6 +17,7 @@ test: &test
   encoding: utf8
   local_infile: true
   variables:
+    work_mem: 1MB
     synchronous_commit: "off"
 
 production:

--- a/lib/transition/import/postgresql_settings.rb
+++ b/lib/transition/import/postgresql_settings.rb
@@ -1,0 +1,33 @@
+module Transition
+  module Import
+    module PostgreSQLSettings
+      def get_setting(name)
+        result_row = ActiveRecord::Base.connection.execute("show #{name}").first
+        result_row[name]
+      end
+
+      def set_setting(name, value)
+        ActiveRecord::Base.connection.execute("set #{name}='#{value}'")
+      end
+
+      ##
+      # Change a setting, do a thing, return setting to previous
+      def change_settings(new_values)
+        old_values = {}
+
+        new_values.each_pair do |name, value|
+          old_values[name] = get_setting(name)
+          set_setting(name, value)
+        end
+
+        begin
+          yield
+        ensure
+          old_values.each_pair do |name, value|
+            set_setting(name, value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/transition/import/postgresql_settings_spec.rb
+++ b/spec/lib/transition/import/postgresql_settings_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+require 'transition/import/postgresql_settings'
+
+describe Transition::Import::PostgreSQLSettings do
+  class PGWrapperUsingClass
+    include Transition::Import::PostgreSQLSettings
+  end
+  let(:object) { PGWrapperUsingClass.new }
+
+  describe '#get_setting' do
+    it 'raises an error for missing settings' do
+      expect { object.get_setting('mrs_tiggywinkle') }.to raise_error(
+        ActiveRecord::StatementInvalid, /unrecognized configuration parameter "mrs_tiggywinkle"/)
+    end
+
+    it 'gets values for existing settings' do
+      expect(object.get_setting('work_mem')).to eql('1MB')
+    end
+  end
+
+  describe '#set_setting' do
+    it 'raises an error for missing settings' do
+      expect { object.set_setting('mrs_tiggywinkle', 'prickly') }.to raise_error(
+        ActiveRecord::StatementInvalid, /unrecognized configuration parameter "mrs_tiggywinkle"/)
+    end
+
+    it 'sets values for existing settings' do
+      old_value = object.get_setting('work_mem')
+      object.set_setting('work_mem', '2MB')
+      expect(object.get_setting('work_mem')).to eql('2MB')
+      object.set_setting('work_mem', old_value)
+    end
+  end
+
+  describe '#change_settings' do
+    it 'temporarily changes multiple valid settings' do
+      old_work_mem = object.get_setting('work_mem')
+      old_work_mem.should_not  == '3MB' # shouldn't be what we're going to set it to
+
+      old_maintenance_work_mem = object.get_setting('maintenance_work_mem')
+      old_maintenance_work_mem.should_not  == '4MB' # shouldn't be what we're going to set it to
+
+      object.change_settings(
+        'work_mem' => '3MB',
+        'maintenance_work_mem' => '4MB'
+      ) do
+        object.get_setting('work_mem').should eql('3MB')
+        object.get_setting('maintenance_work_mem').should eql('4MB')
+      end
+
+      object.get_setting('work_mem').should eql(old_work_mem)
+      object.get_setting('maintenance_work_mem').should eql(old_maintenance_work_mem)
+    end
+
+    it 'changes settings back despite any errors in the block' do
+      class ThisTestErrorOnly < StandardError; end
+
+      old_work_mem = object.get_setting('work_mem')
+
+      begin
+        object.change_settings('work_mem' => '5MB') do
+          raise ThisTestErrorOnly, 'Oh no! I hope they coded this defensively.'
+        end
+      rescue ThisTestErrorOnly
+        expect(object.get_setting('work_mem')).to eql(old_work_mem)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add Transition::Import::PostgreSQLSettings
- Allows a tidier temp boost to working memory when importing hits
