### PR TITLE
Make the cursor change to a hand when hovering over radio buttons

### DIFF
--- a/app/assets/stylesheets/forms.css.scss
+++ b/app/assets/stylesheets/forms.css.scss
@@ -4,4 +4,8 @@ form {
       width: auto;
     }
   }
+
+  input[type=radio] {
+    cursor: pointer;
+  }
 }


### PR DESCRIPTION
- Before, this was only the behaviour for the radio button labels.
- Thanks to Edd Sowden for giving me a better way to globally set the
  CSS for every radio button rather than adding a `hand-pointer` class
  to every radio button tag in the app.
