### PR TITLE
Flip the uniqueness constraint on Mapping

### DIFF
--- a/app/models/mapping.rb
+++ b/app/models/mapping.rb
@@ -30,7 +30,7 @@ class Mapping < ActiveRecord::Base
             exclusion: { in: ['/'], message: I18n.t('mappings.not_possible_to_edit_homepage_mapping')},
             is_path: true
   validates :type, presence: true, inclusion: { :in => SUPPORTED_TYPES }
-  validates :site_id, uniqueness: { scope: [:path], message: 'Mapping already exists for this site and path!' }
+  validates :path, uniqueness: { scope: [:site_id], message: 'Mapping already exists for this site and path!' }
 
   before_validation :trim_scheme_host_and_port_from_path, :fill_in_scheme, :canonicalize_path
 


### PR DESCRIPTION
While the effect is the same either way (that no two `Mapping` objects can have the same values for both `path` and `site_id`), it's clearer this way around that the idea is to ensure no two mappings exist for the same path in a site.
