### PR TITLE
Clarify wording on leaderboard

### DIFF
--- a/app/views/leaderboard/index.html.erb
+++ b/app/views/leaderboard/index.html.erb
@@ -3,7 +3,7 @@
 <div class="page-title">
   <h1>Department leaderboard<br />
     <small>
-      Which departments have the highest numbers of erroring mappings?
+      Which departments have the highest error traffic?
     </small>
   </h1>
 </div>


### PR DESCRIPTION
This page sorts organisations in descending order by the total number of erroring hits, rather than the total number of erroring mappings; so the pedant in me took issue with the precision of the introduction statement (open to other wording "errors" "erroring hits").
