### PR TITLE
Change "private sector URL" to "non-government" URL

### DIFF
--- a/app/views/mappings/_form.html.erb
+++ b/app/views/mappings/_form.html.erb
@@ -74,7 +74,7 @@
     <div data-module="toggle">
       <p class="if-no-js-hide js-toggle-target <% if @mapping.suggested_url %>if-js-hide<% end %>">
         Did this page contain content that shouldn’t be met by government?<br/>
-        <a href="#suggest-url" class="js-toggle link-muted">Suggest a private sector URL</a>
+        <a href="#suggest-url" class="js-toggle link-muted">Suggest a non-government URL</a>
       </p>
       <div class="<% unless @mapping.suggested_url %>if-js-hide<% end %> js-toggle-target">
         <%= f.label :suggested_url do %>

--- a/features/mapping_edit.feature
+++ b/features/mapping_edit.feature
@@ -48,7 +48,7 @@ Feature: Edit a site's mapping
   @javascript
   Scenario: Adding a suggested URL
     When I make the mapping an archive
-    And I click the link "Suggest a private sector URL"
+    And I click the link "Suggest a non-government URL"
     Then I should see the link replaced with a suggested URL field
 
   Scenario: Editing a mapping with invalid values


### PR DESCRIPTION
I've had a few comments from people about this feature: "What about charities? They're not private-sector!"

This PR hopes to clarify the difference. (And appeals to some pedantry of mine.)
