### PR TITLE
Return a 404 response when a batch does not exist

### DIFF
--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -13,5 +13,7 @@ class BatchesController < ApplicationController
 private
   def set_batch
     @batch = current_user.mappings_batches.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    head 404
   end
 end

--- a/spec/controllers/batches_controller_spec.rb
+++ b/spec/controllers/batches_controller_spec.rb
@@ -4,26 +4,39 @@ describe BatchesController do
   describe 'GET #show' do
     let(:user) { create(:user) }
     let(:site) { create(:site) }
-    let(:mappings_batch) { create(:bulk_add_batch, site: site, user: user) }
 
-    before do
-      login_as(user)
-      get :show, site_id: site.abbr, id: mappings_batch.id
-      @parsed_response = JSON.parse(response.body)
+    context 'when batch exists' do
+      let(:mappings_batch) { create(:bulk_add_batch, site: site, user: user) }
+
+      before do
+        login_as(user)
+        get :show, site_id: site.abbr, id: mappings_batch.id
+        @parsed_response = JSON.parse(response.body)
+      end
+
+      it 'responds with the correct HTTP status code' do
+        expect(response.status).to be(200)
+      end
+
+      it 'renders a JSON document' do
+        expected = {
+          'done' => 0,
+          'total' => 2,
+          'past_participle' => 'added'
+        }
+        @parsed_response.should == expected
+      end
     end
 
+    context 'when batch does not exist' do
+      before do
+        login_as(user)
+        get :show, site_id: site.abbr, id: 72
+      end
 
-    it 'responds with the correct HTTP status code' do
-      expect(response.status).to be(200)
-    end
-
-    it 'renders a JSON document' do
-      expected = {
-        'done' => 0,
-        'total' => 2,
-        'past_participle' => 'added'
-      }
-      @parsed_response.should == expected
+      it 'responds with a 404 status code' do
+        expect(response.status).to be(404)
+      end
     end
   end
 end


### PR DESCRIPTION
**Note: merging onto `master` rather than `postgres-master`, for easier rebasing.**

We've been getting intermittent failures in the batch import tests, because Cucumber's PhantomJS instance was sending periodic Ajax requests about the status of the batch it had created, even after the test teardown had removed the batch.

Returning a 404 response instead of raising an error should stop this causing an error in the tests, without having any effect on the behaviour of the front-end itself (it fails just the same with a 404 or a 500 response).
