### PR TITLE
Make the "invalid authenticity token" 403 error pretty like the others

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,8 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
 
   rescue_from ActionController::InvalidAuthenticityToken do
-    render text: "Invalid authenticity token", status: 403
+    render_error(403,
+                 body: "Invalid authenticity token")
   end
 
   def user_for_paper_trail

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -7,6 +7,10 @@ class ErrorsController < ActionController::Base
     error_response(400, "Bad Request")
   end
 
+  def error_403
+    error_response(403, "403 Forbidden")
+  end
+
   def error_404
     error_response(404, "404 Not Found")
   end

--- a/app/views/errors/error_403.html.erb
+++ b/app/views/errors/error_403.html.erb
@@ -1,0 +1,6 @@
+<% content_for(:page_title, '403') %>
+
+<h1 class="page-title">
+  <%= @custom_header || 'Forbidden' %>
+</h1>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Transition::Application.routes.draw do
   resources :glossary, only: [:index]
 
   match '/400' => 'errors#error_400', via: [:get, :post]
+  match '/403' => 'errors#error_403', via: [:get, :post]
   match '/404' => 'errors#error_404', via: [:get, :post]
   match '/422' => 'errors#error_422', via: [:get, :post]
   match '/500' => 'errors#error_500', via: [:get, :post]

--- a/spec/controllers/bulk_add_batches_controller_spec.rb
+++ b/spec/controllers/bulk_add_batches_controller_spec.rb
@@ -141,7 +141,6 @@ describe BulkAddBatchesController do
       subject.stub(:verified_request?).and_return(false)
       post :import, site_id: mapping.site, id: batch.id
       response.status.should eql(403)
-      response.body.should eql('Invalid authenticity token')
     end
   end
 

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -16,6 +16,42 @@ describe ErrorsController do
     end
   end
 
+  describe '#error_403' do
+    before do
+      get :error_403
+    end
+
+    it 'responds with the correct HTTP status code' do
+      expect(response.status).to be(403)
+    end
+
+    it 'renders our custom error page' do
+      expect(response).to render_template 'errors/error_403'
+    end
+
+    it 'uses the error page layout' do
+      expect(response).to render_template 'layouts/error_page'
+    end
+
+    it 'includes the friendly message' do
+      expect(response.body).to include('Forbidden')
+    end
+
+    context 'when requesting JSON' do
+      before do
+        get :error_403, format: 'json'
+        @parsed_response = JSON.parse(response.body)
+      end
+
+      it_behaves_like 'a JSON error'
+
+      it 'responds with the correct HTTP status code' do
+        expect(response.status).to be(403)
+      end
+    end
+
+  end
+
   describe '#error_404' do
     before do
       get :error_404

--- a/spec/controllers/mappings_controller_spec.rb
+++ b/spec/controllers/mappings_controller_spec.rb
@@ -547,7 +547,6 @@ describe MappingsController do
       post :update, site_id: mapping.site, id: mapping.id,
               mapping: { path: '/foo' }
       response.status.should eql(403)
-      response.body.should eql('Invalid authenticity token')
     end
   end
 


### PR DESCRIPTION
- Users *shouldn't* see this, so don't include any extra information.

![screen shot 2014-12-18 at 12 16 34](https://cloud.githubusercontent.com/assets/355033/5487962/c3702a58-86af-11e4-8a07-c7c2f1440051.png)
