### PR TITLE
Remove out-of-date database.travis.yml

### DIFF
--- a/config/database.travis.yml
+++ b/config/database.travis.yml
@@ -1,8 +1,0 @@
-test:
-  adapter: mysql2
-  host: localhost
-  database: transition_test
-  username: transition
-  password: transition
-  encoding: utf8
-  pool: 5


### PR DESCRIPTION
We aren't using either Travis or MySQL any more.
