### PR TITLE
Remove `path_hash` everywhere but the DB

### DIFF
--- a/app/models/bulk_add_batch.rb
+++ b/app/models/bulk_add_batch.rb
@@ -37,14 +37,12 @@ class BulkAddBatch < MappingsBatch
 
   # called after_create, so in the same transaction
   def create_entries
-    canonical_path_hashes = canonical_paths.map { |path| Digest::SHA1.hexdigest(path) }
-    existing_mappings = site.mappings.where(path_hash: canonical_path_hashes)
+    existing_mappings = site.mappings.where(path: canonical_paths)
 
     records = canonical_paths.map do |canonical_path|
       entry = BulkAddBatchEntry.new(path: canonical_path)
       entry.mappings_batch = self
-      path_hash = Digest::SHA1.hexdigest(canonical_path)
-      entry.mapping = existing_mappings.detect { |mapping| mapping.path_hash == path_hash }
+      entry.mapping = existing_mappings.detect { |mapping| mapping.path == canonical_path }
       entry
     end
 

--- a/app/models/hit.rb
+++ b/app/models/hit.rb
@@ -13,11 +13,7 @@ class Hit < ActiveRecord::Base
   validates :http_status, presence: true, length: { maximum: 3 }
   validates :host_id, uniqueness: { scope: [:path, :hit_on, :http_status], message: 'Hit data already exists for this host, path, date and status!' }
 
-  # set a hash of the path because we can't have a unique index on
-  # the path (it's too long)
-  before_validation :set_path_hash
   before_validation :normalize_hit_on
-  validates :path_hash, presence: true
 
   scope :by_host_and_path_and_status, -> {
     select('hits.path AS path, sum(hits.count) as count, hits.host_id, '\
@@ -64,9 +60,6 @@ class Hit < ActiveRecord::Base
   end
 
   protected
-  def set_path_hash
-    self.path_hash = Digest::SHA1.hexdigest(path) if path_changed?
-  end
   def normalize_hit_on
     self.hit_on = hit_on.beginning_of_day if hit_on_changed?
   end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -60,7 +60,7 @@ class Host < ActiveRecord::Base
   end
 
   def update_hits_relations
-    host_paths.update_all(mapping_id: nil, c14n_path_hash: nil)
+    host_paths.update_all(mapping_id: nil, canonical_path: nil)
     hits.update_all(mapping_id: nil)
     Transition::Import::HitsMappingsRelations.refresh!(self.site)
   end

--- a/app/models/host_path.rb
+++ b/app/models/host_path.rb
@@ -3,19 +3,15 @@
 # we've seen and know about. It's derived from Hit data
 # by +Transition::Import::HitsMappingsRelations.refresh!+
 #
-# It also holds a c14n'd path, which lets us update hits
+# It also holds a canonical_path, which lets us update hits
 # when we update mappings.
 class HostPath < ActiveRecord::Base
   belongs_to :host
   belongs_to :mapping
 
-  before_save :set_path_hash, :set_c14n_path_hash
+  before_save :set_canonical_path
 
-  def set_path_hash
-    self.path_hash = Digest::SHA1.hexdigest(path) if path_changed?
-  end
-
-  def set_c14n_path_hash
-    self.c14n_path_hash = Digest::SHA1.hexdigest(host.site.canonical_path(path)) if path_changed?
+  def set_canonical_path
+    self.canonical_path = host.site.canonical_path(path) if path_changed?
   end
 end

--- a/app/models/import_batch.rb
+++ b/app/models/import_batch.rb
@@ -35,14 +35,13 @@ class ImportBatch < MappingsBatch
   after_create :create_entries
 
   def create_entries
-    canonical_path_hashes = deduplicated_csv_rows.map { |row| Digest::SHA1.hexdigest(row.path) }
-    existing_mappings = site.mappings.where(path_hash: canonical_path_hashes)
+    canonical_paths = deduplicated_csv_rows.map(&:path)
+    existing_mappings = site.mappings.where(path: canonical_paths)
 
     deduplicated_csv_rows.each do |row|
       entry = ImportBatchEntry.new(path: row.path, type: row.type, new_url: row.new_url)
       entry.mappings_batch = self
-      path_hash = Digest::SHA1.hexdigest(row.path)
-      entry.mapping = existing_mappings.detect { |mapping| mapping.path_hash == path_hash }
+      entry.mapping = existing_mappings.detect { |mapping| mapping.path == row.path }
       entry.save!
     end
   end

--- a/app/models/mapping.rb
+++ b/app/models/mapping.rb
@@ -30,12 +30,9 @@ class Mapping < ActiveRecord::Base
             exclusion: { in: ['/'], message: I18n.t('mappings.not_possible_to_edit_homepage_mapping')},
             is_path: true
   validates :type, presence: true, inclusion: { :in => SUPPORTED_TYPES }
-  validates :site_id, uniqueness: { scope: [:path_hash], message: 'Mapping already exists for this site and path!' }
+  validates :site_id, uniqueness: { scope: [:path], message: 'Mapping already exists for this site and path!' }
 
-  # set a hash of the path because we can't have a unique index on
-  # the path (it's too long)
-  before_validation :trim_scheme_host_and_port_from_path, :fill_in_scheme, :canonicalize_path, :set_path_hash
-  validates :path_hash, presence: true
+  before_validation :trim_scheme_host_and_port_from_path, :fill_in_scheme, :canonicalize_path
 
   before_save :ensure_papertrail_user_config
 
@@ -159,10 +156,6 @@ protected
     # The path isn't parseable, so leave it intact for validations to report
   end
 
-  def set_path_hash
-    self.path_hash = Digest::SHA1.hexdigest(path) if path_changed?
-  end
-
   def canonicalize_path
     self.path = site.canonical_path(path) unless (site.nil? || path == '/' || path =~ /^[^\/]/)
   end
@@ -176,10 +169,10 @@ protected
   end
 
   def update_hit_relations
-    host_paths = site.host_paths.where(c14n_path_hash: path_hash)
-    new_hits_hashes = host_paths.pluck(:path_hash)
+    host_paths = site.host_paths.where(canonical_path: path)
+    new_hits_paths = host_paths.pluck(:path)
 
-    site.hits.where(path_hash: new_hits_hashes).update_all(mapping_id: self.id)
+    site.hits.where(path: new_hits_paths).update_all(mapping_id: self.id)
     host_paths.update_all(mapping_id: self.id)
 
     self.update_column(:hit_count, hits.sum('count'))

--- a/app/models/mappings_batch.rb
+++ b/app/models/mappings_batch.rb
@@ -39,8 +39,7 @@ class MappingsBatch < ActiveRecord::Base
   def process
     with_state_tracking do
       entries.each do |entry|
-        path_hash = Digest::SHA1.hexdigest(entry.path)
-        mapping = site.mappings.where(path_hash: path_hash).first_or_initialize
+        mapping = site.mappings.where(path: entry.path).first_or_initialize
 
         next if !update_existing && mapping.persisted?
         mapping.path = entry.path

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -79,7 +79,7 @@ class Site < ActiveRecord::Base
   end
 
   def update_hits_relations
-    host_paths.update_all(mapping_id: nil, c14n_path_hash: nil)
+    host_paths.update_all(mapping_id: nil, canonical_path: nil)
     hits.update_all(mapping_id: nil)
     Transition::Import::HitsMappingsRelations.refresh!(self)
   end

--- a/db/migrate/20141104102518_add_canonical_path_to_host_paths.rb
+++ b/db/migrate/20141104102518_add_canonical_path_to_host_paths.rb
@@ -1,0 +1,55 @@
+class AddCanonicalPathToHostPaths < ActiveRecord::Migration
+  def up
+    # Remove the UNIQUE index on path_hash
+    remove_index :host_paths, column: [:host_id, :path_hash]
+
+    # Add a canonical path column and populate it using optic14n's c14n rules
+    add_column    :host_paths, :canonical_path, :string, limit: 2048
+    require 'transition/import/hits_mappings_relations'
+    Transition::Import::HitsMappingsRelations.new.send :connect_mappings_to_host_paths!
+
+    # Add the UNIQUE index to non-canonical path now we've done the expensive work
+    add_index     :host_paths, [:host_id, :path], unique: true
+
+    # Make the mappings and hits path hashes unimportant to our new code,
+    # but still present to any extant processes needing access
+    change_column_null :mappings, :path_hash, true
+    change_column_null :hits,     :path_hash, true
+  end
+
+  # If we're rolling back this migration, we will have nulls
+  # in hits/mappings path_hash where none should exist. Fill them
+  # in using the path.
+  #
+  # Note that this +down+ will be unrunnable and this migration will be
+  # irreversible once DROP EXTENSION pgcrypto is run (planned for the
+  # deploy following the one in which this migration runs)
+  #
+  # As a result, +raise ActiveRecord::IrreversibleMigration+ or convert this
+  # SQL to Ruby following initial deploy.
+  BACKFILL_PATH_HASH_NULLS = <<-postgreSQL
+    UPDATE hits
+    SET    path_hash = (encode(digest(hits.path, 'sha1'), 'hex'))
+    WHERE  hits.path_hash IS NULL;
+
+    UPDATE mappings
+    SET    path_hash = (encode(digest(mappings.path, 'sha1'), 'hex'))
+    WHERE  mappings.path_hash IS NULL;
+  postgreSQL
+
+  def down
+    remove_column :host_paths, :canonical_path
+
+    # Remove the UNIQUE index on host_paths (host_id, path)
+    remove_index  :host_paths, column: [:host_id, :path]
+    # And put it back on (host_id, path_hash)
+    add_index :host_paths, [:host_id, :path_hash], unique: true
+
+    # Fill in any blanks in hits/mappings that can't be NULL
+    ActiveRecord::Base.connection.execute(BACKFILL_PATH_HASH_NULLS)
+
+    # Enforce that constraint
+    change_column_null :hits,     :path_hash, false
+    change_column_null :mappings, :path_hash, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141103142639) do
+ActiveRecord::Schema.define(version: 20141104102518) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,7 +29,7 @@ ActiveRecord::Schema.define(version: 20141103142639) do
   create_table "hits", force: true do |t|
     t.integer "host_id",                  null: false
     t.string  "path",        limit: 2048, null: false
-    t.string  "path_hash",   limit: 40,   null: false
+    t.string  "path_hash",   limit: 40
     t.string  "http_status", limit: 3,    null: false
     t.integer "count",                    null: false
     t.date    "hit_on",                   null: false
@@ -55,10 +55,11 @@ ActiveRecord::Schema.define(version: 20141103142639) do
     t.string  "c14n_path_hash"
     t.integer "host_id"
     t.integer "mapping_id"
+    t.string  "canonical_path", limit: 2048
   end
 
   add_index "host_paths", ["c14n_path_hash"], name: "index_host_paths_on_c14n_path_hash", using: :btree
-  add_index "host_paths", ["host_id", "path_hash"], name: "index_host_paths_on_host_id_and_path_hash", unique: true, using: :btree
+  add_index "host_paths", ["host_id", "path"], name: "index_host_paths_on_host_id_and_path", unique: true, using: :btree
   add_index "host_paths", ["mapping_id"], name: "index_host_paths_on_mapping_id", using: :btree
 
   create_table "hosts", force: true do |t|
@@ -89,7 +90,7 @@ ActiveRecord::Schema.define(version: 20141103142639) do
   create_table "mappings", force: true do |t|
     t.integer "site_id",                                      null: false
     t.string  "path",            limit: 2048,                 null: false
-    t.string  "path_hash",       limit: 40,                   null: false
+    t.string  "path_hash",       limit: 40
     t.text    "new_url"
     t.text    "suggested_url"
     t.text    "archive_url"

--- a/lib/transition/import/hits.rb
+++ b/lib/transition/import/hits.rb
@@ -98,8 +98,8 @@ module Transition
       postgreSQL
 
       INSERT_FROM_STAGING = <<-postgreSQL
-        INSERT INTO hits (host_id, path, path_hash, http_status, count, hit_on)
-        SELECT h.id, st.path, encode(digest(st.path, 'sha1'), 'hex'), st.http_status, st.count, st.hit_on
+        INSERT INTO hits (host_id, path, http_status, count, hit_on)
+        SELECT h.id, st.path, st.http_status, st.count, st.hit_on
         FROM   hits_staging st
         INNER JOIN hosts h on h.hostname = st.hostname
         WHERE LENGTH(st.path) <= 2048

--- a/lib/transition/import/hits_mappings_relations.rb
+++ b/lib/transition/import/hits_mappings_relations.rb
@@ -13,7 +13,7 @@ module Transition
 
       def refresh!
         start('Refreshing host paths'                                 ) { refresh_host_paths! }
-        start('Adding missing mapping_id/c14n_path_hash to host paths') { connect_mappings_to_host_paths! }
+        start('Adding missing mapping_id/canonical_path to host paths') { connect_mappings_to_host_paths! }
         start('Updating hits from host paths'                         ) { refresh_hits_from_host_paths! }
         start('Precomputing mapping hit counts'                       ) { precompute_mapping_hit_counts! }
       end
@@ -36,8 +36,8 @@ module Transition
       def refresh_host_paths!
         and_host_is_in_site = site ? "AND hits.host_id #{in_site_hosts}" : ''
         sql = <<-postgreSQL
-          INSERT INTO host_paths(host_id, path_hash, path)
-          SELECT hits.host_id, hits.path_hash, hits.path
+          INSERT INTO host_paths(host_id, path)
+          SELECT hits.host_id, hits.path
           FROM   hits
           WHERE NOT EXISTS (
             SELECT 1 FROM host_paths
@@ -47,7 +47,6 @@ module Transition
           )
           #{and_host_is_in_site}
           GROUP  BY hits.host_id,
-                    hits.path_hash,
                     hits.path
         postgreSQL
         ActiveRecord::Base.connection.execute(sql)
@@ -57,15 +56,14 @@ module Transition
         host_paths.includes(:host).find_each do |host_path|
           site = host_path.host.site
 
-          c14nized_path_hash =
-            Digest::SHA1.hexdigest(site.canonical_path(host_path.path))
+          canonical_path = site.canonical_path(host_path.path)
           mapping_id = Mapping.where(
-            path_hash: c14nized_path_hash, site_id: site.id).pluck(:id).first
+            path: canonical_path, site_id: site.id).pluck(:id).first
 
-          if host_path.mapping_id != mapping_id || host_path.c14n_path_hash != c14nized_path_hash
+          if host_path.mapping_id != mapping_id || host_path.canonical_path != canonical_path
             host_path.update_columns(
               mapping_id: mapping_id,
-              c14n_path_hash: c14nized_path_hash)
+              canonical_path: canonical_path)
           end
         end
       end

--- a/lib/transition/import/mappings_from_host_paths.rb
+++ b/lib/transition/import/mappings_from_host_paths.rb
@@ -10,7 +10,7 @@ module Transition
           Transition::History.as_a_user(user) do
             site_paths = site.host_paths
               .select('MIN(host_paths.path) AS path')
-              .where('mapping_id is null').group('c14n_path_hash').map(&:path)
+              .where('mapping_id is null').group('canonical_path').map(&:path)
 
             site_paths.each do |uncanonicalized_path|
               # Try to create them (there may be duplicates in the set and they may

--- a/lib/transition/import/whitehall/mappings_csv.rb
+++ b/lib/transition/import/whitehall/mappings_csv.rb
@@ -34,7 +34,7 @@ module Transition
                 Rails.logger.warn("Skipping mapping for unknown host in Whitehall URL CSV: '#{old_uri.host}'")
               else
                 canonical_path = host.site.canonical_path(row['Old URL'])
-                existing_mapping = host.site.mappings.where(path_hash: path_hash(canonical_path)).first
+                existing_mapping = host.site.mappings.where(path: canonical_path).first
 
                 if existing_mapping
                     if existing_mapping.type == 'archive' ||
@@ -52,10 +52,6 @@ module Transition
 
         def hosts_by_hostname
           @_hosts ||= Host.all.inject({}) { |accumulator,host| accumulator.merge(host.hostname => host) }
-        end
-
-        def path_hash(canonical_path)
-          Digest::SHA1.hexdigest(canonical_path)
         end
       end
     end

--- a/spec/lib/transition/import/hits_mappings_relations_spec.rb
+++ b/spec/lib/transition/import/hits_mappings_relations_spec.rb
@@ -49,8 +49,7 @@ describe Transition::Import::HitsMappingsRelations do
     describe 'The first HostPath' do
       subject { HostPath.where(path: '/this/Exists?and=can&canonicalize=1&significant=1').first }
 
-      its(:path_hash)      { should eql(Digest::SHA1.hexdigest('/this/Exists?and=can&canonicalize=1&significant=1')) }
-      its(:c14n_path_hash) { should eql(Digest::SHA1.hexdigest('/this/exists?significant=1')) }
+      its(:canonical_path) { should eql('/this/exists?significant=1') }
     end
 
     context 'when canonicalization has changed since a previous refresh' do

--- a/spec/lib/transition/import/hits_spec.rb
+++ b/spec/lib/transition/import/hits_spec.rb
@@ -45,7 +45,6 @@ describe Transition::Import::Hits do
         its(:hit_on)    { should eql(Date.new(2012, 10, 14)) }
         its(:count)     { should eql(21) }
         its(:path)      { should eql('/') }
-        its(:path_hash) { should eql('42099b4af021e53fd8fd4e056c2568d7c2e3ffa8') }
       end
     end
 

--- a/spec/lib/transition/import/mappings_from_host_paths_spec.rb
+++ b/spec/lib/transition/import/mappings_from_host_paths_spec.rb
@@ -36,7 +36,6 @@ describe Transition::Import::MappingsFromHostPaths do
       subject { @site.mappings.first }
 
       its(:path)        { should eql('/foo') }
-      its(:path_hash)   { should eql(@host_path.c14n_path_hash) }
       its(:type)        { should eql('unresolved') }
     end
 

--- a/spec/models/hit_spec.rb
+++ b/spec/models/hit_spec.rb
@@ -8,7 +8,6 @@ describe Hit do
   describe 'validations' do
     it { should validate_presence_of(:host) }
     it { should validate_presence_of(:path) }
-    it { should validate_presence_of(:path_hash) }
     it { should validate_presence_of(:count) }
     it { should validate_numericality_of(:count).is_greater_than_or_equal_to(0) }
   end
@@ -17,7 +16,6 @@ describe Hit do
     subject { create :hit, hit_on: DateTime.new(2014, 12, 31, 23, 59, 59) }
 
     its(:hit_on)    { should eql(DateTime.new(2014, 12, 31, 0, 0, 0)) }
-    its(:path_hash) { should eql('ce81157034ae8c32f429d3dc03bed10cc0c47b65') }
   end
 
   describe '#homepage?' do

--- a/spec/models/host_path_spec.rb
+++ b/spec/models/host_path_spec.rb
@@ -12,7 +12,6 @@ describe HostPath do
     end
 
     its(:path)           { should eql(uncanonicalized_path) }
-    its(:path_hash)      { should eql(Digest::SHA1.hexdigest(uncanonicalized_path)) }
-    its(:c14n_path_hash) { should eql(Digest::SHA1.hexdigest(canonicalized_path)) }
+    its(:canonical_path) { should eql(canonicalized_path)   }
   end
 end

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -179,14 +179,6 @@ describe Host do
           host_path = runaway_host.host_paths.find_by_path(hit.path)
           host_path.mapping.should eql(nil)
         end
-
-        it 're-generates the c14n_path_hash' do
-          host_path = runaway_host.host_paths.find_by_path(hit.path)
-
-          # significant_on_first_site is not significant on the new site
-          new_path_hash = Digest::SHA1.hexdigest('/some-path')
-          host_path.c14n_path_hash.should eql(new_path_hash)
-        end
       end
 
       context 'mappings for the same paths exist on the new site' do
@@ -207,7 +199,7 @@ describe Host do
 
           host_path = runaway_host.host_paths.find_by_path(hit.path)
           host_path.mapping.should eql(other_mapping)
-          host_path.c14n_path_hash.should_not be_nil
+          host_path.canonical_path.should_not be_nil
         end
 
         it 'sets the hit count on the mappings which now have hits' do

--- a/spec/models/mapping_spec.rb
+++ b/spec/models/mapping_spec.rb
@@ -271,7 +271,6 @@ describe Mapping do
     end
 
     its(:path)        { should eql(canonicalized_path) }
-    its(:path_hash)   { should eql(Digest::SHA1.hexdigest(canonicalized_path)) }
 
     describe 'the linkage to hits' do
       let!(:hit_on_uncanonicalized) { create :hit, path: uncanonicalized_path, host: site.default_host }


### PR DESCRIPTION
Most important thing in this (given that the tests pass) is checking over the [migration](https://github.com/alphagov/transition/blob/37ea1bef7451d5617771de9c36dec1145a94c605/db/migrate/20141104102518_add_canonical_path_to_host_paths.rb), which ended up needed a deal more work than we expected.
### DB
- Leave `hits` and `mappings` `path_hash` `NULL`able so that existing
  processes are not disrupted
- Add `canonical_path` to `host_paths` to replace `c14n_path_hash`
- Populate it using the private
  `HitsMappingsRelations#connect_mappings_to_host_paths`
- Move the UNIQUE `host_paths` index from `(host_id, path_hash)` to
  `(host_id, path)`
- Cope with any possible rollback (including backfilling `path_hash` for `hits`
  and `mappings` in the migration's `down`)
### Code
- Remap usages of `host_paths.c14n_path_hash` to
  `host_paths.canonical_path`
- Replace usages of `path_hash` with appropriate plain
  `*path` alternatives
