### PR TITLE
Add *.nhs.uk as an automatically allowed ending for a hostname

### DIFF
--- a/app/models/whitelisted_host.rb
+++ b/app/models/whitelisted_host.rb
@@ -16,8 +16,8 @@ class WhitelistedHost < ActiveRecord::Base
 
   def hostname_is_not_automatically_allowed_anyway
     return if hostname.nil?
-    if hostname.end_with?('.gov.uk') || hostname.end_with?('.mod.uk')
-      errors.add(:hostname, 'cannot end in .gov.uk or .mod.uk - these are automatically whitelisted')
+    if hostname.end_with?('.gov.uk') || hostname.end_with?('.mod.uk') || hostname.end_with?('.nhs.uk')
+      errors.add(:hostname, 'cannot end in .gov.uk, .mod.uk or .nhs.uk - these are automatically whitelisted')
     end
   end
 end

--- a/spec/models/whitelisted_host_spec.rb
+++ b/spec/models/whitelisted_host_spec.rb
@@ -20,7 +20,7 @@ describe WhitelistedHost do
 
         its(:valid?) { should be_false }
         it 'should have an error' do
-          whitelisted_host.errors_on(:hostname).should include('cannot end in .gov.uk or .mod.uk - these are automatically whitelisted')
+          whitelisted_host.errors_on(:hostname).should include('cannot end in .gov.uk, .mod.uk or .nhs.uk - these are automatically whitelisted')
         end
       end
 


### PR DESCRIPTION
- Like we do for *.gov.uk and *.mod.uk, *.nhs.uk should not need
  whitelisting. We were getting many requests for *.nhs.uk domains to
  be whitelisted, from PHE's transition, and it's easier to deal with
  them globally than have them ask us to add yet another to the
  whitelist when they find one.