### PR TITLE
Run DNS details import hourly only during the working week

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -12,7 +12,8 @@ every :day, at: ['4:15am', '2pm'] do
   rake 'import:whitehall:mappings'
 end
 
-every :hour do
+# every hour 7am-7pm, Mon-Fri
+every '0 07-19 * * 1-5' do
   rake 'import:dns_details'
 end
 


### PR DESCRIPTION
This import seems to be able to cause a deadlock if it runs during the
mysql-to-postgres sync, which can cause the sync job to fail. We only
need the DNS details to be updated hourly while users are likely to be
in the app, so only run it during workdays so that it will not be running
early in the morning, potentially conflicting with the sync job.
