### PR TITLE
Remove the specific *.nhs.uk hosts from the whitelist list

### DIFF
--- a/db/migrate/20150320164433_remove_individual_nhsuk_domains_from_whitelist.rb
+++ b/db/migrate/20150320164433_remove_individual_nhsuk_domains_from_whitelist.rb
@@ -1,0 +1,12 @@
+class RemoveIndividualNhsukDomainsFromWhitelist < ActiveRecord::Migration
+  def up
+    WhitelistedHost.where("hostname LIKE '%.nhs.uk'").each do |whitelisted_host|
+      whitelisted_host.destroy
+    end
+  end
+
+  def down
+    # Nothing here given we don't want to put back domains that don't
+    # need to be explicitly whitelisted.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141120164444) do
+ActiveRecord::Schema.define(version: 20150320164433) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
- Anything ending in .nhs.uk is now automatically whitelisted. See
  https://github.com/alphagov/transition/pull/485 and
  https://github.com/alphagov/transition/pull/486. This is the tidying
  up migration to remove the hosts we'd manually added to the
  whitelist before we made the global change.