### PR TITLE
Make migration slightly more robust

### DIFF
--- a/db/migrate/20141114110930_populate_host_paths_canonical_path.rb
+++ b/db/migrate/20141114110930_populate_host_paths_canonical_path.rb
@@ -2,6 +2,8 @@ class PopulateHostPathsCanonicalPath < ActiveRecord::Migration
   include ActionView::Helpers::DateHelper
 
   def up
+    Site.reset_column_information
+
     record_offset = 0
     batch_size    = 5000
     total_records = HostPath.where(canonical_path: nil).count


### PR DESCRIPTION
For some reason, when I dropped and migrated my database from scratch, this
migration would fail because it was using column definitions for the Site
table which changed some time ago. Defining local copies of the models didn't
fix the problem.
