### PR TITLE
Stop truncating ex-MyISAM tables in tests

### DIFF
--- a/spec/controllers/mappings_controller_spec.rb
+++ b/spec/controllers/mappings_controller_spec.rb
@@ -13,7 +13,7 @@ describe MappingsController do
       login_as_stub_user
     end
 
-    describe 'sorting', truncate_everything: true do
+    describe 'sorting' do
       let(:site)     { create :site, :with_mappings_and_hits }
 
       context 'in the absence of a sort parameter' do

--- a/spec/lib/transition/google/ingester_spec.rb
+++ b/spec/lib/transition/google/ingester_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'transition/google/url_ingester'
 
-describe Transition::Google::UrlIngester, truncate_everything: true do
+describe Transition::Google::UrlIngester do
   TOO_FEW = 9
   let(:hostpath_rows) {[
     ['dpm.gov.uk', '/path', 30],

--- a/spec/lib/transition/import/hits_mappings_relations_spec.rb
+++ b/spec/lib/transition/import/hits_mappings_relations_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'transition/import/hits_mappings_relations'
 
 describe Transition::Import::HitsMappingsRelations do
-  describe '.refresh!', truncate_everything: true do
+  describe '.refresh!' do
     before do
       @host = create :host, site: create(:site_without_host, query_params: 'significant')
       @site = @host.site

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -150,7 +150,7 @@ describe Host do
   end
 
   describe 'moving to a different site' do
-    context 'there are related mappings, host_paths and hits', truncate_everything: true do
+    context 'there are related mappings, host_paths and hits' do
       let!(:site)          { create(:site, query_params: 'significant_on_first_site') }
       let!(:other_site)    { create(:site) }
       let!(:runaway_host)  { create(:host, site: site) }

--- a/spec/models/mapping_spec.rb
+++ b/spec/models/mapping_spec.rb
@@ -261,7 +261,7 @@ describe Mapping do
     end
   end
 
-  describe 'path canonicalization and relation to hits', truncate_everything: true do
+  describe 'path canonicalization and relation to hits' do
     let(:uncanonicalized_path) { '/A/b/c?significant=1&really-significant=2&insignificant=2' }
     let(:canonicalized_path)   { '/a/b/c?really-significant=2&significant=1' }
     let(:site)                 { create(:site, query_params: 'significant:really-significant')}

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -51,7 +51,7 @@ describe Site do
   end
 
   describe 'changing query_params' do
-    context 'there are related mappings, host_paths and hits', truncate_everything: true do
+    context 'there are related mappings, host_paths and hits' do
       let!(:host)          { create(:host, site: create(:site, query_params: 'initial')) }
       let!(:site)          { host.site }
       let!(:hit)           { create(:hit, path: '/this/Exists?added_later=2&initial=1', host: host) }
@@ -236,7 +236,7 @@ describe Site do
     end
   end
 
-  describe '#hit_total_count', truncate_everything: true do
+  describe '#hit_total_count' do
     let(:site) { create :site }
 
     subject    { site.hit_total_count }

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -11,16 +11,6 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :transaction
   end
 
-  ##
-  # For tests that are using MySQL DDE, i.e. anything with an
-  # import/ingest using LOAD DATA LOCAL INFILE
-  # *OR* any test using a myISAM table for which you need
-  # the table to be in a known state per-test I.E. HITS
-  config.before(:each, :truncate_everything => true) do
-    DatabaseCleaner.strategy = :truncation
-    DatabaseCleaner.clean
-  end
-
   config.before(:each, :js => true) do
     DatabaseCleaner.strategy = :truncation
     DatabaseCleaner.clean


### PR DESCRIPTION
We were doing this on MySQL because the hits tables were using MyISAM,
which doesn't support transactions (which are the default strategy for
`database_cleaner`). There shouldn't be any reason to do this on PostgreSQL,
so let's stop.

For some tests which have a lot of setup, we have been using `testing_before_all`
to indicate that their test data should be cleaned up only once at
the end, and with truncation, to speed up test runs. This commit assumes that:
- that's still a good thing to do for those cases;
- we have always been consistent about using `truncate_everything`
  for only MyISAM reasons, and `testing_before_all` for tests with lots
  of data.
