### PR TITLE
Remove a reference to managed_by_transition from an import rake task

### DIFF
--- a/lib/tasks/import/mappings_from_host_paths.rake
+++ b/lib/tasks/import/mappings_from_host_paths.rake
@@ -5,7 +5,6 @@ namespace :import do
   task :mappings_from_host_paths, [:site_abbr] => :environment do |_, args|
     site = Site.find_by_abbr(args[:site_abbr])
     raise "No site found for #{args[:site_abbr]}" unless site
-    raise 'ABORT: This site is not managed by transition' unless site.managed_by_transition?
 
     if site.global_type
       STDOUT.flush


### PR DESCRIPTION
- A transtion-postgres Errbit error (https://errbit.preview.alphagov.co.uk/apps/53e8c4e40da115dfc200684d/problems/5425716e0da11550d7001181) made me do a full search everywhere. Clearly nothing has used
  this rake task since https://github.com/alphagov/transition/pull/413 otherwise
  Errbit would have caught the exception?
