### PR TITLE
Correctly pluralize 'file' in hits import message

### DIFF
--- a/lib/transition/import/hits.rb
+++ b/lib/transition/import/hits.rb
@@ -143,7 +143,7 @@ module Transition
           ActiveRecord::Base.connection.execute('SET autocommit=1')
         end
 
-        console_puts "#{done} hits files imported (#{unchanged} unchanged)."
+        console_puts "#{done} hits #{'file'.pluralize(done)} imported (#{unchanged} unchanged)."
 
         done
       end


### PR DESCRIPTION
In the hourly import of transition-stats hits, usually only one file
has changed and the resulting incorrect pluralization annoys me.
