### PR TITLE
Remove the advice to run the import:hits_mappings_relations rake task (when importing mappings)

### DIFF
--- a/lib/tasks/import/hits_mappings_relations.rake
+++ b/lib/tasks/import/hits_mappings_relations.rake
@@ -1,7 +1,7 @@
 require 'transition/import/hits_mappings_relations'
 
 namespace :import do
-  desc 'Refresh c14nd path relations between hits and mappings'
+  desc 'Dev only: refresh c14nd path relations between hits and mappings'
   task :hits_mappings_relations => :environment do
     Transition::Import::HitsMappingsRelations.refresh!
   end

--- a/lib/tasks/import/mappings_from_host_paths.rake
+++ b/lib/tasks/import/mappings_from_host_paths.rake
@@ -16,6 +16,5 @@ namespace :import do
     end
 
     Transition::Import::MappingsFromHostPaths.refresh!(site)
-    puts 'You may now want to run `rake import:hits_mappings_relations` to connect hits and any new mappings.'
   end
 end


### PR DESCRIPTION
- In writing some instructions on how to generate mappings from hits for
  sites in preview and production, I wondered about the
  `import:hits_mappings_relations` rake task and its purpose. Following
  feedback from Jenny, it seems like the purpose of this rake task is
  fulfilled by
  https://github.com/alphagov/transition/blob/master/app/models/mapping.rb#L42.
  This means that this rake task (and the advice at the end of
  `import:mappings_from_host_paths` to run it) can be removed.
