### PR TITLE
Update the whitelist request email address to reflect the new teams

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -63,6 +63,6 @@ module Transition
     config.assets.precompile += %w(html5.js)
     config.assets.precompile += %w(respond.min.js)
 
-    config.support_email = 'transition-dev@digital.cabinet-office.gov.uk'
+    config.support_email = 'govuk-core-team@digital.cabinet-office.gov.uk'
   end
 end

--- a/spec/models/bulk_add_batch_spec.rb
+++ b/spec/models/bulk_add_batch_spec.rb
@@ -57,7 +57,7 @@ describe BulkAddBatch do
         subject(:mappings_batch) { build(:bulk_add_batch, type: 'redirect', new_url: 'http://bad.com') }
 
         it 'errors and asks for a whitelisted one' do
-          mappings_batch.errors[:new_url].should include('The URL to redirect to must be on a whitelisted domain. Contact transition-dev@digital.cabinet-office.gov.uk for more information.')
+          mappings_batch.errors[:new_url].should include('The URL to redirect to must be on a whitelisted domain. Contact govuk-core-team@digital.cabinet-office.gov.uk for more information.')
         end
       end
 

--- a/spec/models/import_batch_spec.rb
+++ b/spec/models/import_batch_spec.rb
@@ -116,7 +116,7 @@ describe ImportBatch do
 
         before { mappings_batch.should_not be_valid }
         it 'should declare it invalid' do
-          mappings_batch.errors[:new_urls].should include('The URL to redirect to must be on a whitelisted domain. Contact transition-dev@digital.cabinet-office.gov.uk for more information.')
+          mappings_batch.errors[:new_urls].should include('The URL to redirect to must be on a whitelisted domain. Contact govuk-core-team@digital.cabinet-office.gov.uk for more information.')
         end
       end
 

--- a/spec/models/mapping_spec.rb
+++ b/spec/models/mapping_spec.rb
@@ -128,7 +128,7 @@ describe Mapping do
           subject(:mapping) { build(:redirect, new_url: 'http://m.com/foo') }
 
           it 'fails' do
-            mapping.errors[:new_url].should == ['must be on a whitelisted domain. Contact transition-dev@digital.cabinet-office.gov.uk for more information.']
+            mapping.errors[:new_url].should == ['must be on a whitelisted domain. Contact govuk-core-team@digital.cabinet-office.gov.uk for more information.']
           end
         end
 


### PR DESCRIPTION
- For the moment, set this to be govuk-core-team@ instead of
  2nd-line-support@, or transition-dev@ as it was before, to avoid
  these requests only being dealt with by people subscribed to the now
  disbanded Transition Tool development team list - Jamie, Jenny, me,
  etc.

Hopefully soon we'll get around to writing some documentation in the opsmanual for this process and why it is like it is, so that 2nd line can take it on...

(cc @jamiecobbett, @jennyd)