### PR TITLE
Fix name of a migration class to not rely on inflection

### DIFF
--- a/db/migrate/20140925104317_delete_tna_new_urls.rb
+++ b/db/migrate/20140925104317_delete_tna_new_urls.rb
@@ -1,4 +1,4 @@
-class DeleteTNANewURLs < ActiveRecord::Migration
+class DeleteTnaNewURLs < ActiveRecord::Migration
   class Mapping < ActiveRecord::Base
     self.inheritance_column = nil
   end


### PR DESCRIPTION
This migration was failing because the class name was relying on
inflection of 'TNA', but that isn't loaded here. This reverts the
name to 'Tna' so that it runs.
