### PR TITLE
Stop using pgcrypto extension

### DIFF
--- a/db/migrate/20141120164444_drop_pgcrypto.rb
+++ b/db/migrate/20141120164444_drop_pgcrypto.rb
@@ -1,0 +1,9 @@
+class DropPgcrypto < ActiveRecord::Migration
+  def up
+    disable_extension 'pgcrypto'
+  end
+
+  def down
+    enable_extension 'pgcrypto'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,11 +11,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141119113045) do
+ActiveRecord::Schema.define(version: 20141120164444) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "pgcrypto"
 
   create_table "daily_hit_totals", force: true do |t|
     t.integer "host_id",               null: false

--- a/lib/tasks/db/create.rake
+++ b/lib/tasks/db/create.rake
@@ -1,9 +1,0 @@
-namespace :db do
-  # We need the pgcrypto extension, which can only be enabled by a superuser.
-  # We'd rather not have the app using a superuser role, so shell out and use
-  # the postgres user instead.
-  task :create do
-    database_name = Rails.configuration.database_configuration[Rails.env]['database']
-    system("sudo -u postgres psql -d #{database_name} -c 'CREATE EXTENSION IF NOT EXISTS pgcrypto'")
-  end
-end


### PR DESCRIPTION
Now that we've got rid of path_hash entirely, we don't need this
extension. Even though there's a migration here to drop it, we need
to remove the extension from Puppet and make sure that it is dropped
in all environments by hand before we deploy this. Otherwise the
migration will fail because the transition Postgres role isn't a
superuser. We had a migration to enable this extension, so should
have one to remove it too, even though it isn't much use to us.
