### PR TITLE
Async commit of hits

### DIFF
--- a/lib/transition/import/hits.rb
+++ b/lib/transition/import/hits.rb
@@ -159,7 +159,7 @@ module Transition
       def self.from_redirector_mask!(filemask)
         done, unchanged = 0, 0
 
-        change_settings('work_mem' => '2GB') do
+        change_settings('work_mem' => '2GB', 'synchronous_commit' => 'off') do
           Dir[File.expand_path(filemask)].each do |filename|
             Hits.from_redirector_tsv_file!(filename) ? done += 1 : unchanged += 1
           end


### PR DESCRIPTION
- Improves write performance of hits import by setting
  `synchronous_commit=off` for the duration of a hits file import
- At worst, if anything goes down during the import, the transaction
  won't be committed. This means no `ImportedHitsFile` record will be
  written. Consequently, `import:hits` will pick up the unimported file
  on the next job run.
