### PR TITLE
Widen the column width of the mapping type radio buttons

### DIFF
--- a/app/views/mappings/_form.html.erb
+++ b/app/views/mappings/_form.html.erb
@@ -6,7 +6,7 @@
   <% end %>
 
   <div class="form-group row">
-    <div class="col-md-3">
+    <div class="col-md-6">
       <legend class="legend-reset add-label-margin bold">Type</legend>
       <% Mapping::SUPPORTED_TYPES.each do |type| %>
         <%= f.label :type, value: type, class: 'radio-inline' do %>


### PR DESCRIPTION
These radio buttons, at a certain browser size, were appearing like:
![screen shot 2014-11-18 at 10 29 52](https://cloud.githubusercontent.com/assets/355033/5086514/78f937be-6f15-11e4-898e-44eb3c9209b2.png)

Now they're as normal.
