### PR TITLE
Make the single edit mapping type labels clickable

### DIFF
--- a/app/views/mappings/_form.html.erb
+++ b/app/views/mappings/_form.html.erb
@@ -9,7 +9,7 @@
     <div class="col-md-3">
       <legend class="legend-reset add-label-margin bold">Type</legend>
       <% Mapping::SUPPORTED_TYPES.each do |type| %>
-        <%= f.label :type, class: 'radio-inline' do %>
+        <%= f.label :type, value: type, class: 'radio-inline' do %>
           <%= f.radio_button :type, type, class: 'js-type' %>
           <%= type.titleize %>
         <% end %>


### PR DESCRIPTION
- Before, only the radio buttons on the single edit mapping form were
  clickable, not the labels. This works by setting the `value:`
  attribute of the Rails `f.label` helper to whatever `type` is
  depending on the mapping, leading to greater consistency across the
  app.

(Cc: @fofr)
