### PR TITLE
Update the whitelist and support request email address to cite Zendesk

### DIFF
--- a/app/models/bulk_add_batch.rb
+++ b/app/models/bulk_add_batch.rb
@@ -16,8 +16,7 @@ class BulkAddBatch < MappingsBatch
     redirect.validates :new_url, length: { maximum: 2048 }
     redirect.validates :new_url, non_blank_url: { message: I18n.t('mappings.bulk.new_url_invalid') }
     redirect.validates :new_url, host_in_whitelist: {
-      message: I18n.t('mappings.bulk.new_url_must_be_on_whitelist',
-      email: Rails.configuration.support_email)
+      message: I18n.t('mappings.bulk.new_url_must_be_on_whitelist')
     }
     redirect.validates :new_url, not_a_national_archives_url: {
       message: I18n.t('mappings.bulk.new_url_must_not_be_on_tna')

--- a/app/models/import_batch.rb
+++ b/app/models/import_batch.rb
@@ -28,8 +28,7 @@ class ImportBatch < MappingsBatch
   }
   validates :new_urls, each_in_collection: {
     validator: HostInWhitelistValidator,
-    message: I18n.t('mappings.bulk.new_url_must_be_on_whitelist',
-      email: Rails.configuration.support_email)
+    message: I18n.t('mappings.bulk.new_url_must_be_on_whitelist')
   }
 
   after_create :create_entries

--- a/app/validators/host_in_whitelist_validator.rb
+++ b/app/validators/host_in_whitelist_validator.rb
@@ -2,7 +2,7 @@ class HostInWhitelistValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return if value.blank?
     unless in_whitelist?(value)
-      message = (options[:message] || "must be on a whitelisted domain. Contact #{Rails.configuration.support_email} for more information.")
+      message = (options[:message] || "must be on a whitelisted domain. <a href='https://support.production.alphagov.co.uk/general_request/new'>Raise a support request through the GOV.UK Support form</a> for more information.")
       record.errors.add(attribute, message)
     end
   end

--- a/app/views/errors/error_503.html.erb
+++ b/app/views/errors/error_503.html.erb
@@ -7,5 +7,5 @@
   <p><%= @custom_body %></p>
 <% else %>
   <p>Transition is unavailable due to scheduled maintenance</p>
-  <p><a href="mailto:<%= Rails.configuration.support_email %>">Contact us</a> for more information</p>
+  <p><a href='https://support.production.alphagov.co.uk/general_request/new'>Raise a support request through the GOV.UK Support form</a> for more information</p>
 <% end %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,11 +1,11 @@
 <% if error_messages.present? %>
   <div class="alert alert-danger">
     <% if error_messages.size == 1 %>
-      <p><%= error_messages.first %></p>
+      <p><%= error_messages.first.html_safe %></p>
     <% else %>
       <ul>
         <% error_messages.each do |message| %>
-          <li><%= message %></li>
+          <li><%= message.html_safe %></li>
         <% end %>
       </ul>
     <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -62,7 +62,5 @@ module Transition
     config.assets.version = '1.0'
     config.assets.precompile += %w(html5.js)
     config.assets.precompile += %w(respond.min.js)
-
-    config.support_email = 'transition-dev@digital.cabinet-office.gov.uk'
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,7 +31,7 @@ en:
     bulk:
       type_invalid: 'Please select either redirect, archive or unresolved'
       new_url_invalid: 'Enter a valid URL to redirect to'
-      new_url_must_be_on_whitelist: 'The URL to redirect to must be on a whitelisted domain. Contact %{email} for more information.'
+      new_url_must_be_on_whitelist: "The URL to redirect to must be on a whitelisted domain. <a href='https://support.production.alphagov.co.uk/general_request/new'>Raise a support request through the GOV.UK Support form</a> for more information."
       new_url_must_not_be_on_tna: 'You must use an archive mapping to link to the National Archives, not a redirect'
       edit:
         mappings_empty: 'No mappings were selected'

--- a/features/mapping_edit.feature
+++ b/features/mapping_edit.feature
@@ -57,6 +57,13 @@ Feature: Edit a site's mapping
     Then I should still be editing a mapping
     And I should see "The URL to redirect to is not a URL"
 
+  Scenario: Error when trying to redirect to a host not on the whitelist
+    When I make the mapping a redirect to "http://not-on-whitelist.com"
+    And I save the mapping
+    Then I should still be editing a mapping
+    And I should see "The URL to redirect to must be on a whitelisted domain. Raise a support request through the GOV.UK Support form for more information."
+    And "Raise a support request through the GOV.UK Support form" should be a link
+
   Scenario: Error when trying to redirect to the National Archives
     When I make the mapping a redirect to http://webarchive.nationalarchives.gov.uk/mapping
     And I save the mapping

--- a/features/step_definitions/mappings_assertion_steps.rb
+++ b/features/step_definitions/mappings_assertion_steps.rb
@@ -84,6 +84,12 @@ Then(/^the archive URL field should be empty$/) do
   field_labeled('Alternative National Archives URL').value.should be_empty
 end
 
+And(/^"Raise a support request through the GOV.UK Support form" should be a link$/) do
+  within 'div.alert.alert-danger' do
+    expect(page).to have_selector('a')
+  end
+end
+
 But(/^I should see help for the unresolved status$/) do
   within '[data-module="toggle-mapping-form-fields"]' do
     expect(page).to have_selector('.js-for-unresolved')

--- a/spec/models/bulk_add_batch_spec.rb
+++ b/spec/models/bulk_add_batch_spec.rb
@@ -57,7 +57,7 @@ describe BulkAddBatch do
         subject(:mappings_batch) { build(:bulk_add_batch, type: 'redirect', new_url: 'http://bad.com') }
 
         it 'errors and asks for a whitelisted one' do
-          mappings_batch.errors[:new_url].should include('The URL to redirect to must be on a whitelisted domain. Contact transition-dev@digital.cabinet-office.gov.uk for more information.')
+          mappings_batch.errors[:new_url].should include("The URL to redirect to must be on a whitelisted domain. <a href='https://support.production.alphagov.co.uk/general_request/new'>Raise a support request through the GOV.UK Support form</a> for more information.")
         end
       end
 

--- a/spec/models/import_batch_spec.rb
+++ b/spec/models/import_batch_spec.rb
@@ -116,7 +116,7 @@ describe ImportBatch do
 
         before { mappings_batch.should_not be_valid }
         it 'should declare it invalid' do
-          mappings_batch.errors[:new_urls].should include('The URL to redirect to must be on a whitelisted domain. Contact transition-dev@digital.cabinet-office.gov.uk for more information.')
+          mappings_batch.errors[:new_urls].should include("The URL to redirect to must be on a whitelisted domain. <a href='https://support.production.alphagov.co.uk/general_request/new'>Raise a support request through the GOV.UK Support form</a> for more information.")
         end
       end
 

--- a/spec/models/mapping_spec.rb
+++ b/spec/models/mapping_spec.rb
@@ -128,7 +128,7 @@ describe Mapping do
           subject(:mapping) { build(:redirect, new_url: 'http://m.com/foo') }
 
           it 'fails' do
-            mapping.errors[:new_url].should == ['must be on a whitelisted domain. Contact transition-dev@digital.cabinet-office.gov.uk for more information.']
+            mapping.errors[:new_url].should == ["must be on a whitelisted domain. <a href='https://support.production.alphagov.co.uk/general_request/new'>Raise a support request through the GOV.UK Support form</a> for more information."]
           end
         end
 


### PR DESCRIPTION
- The team behind the transition-dev@ mailing list was dissolved a few
  months ago in the GOV.UK restructure. The email address is still
  active and they still receive sporadic whitelist requests for
  domains. These requests are now fielded via second-line support, and
  so should go to Zendesk. Given that people using the Transition Tool
  are inside government departments or agencies, they should know what
  Zendesk is and how to send queries via it, without us having to link
  explicitly to it.