### PR TITLE
Be consistent with production: don't set synchronous_commit in dev

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -18,11 +18,5 @@ test: &test
   variables:
     work_mem: 1MB
 
-production:
-  adapter: postgresql
-  database: transition_production
-  template: template0
-  encoding: utf8
-
 cucumber:
   <<: *test


### PR DESCRIPTION
- This was used for Postgres in dev for some reasons, but isn't set in production, and we should have no disparity between production and dev anymore. Remove it from the test database config as well for good measure.
