### PR TITLE
Use path fields instead of `path_hash`

### DIFF
--- a/app/models/bulk_add_batch.rb
+++ b/app/models/bulk_add_batch.rb
@@ -37,14 +37,12 @@ class BulkAddBatch < MappingsBatch
 
   # called after_create, so in the same transaction
   def create_entries
-    canonical_path_hashes = canonical_paths.map { |path| Digest::SHA1.hexdigest(path) }
-    existing_mappings = site.mappings.where(path_hash: canonical_path_hashes)
+    existing_mappings = site.mappings.where(path: canonical_paths)
 
     records = canonical_paths.map do |canonical_path|
       entry = BulkAddBatchEntry.new(path: canonical_path)
       entry.mappings_batch = self
-      path_hash = Digest::SHA1.hexdigest(canonical_path)
-      entry.mapping = existing_mappings.detect { |mapping| mapping.path_hash == path_hash }
+      entry.mapping = existing_mappings.detect { |mapping| mapping.path == canonical_path }
       entry
     end
 

--- a/app/models/hit.rb
+++ b/app/models/hit.rb
@@ -1,4 +1,3 @@
-require 'digest/sha1'
 require 'kaminari'
 
 class Hit < ActiveRecord::Base
@@ -13,11 +12,7 @@ class Hit < ActiveRecord::Base
   validates :http_status, presence: true, length: { maximum: 3 }
   validates :host_id, uniqueness: { scope: [:path, :hit_on, :http_status], message: 'Hit data already exists for this host, path, date and status!' }
 
-  # set a hash of the path because we can't have a unique index on
-  # the path (it's too long)
-  before_validation :set_path_hash
   before_validation :normalize_hit_on
-  validates :path_hash, presence: true
 
   scope :by_host_and_path_and_status, -> {
     select('hits.path AS path, sum(hits.count) as count, hits.host_id, '\
@@ -64,9 +59,6 @@ class Hit < ActiveRecord::Base
   end
 
   protected
-  def set_path_hash
-    self.path_hash = Digest::SHA1.hexdigest(path) if path_changed?
-  end
   def normalize_hit_on
     self.hit_on = hit_on.beginning_of_day if hit_on_changed?
   end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -60,7 +60,7 @@ class Host < ActiveRecord::Base
   end
 
   def update_hits_relations
-    host_paths.update_all(mapping_id: nil, c14n_path_hash: nil)
+    host_paths.update_all(mapping_id: nil, canonical_path: nil)
     hits.update_all(mapping_id: nil)
     Transition::Import::HitsMappingsRelations.refresh!(self.site)
   end

--- a/app/models/host_path.rb
+++ b/app/models/host_path.rb
@@ -3,19 +3,15 @@
 # we've seen and know about. It's derived from Hit data
 # by +Transition::Import::HitsMappingsRelations.refresh!+
 #
-# It also holds a c14n'd path, which lets us update hits
+# It also holds a canonical_path, which lets us update hits
 # when we update mappings.
 class HostPath < ActiveRecord::Base
   belongs_to :host
   belongs_to :mapping
 
-  before_save :set_path_hash, :set_c14n_path_hash
+  before_save :set_canonical_path
 
-  def set_path_hash
-    self.path_hash = Digest::SHA1.hexdigest(path) if path_changed?
-  end
-
-  def set_c14n_path_hash
-    self.c14n_path_hash = Digest::SHA1.hexdigest(host.site.canonical_path(path)) if path_changed?
+  def set_canonical_path
+    self.canonical_path = host.site.canonical_path(path) if path_changed?
   end
 end

--- a/app/models/import_batch.rb
+++ b/app/models/import_batch.rb
@@ -35,14 +35,13 @@ class ImportBatch < MappingsBatch
   after_create :create_entries
 
   def create_entries
-    canonical_path_hashes = deduplicated_csv_rows.map { |row| Digest::SHA1.hexdigest(row.path) }
-    existing_mappings = site.mappings.where(path_hash: canonical_path_hashes)
+    canonical_paths = deduplicated_csv_rows.map(&:path)
+    existing_mappings = site.mappings.where(path: canonical_paths)
 
     deduplicated_csv_rows.each do |row|
       entry = ImportBatchEntry.new(path: row.path, type: row.type, new_url: row.new_url)
       entry.mappings_batch = self
-      path_hash = Digest::SHA1.hexdigest(row.path)
-      entry.mapping = existing_mappings.detect { |mapping| mapping.path_hash == path_hash }
+      entry.mapping = existing_mappings.detect { |mapping| mapping.path == row.path }
       entry.save!
     end
   end

--- a/app/models/mapping.rb
+++ b/app/models/mapping.rb
@@ -1,4 +1,3 @@
-require 'digest/sha1'
 require 'transition/history'
 
 class Mapping < ActiveRecord::Base
@@ -32,10 +31,7 @@ class Mapping < ActiveRecord::Base
   validates :type, presence: true, inclusion: { :in => SUPPORTED_TYPES }
   validates :path, uniqueness: { scope: [:site_id], message: 'Mapping already exists for this site and path!' }
 
-  # set a hash of the path because we can't have a unique index on
-  # the path (it's too long)
-  before_validation :trim_scheme_host_and_port_from_path, :fill_in_scheme, :canonicalize_path, :set_path_hash
-  validates :path_hash, presence: true
+  before_validation :trim_scheme_host_and_port_from_path, :fill_in_scheme, :canonicalize_path
 
   before_save :ensure_papertrail_user_config
 
@@ -159,10 +155,6 @@ protected
     # The path isn't parseable, so leave it intact for validations to report
   end
 
-  def set_path_hash
-    self.path_hash = Digest::SHA1.hexdigest(path) if path_changed?
-  end
-
   def canonicalize_path
     self.path = site.canonical_path(path) unless (site.nil? || path == '/' || path =~ /^[^\/]/)
   end
@@ -176,10 +168,10 @@ protected
   end
 
   def update_hit_relations
-    host_paths = site.host_paths.where(c14n_path_hash: path_hash)
-    new_hits_hashes = host_paths.pluck(:path_hash)
+    host_paths = site.host_paths.where(canonical_path: path)
+    new_hits_paths = host_paths.pluck(:path)
 
-    site.hits.where(path_hash: new_hits_hashes).update_all(mapping_id: self.id)
+    site.hits.where(path: new_hits_paths).update_all(mapping_id: self.id)
     host_paths.update_all(mapping_id: self.id)
 
     self.update_column(:hit_count, hits.sum('count'))

--- a/app/models/mappings_batch.rb
+++ b/app/models/mappings_batch.rb
@@ -39,8 +39,7 @@ class MappingsBatch < ActiveRecord::Base
   def process
     with_state_tracking do
       entries.each do |entry|
-        path_hash = Digest::SHA1.hexdigest(entry.path)
-        mapping = site.mappings.where(path_hash: path_hash).first_or_initialize
+        mapping = site.mappings.where(path: entry.path).first_or_initialize
 
         next if !update_existing && mapping.persisted?
         mapping.path = entry.path

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -79,7 +79,7 @@ class Site < ActiveRecord::Base
   end
 
   def update_hits_relations
-    host_paths.update_all(mapping_id: nil, c14n_path_hash: nil)
+    host_paths.update_all(mapping_id: nil, canonical_path: nil)
     hits.update_all(mapping_id: nil)
     Transition::Import::HitsMappingsRelations.refresh!(self)
   end

--- a/db/migrate/20141118112125_stop_using_path_hash.rb
+++ b/db/migrate/20141118112125_stop_using_path_hash.rb
@@ -1,0 +1,48 @@
+# Stop using `path_hash` for anything important.
+#
+# * change the unique host path index on `host_id` and `path_hash` for one on
+#   `host_id` and `path`
+# * drop NOT NULL constraints on all `path_hash` fields
+class StopUsingPathHash < ActiveRecord::Migration
+  def up
+    remove_index :host_paths, column: [:host_id, :path_hash]
+    add_index :host_paths, [:host_id, :path], unique: true
+
+    # Make the mappings and hits path hashes unimportant to our new code,
+    # but still present to any extant processes needing access
+    change_column_null :mappings, :path_hash, true
+    change_column_null :hits,     :path_hash, true
+  end
+
+  # If we're rolling back this migration, we will have nulls
+  # in hits/mappings path_hash where none should exist. Fill them
+  # in using the path.
+  #
+  # Note that this +down+ will be unrunnable and this migration will be
+  # irreversible once DROP EXTENSION pgcrypto is run (planned for the
+  # deploy following the one in which this migration runs)
+  #
+  # As a result, +raise ActiveRecord::IrreversibleMigration+ or convert this
+  # SQL to Ruby following initial deploy.
+  BACKFILL_PATH_HASH_NULLS = <<-postgreSQL
+    UPDATE hits
+    SET    path_hash = (encode(digest(hits.path, 'sha1'), 'hex'))
+    WHERE  hits.path_hash IS NULL;
+
+    UPDATE mappings
+    SET    path_hash = (encode(digest(mappings.path, 'sha1'), 'hex'))
+    WHERE  mappings.path_hash IS NULL;
+  postgreSQL
+
+  def down
+    remove_index :host_paths, column: [:host_id, :path]
+    add_index :host_paths, [:host_id, :path_hash], unique: true
+
+    # Fill in any blanks in hits/mappings that can't be NULL
+    execute(BACKFILL_PATH_HASH_NULLS)
+
+    # Enforce that constraint
+    change_column_null :hits,     :path_hash, false
+    change_column_null :mappings, :path_hash, false
+  end
+end

--- a/db/migrate/20141118121300_switch_host_path_index_to_canonical_path.rb
+++ b/db/migrate/20141118121300_switch_host_path_index_to_canonical_path.rb
@@ -1,0 +1,11 @@
+class SwitchHostPathIndexToCanonicalPath < ActiveRecord::Migration
+  def up
+    add_index :host_paths, :canonical_path
+    remove_index :host_paths, column: [:c14n_path_hash]
+  end
+
+  def down
+    add_index :host_paths, :c14n_path_hash
+    remove_index :host_paths, column: [:canonical_path]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141114110930) do
+ActiveRecord::Schema.define(version: 20141118121300) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,7 +29,7 @@ ActiveRecord::Schema.define(version: 20141114110930) do
   create_table "hits", force: true do |t|
     t.integer "host_id",                  null: false
     t.string  "path",        limit: 2048, null: false
-    t.string  "path_hash",   limit: 40,   null: false
+    t.string  "path_hash",   limit: 40
     t.string  "http_status", limit: 3,    null: false
     t.integer "count",                    null: false
     t.date    "hit_on",                   null: false
@@ -58,8 +58,8 @@ ActiveRecord::Schema.define(version: 20141114110930) do
     t.string  "canonical_path", limit: 2048
   end
 
-  add_index "host_paths", ["c14n_path_hash"], name: "index_host_paths_on_c14n_path_hash", using: :btree
-  add_index "host_paths", ["host_id", "path_hash"], name: "index_host_paths_on_host_id_and_path_hash", unique: true, using: :btree
+  add_index "host_paths", ["canonical_path"], name: "index_host_paths_on_canonical_path", using: :btree
+  add_index "host_paths", ["host_id", "path"], name: "index_host_paths_on_host_id_and_path", unique: true, using: :btree
   add_index "host_paths", ["mapping_id"], name: "index_host_paths_on_mapping_id", using: :btree
 
   create_table "hosts", force: true do |t|
@@ -90,7 +90,7 @@ ActiveRecord::Schema.define(version: 20141114110930) do
   create_table "mappings", force: true do |t|
     t.integer "site_id",                                      null: false
     t.string  "path",            limit: 2048,                 null: false
-    t.string  "path_hash",       limit: 40,                   null: false
+    t.string  "path_hash",       limit: 40
     t.text    "new_url"
     t.text    "suggested_url"
     t.text    "archive_url"

--- a/lib/transition/import/hits.rb
+++ b/lib/transition/import/hits.rb
@@ -98,8 +98,8 @@ module Transition
       postgreSQL
 
       INSERT_FROM_STAGING = <<-postgreSQL
-        INSERT INTO hits (host_id, path, path_hash, http_status, count, hit_on)
-        SELECT h.id, st.path, encode(digest(st.path, 'sha1'), 'hex'), st.http_status, st.count, st.hit_on
+        INSERT INTO hits (host_id, path, http_status, count, hit_on)
+        SELECT h.id, st.path, st.http_status, st.count, st.hit_on
         FROM   hits_staging st
         INNER JOIN hosts h on h.hostname = st.hostname
         WHERE LENGTH(st.path) <= 2048

--- a/lib/transition/import/mappings_from_host_paths.rb
+++ b/lib/transition/import/mappings_from_host_paths.rb
@@ -10,7 +10,7 @@ module Transition
           Transition::History.as_a_user(user) do
             site_paths = site.host_paths
               .select('MIN(host_paths.path) AS path')
-              .where('mapping_id is null').group('c14n_path_hash').map(&:path)
+              .where('mapping_id is null').group('canonical_path').map(&:path)
 
             site_paths.each do |uncanonicalized_path|
               # Try to create them (there may be duplicates in the set and they may

--- a/lib/transition/import/whitehall/mappings_csv.rb
+++ b/lib/transition/import/whitehall/mappings_csv.rb
@@ -34,7 +34,7 @@ module Transition
                 Rails.logger.warn("Skipping mapping for unknown host in Whitehall URL CSV: '#{old_uri.host}'")
               else
                 canonical_path = host.site.canonical_path(row['Old URL'])
-                existing_mapping = host.site.mappings.where(path_hash: path_hash(canonical_path)).first
+                existing_mapping = host.site.mappings.where(path: canonical_path).first
 
                 if existing_mapping
                     if existing_mapping.type == 'archive' ||
@@ -52,10 +52,6 @@ module Transition
 
         def hosts_by_hostname
           @_hosts ||= Host.all.inject({}) { |accumulator,host| accumulator.merge(host.hostname => host) }
-        end
-
-        def path_hash(canonical_path)
-          Digest::SHA1.hexdigest(canonical_path)
         end
       end
     end

--- a/spec/lib/transition/import/hits_mappings_relations_spec.rb
+++ b/spec/lib/transition/import/hits_mappings_relations_spec.rb
@@ -49,8 +49,6 @@ describe Transition::Import::HitsMappingsRelations do
     describe 'The first HostPath' do
       subject { HostPath.where(path: '/this/Exists?and=can&canonicalize=1&significant=1').first }
 
-      its(:path_hash)      { should eql(Digest::SHA1.hexdigest('/this/Exists?and=can&canonicalize=1&significant=1')) }
-      its(:c14n_path_hash) { should eql(Digest::SHA1.hexdigest('/this/exists?significant=1')) }
       its(:canonical_path) { should eql('/this/exists?significant=1') }
     end
 

--- a/spec/lib/transition/import/hits_spec.rb
+++ b/spec/lib/transition/import/hits_spec.rb
@@ -45,7 +45,6 @@ describe Transition::Import::Hits do
         its(:hit_on)    { should eql(Date.new(2012, 10, 14)) }
         its(:count)     { should eql(21) }
         its(:path)      { should eql('/') }
-        its(:path_hash) { should eql('42099b4af021e53fd8fd4e056c2568d7c2e3ffa8') }
       end
     end
 

--- a/spec/lib/transition/import/mappings_from_host_paths_spec.rb
+++ b/spec/lib/transition/import/mappings_from_host_paths_spec.rb
@@ -36,7 +36,6 @@ describe Transition::Import::MappingsFromHostPaths do
       subject { @site.mappings.first }
 
       its(:path)        { should eql('/foo') }
-      its(:path_hash)   { should eql(@host_path.c14n_path_hash) }
       its(:type)        { should eql('unresolved') }
     end
 

--- a/spec/models/hit_spec.rb
+++ b/spec/models/hit_spec.rb
@@ -8,7 +8,6 @@ describe Hit do
   describe 'validations' do
     it { should validate_presence_of(:host) }
     it { should validate_presence_of(:path) }
-    it { should validate_presence_of(:path_hash) }
     it { should validate_presence_of(:count) }
     it { should validate_numericality_of(:count).is_greater_than_or_equal_to(0) }
   end
@@ -17,7 +16,6 @@ describe Hit do
     subject { create :hit, hit_on: DateTime.new(2014, 12, 31, 23, 59, 59) }
 
     its(:hit_on)    { should eql(DateTime.new(2014, 12, 31, 0, 0, 0)) }
-    its(:path_hash) { should eql('ce81157034ae8c32f429d3dc03bed10cc0c47b65') }
   end
 
   describe '#homepage?' do

--- a/spec/models/host_path_spec.rb
+++ b/spec/models/host_path_spec.rb
@@ -12,7 +12,6 @@ describe HostPath do
     end
 
     its(:path)           { should eql(uncanonicalized_path) }
-    its(:path_hash)      { should eql(Digest::SHA1.hexdigest(uncanonicalized_path)) }
-    its(:c14n_path_hash) { should eql(Digest::SHA1.hexdigest(canonicalized_path)) }
+    its(:canonical_path) { should eql(canonicalized_path)   }
   end
 end

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -179,14 +179,6 @@ describe Host do
           host_path = runaway_host.host_paths.find_by_path(hit.path)
           host_path.mapping.should eql(nil)
         end
-
-        it 're-generates the c14n_path_hash' do
-          host_path = runaway_host.host_paths.find_by_path(hit.path)
-
-          # significant_on_first_site is not significant on the new site
-          new_path_hash = Digest::SHA1.hexdigest('/some-path')
-          host_path.c14n_path_hash.should eql(new_path_hash)
-        end
       end
 
       context 'mappings for the same paths exist on the new site' do
@@ -207,7 +199,7 @@ describe Host do
 
           host_path = runaway_host.host_paths.find_by_path(hit.path)
           host_path.mapping.should eql(other_mapping)
-          host_path.c14n_path_hash.should_not be_nil
+          host_path.canonical_path.should_not be_nil
         end
 
         it 'sets the hit count on the mappings which now have hits' do

--- a/spec/models/mapping_spec.rb
+++ b/spec/models/mapping_spec.rb
@@ -271,7 +271,6 @@ describe Mapping do
     end
 
     its(:path)        { should eql(canonicalized_path) }
-    its(:path_hash)   { should eql(Digest::SHA1.hexdigest(canonicalized_path)) }
 
     describe 'the linkage to hits' do
       let!(:hit_on_uncanonicalized) { create :hit, path: uncanonicalized_path, host: site.default_host }


### PR DESCRIPTION
We are now using the `path` and `canonical_path` fields throughout the app, instead of the hashed variants, which we needed because of MySQL limitations.

We've flipped the index in the `host_paths` table to use the `path` field, and declared the hash variants as nullable throughout. We're not removing the columns yet, so that we don't break existing processes that try to write to them; we'll do that in a subsequent migration.

We also need to index the `canonical_path` field, to replace the index on `c14n_path_hash`.

This mostly reverts commit 52f0b9fc800a62468ee25d57fe95dec765d1fdc1.
