### PR TITLE
Allow adding mappings to *.nhs.uk hosts

### DIFF
--- a/app/validators/host_in_whitelist_validator.rb
+++ b/app/validators/host_in_whitelist_validator.rb
@@ -10,7 +10,7 @@ class HostInWhitelistValidator < ActiveModel::EachValidator
   def in_whitelist?(url)
     uri = Addressable::URI.parse(url)
     return false if uri.host.nil?
-    uri.host.end_with?('.gov.uk') || uri.host.end_with?('.mod.uk') || WhitelistedHost.exists?(hostname: uri.host)
+    uri.host.end_with?('.gov.uk') || uri.host.end_with?('.mod.uk') || uri.host.end_with?('.nhs.uk') || WhitelistedHost.exists?(hostname: uri.host)
   rescue Addressable::URI::InvalidURIError
   end
 end

--- a/app/views/admin/whitelisted_hosts/index.html.erb
+++ b/app/views/admin/whitelisted_hosts/index.html.erb
@@ -4,7 +4,7 @@
   <h1>
     Redirection whitelist<br/>
     <small>
-      You can only create redirects if they go to a domain on this list or the domain ends in .gov.uk or .mod.uk.
+      You can only create redirects if they go to a domain on this list or the domain ends in .gov.uk, .mod.uk or .nhs.uk.
     </small>
   </h1>
 </div>

--- a/features/whitelist.feature
+++ b/features/whitelist.feature
@@ -1,7 +1,7 @@
 Feature: Whitelist
   As a Transition Admin,
   I would like to see a whitelist of sites
-  So that I can see which sites we're redirecting to outside of .gov.uk or .mod.uk
+  So that I can see which sites we're redirecting to outside of .gov.uk, .mod.uk or .nhs.uk
 
   Scenario: Visit the whitelist page as an admin
     Given I have logged in as an admin

--- a/lib/transition/path_or_url.rb
+++ b/lib/transition/path_or_url.rb
@@ -11,6 +11,7 @@ module Transition
         .info
         .mod.uk
         .net
+        .nhs.uk
         .org
         .org.uk
         .police.uk

--- a/spec/models/mapping_spec.rb
+++ b/spec/models/mapping_spec.rb
@@ -151,6 +151,12 @@ describe Mapping do
           it { should be_valid }
         end
 
+        context 'is on *.nhs.uk' do
+          subject(:mapping) { build(:redirect, new_url: 'http://m.nhs.uk/foo') }
+
+          it { should be_valid }
+        end
+
         context 'mapping is not a redirect' do
           subject(:mapping) { build(:archived, new_url: 'http://evil.com') }
 


### PR DESCRIPTION
- This is needed otherwise the validations of whitelisted hosts disallow mappings to be added for, for example, `somethingnotexplicitlywhitelistedyet.nhs.uk` A good spot by Jenny pre-deploy of https://github.com/alphagov/transition/pull/485. :sunny: