### PR TITLE
Remove the extra horizontal line on the edit single mapping page

### DIFF
--- a/app/views/mappings/_form.html.erb
+++ b/app/views/mappings/_form.html.erb
@@ -92,7 +92,6 @@
         </div>
       </div>
     </div>
-    <hr>
   <% end %>
   <hr>
 


### PR DESCRIPTION
- An extra horizontal line appeared when "archive" was selected as the
  mapping type.

Before:

![screen shot 2014-10-24 at 20 17 48](https://cloud.githubusercontent.com/assets/355033/4791443/34d0ad22-5ddd-11e4-956e-72d63f2ed3a9.png)

After:

![screen shot 2014-10-27 at 13 29 51](https://cloud.githubusercontent.com/assets/355033/4791465/5d555284-5ddd-11e4-9d96-1881ef5e3cdc.png)
