### PR TITLE
Strip trailing whitespace from hosts added to the whitelist

### DIFF
--- a/app/models/whitelisted_host.rb
+++ b/app/models/whitelisted_host.rb
@@ -4,6 +4,7 @@ class WhitelistedHost < ActiveRecord::Base
   before_save :ensure_papertrail_user_config
 
   before_validation { hostname.try(:downcase!) }
+  before_validation { hostname.try(:strip!) }
   validates :hostname, presence: true
   validates :hostname, hostname: true
   validates :hostname, uniqueness: { message: 'is already in the list' }

--- a/spec/models/whitelisted_host_spec.rb
+++ b/spec/models/whitelisted_host_spec.rb
@@ -23,6 +23,18 @@ describe WhitelistedHost do
           whitelisted_host.errors_on(:hostname).should include('cannot end in .gov.uk or .mod.uk - these are automatically whitelisted')
         end
       end
+
+      context 'is valid' do
+        subject(:whitelisted_host) { build(:whitelisted_host, hostname: 'B.com ') }
+
+        its(:valid?) { should be_true }
+        it 'should strip whitespace and downcase the hostname' do
+          # This processing is done in before_validation callbacks, so we need
+          # to trigger validation first:
+          whitelisted_host.valid?
+          whitelisted_host.hostname.should eq('b.com')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
- Upon accidentally adding a host with trailing whitespace this morning, thanks to a failed copy/paste, I realised that the whitelist let it through without stripping the whitespace or erroring. Make it strip the whitespace from the hostname, so that people and Bouncer don't get confused or match on the wrong thing.