### PR TITLE
Allow defining custom archive URLs in a bulk import

### DIFF
--- a/app/helpers/versions_helper.rb
+++ b/app/helpers/versions_helper.rb
@@ -25,7 +25,7 @@ module VersionsHelper
       friendly_changeset_title_for_type(changeset['type'][1])
     elsif changeset.length == 1
       first = changeset.first[0].titleize
-      first = 'Alternative Archive URL' if first == 'Archive URL'
+      first = 'Custom Archive URL' if first == 'Archive URL'
       "#{first} updated"
     else
       "Multiple properties updated"
@@ -35,7 +35,7 @@ module VersionsHelper
   def friendly_field_name(field)
     case field
     when 'archive_url'
-      'Alternative Archive URL'
+      'Custom Archive URL'
     else
       field.titleize
     end

--- a/app/models/import_batch_entry.rb
+++ b/app/models/import_batch_entry.rb
@@ -4,6 +4,8 @@ class ImportBatchEntry < MappingsBatchEntry
   scope :archives,   -> { with_type('archive') }
   scope :unresolved, -> { with_type('unresolved') }
 
+  scope :with_custom_archive_urls, -> { archives.where("archive_url IS NOT NULL") }
+
   def redirect?
     type == 'redirect'
   end

--- a/app/models/mappings_batch.rb
+++ b/app/models/mappings_batch.rb
@@ -45,6 +45,7 @@ class MappingsBatch < ActiveRecord::Base
         mapping.path = entry.path
         mapping.type = entry.type
         mapping.new_url = entry.new_url
+        mapping.archive_url = entry.archive_url
         mapping.tag_list = [mapping.tag_list, tag_list].join(',')
         mapping.save
 

--- a/app/presenters/batch_preview_presenter.rb
+++ b/app/presenters/batch_preview_presenter.rb
@@ -11,6 +11,10 @@ class BatchPreviewPresenter
     @batch.entries.without_existing_mappings.archives.count
   end
 
+  def custom_archive_url_count
+    @batch.entries.with_custom_archive_urls.count
+  end
+
   def unresolved_count
     @batch.entries.without_existing_mappings.unresolved.count
   end

--- a/app/views/import_batches/preview.html.erb
+++ b/app/views/import_batches/preview.html.erb
@@ -27,7 +27,12 @@
   <h4 class="add-bottom-margin">Running this import will</h4>
   <ul class="list-group">
     <li class="list-group-item">Create <%= pluralize(@preview.redirect_count, 'new redirect') %></li>
-    <li class="list-group-item">Create <%= pluralize(@preview.archive_count, 'new archive') %></li>
+    <li class="list-group-item">
+      Create <%= pluralize(@preview.archive_count, 'new archive') %>
+      <% if @preview.custom_archive_url_count > 0 %>
+        (<%= pluralize(@preview.custom_archive_url_count, 'with custom URL') %>)
+      <% end %>
+    </li>
     <li class="list-group-item">Create <%= pluralize(@preview.unresolved_count, 'new unresolved mapping') %></li>
     <% if @preview.existing_mappings_count > 0 %>
       <li class="list-group-item list-group-item-warning js-overwrite-count">Overwrite <%= pluralize(@preview.existing_mappings_count, 'existing mapping') %></li>

--- a/app/views/mappings/_form.html.erb
+++ b/app/views/mappings/_form.html.erb
@@ -49,12 +49,12 @@
         <dt>National Archives</dt>
         <dd>
           <%= link_to @mapping.national_archive_url, @mapping.national_archive_url %><br />
-          <span class="text-muted">Is this archive missing? <a href="#add-alternative-url" class="if-no-js-hide link-muted js-toggle">Use an alternative</a></span>
+          <span class="text-muted">Is this archive missing? <a href="#add-custom-url" class="if-no-js-hide link-muted js-toggle">Use an alternative</a></span>
         </dd>
       </dl>
       <div class="add-bottom-margin js-toggle-target <% unless @mapping.archive_url %>if-js-hide<% end %>">
         <%= f.label :archive_url do %>
-          Alternative National Archives URL (<%= link_to 'Find on the National Archives', @mapping.national_archive_index_url %>)
+          Custom National Archives URL (<%= link_to 'Find on the National Archives', @mapping.national_archive_index_url %>)
         <% end %>
         <div class="row">
           <div class="col-md-8">

--- a/db/migrate/20150715141152_add_archive_url_to_mappings_batch_entries.rb
+++ b/db/migrate/20150715141152_add_archive_url_to_mappings_batch_entries.rb
@@ -1,0 +1,5 @@
+class AddArchiveURLToMappingsBatchEntries < ActiveRecord::Migration
+  def change
+    add_column :mappings_batch_entries, :archive_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150429154045) do
+ActiveRecord::Schema.define(version: 20150715141152) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -107,6 +107,7 @@ ActiveRecord::Schema.define(version: 20150429154045) do
     t.string  "klass"
     t.string  "new_url",           limit: 2048
     t.string  "type"
+    t.string  "archive_url"
   end
 
   add_index "mappings_batch_entries", ["mappings_batch_id"], name: "index_mappings_batch_entries_on_mappings_batch_id", using: :btree

--- a/features/mapping_edit.feature
+++ b/features/mapping_edit.feature
@@ -36,10 +36,10 @@ Feature: Edit a site's mapping
     But I should see help for the unresolved status
 
   @javascript
-  Scenario: Adding an alternative archive URL
+  Scenario: Adding a custom archive URL
     When I make the mapping an archive
     And I click the link "Use an alternative"
-    Then I should see the National Archives link replaced with an alternative National Archives field
+    Then I should see the National Archives link replaced with a custom National Archives field
     When I enter an archive URL but then click "Cancel"
     Then I should see the National Archives link again
     When I click the link "Use an alternative"

--- a/features/mapping_import.feature
+++ b/features/mapping_import.feature
@@ -33,6 +33,14 @@ Feature: Import mappings
     And I should see that my unresolved mapping is there
     And we have recorded analytics that show that import with overwrite existing was used
 
+  Scenario: Importing archive mappings with and without custom URLs
+    Given I have logged in as a GDS Editor
+    And a site bis exists
+    And I visit the path /sites/bis
+    And I go to import some mappings
+    When I submit the form with a small CSV of archive mappings
+    Then I should see how many archive mappings will be created and how many have custom URLs
+
   @javascript
   Scenario: Successfully importing a larger batch of mappings
     Given I have logged in as a GDS Editor

--- a/features/step_definitions/mappings_assertion_steps.rb
+++ b/features/step_definitions/mappings_assertion_steps.rb
@@ -70,18 +70,18 @@ Then(/^I should not see archive fields$/) do
   end
 end
 
-Then(/^I should see the National Archives link replaced with an alternative National Archives field$/) do
+Then(/^I should see the National Archives link replaced with a custom National Archives field$/) do
   expect(page).to have_selector('#mapping_archive_url')
-  expect(page).not_to have_selector('a[href="#add-alternative-url"]')
+  expect(page).not_to have_selector('a[href="#add-custom-url"]')
 end
 
 Then(/^I should see the National Archives link again$/) do
   expect(page).not_to have_selector('#mapping_archive_url')
-  expect(page).to have_selector('a[href="#add-alternative-url"]')
+  expect(page).to have_selector('a[href="#add-custom-url"]')
 end
 
 Then(/^the archive URL field should be empty$/) do
-  field_labeled('Alternative National Archives URL').value.should be_empty
+  field_labeled('Custom National Archives URL').value.should be_empty
 end
 
 And(/^"Raise a support request through the GOV.UK Support form" should be a link$/) do

--- a/features/step_definitions/mappings_import_assertion_steps.rb
+++ b/features/step_definitions/mappings_import_assertion_steps.rb
@@ -11,6 +11,11 @@ Then(/^I should see how many of each type of mapping will be created$/) do
   }
 end
 
+Then(/^I should see how many archive mappings will be created and how many have custom URLs$/) do
+  steps %{
+    Then I should see "Create 3 new archives (2 with custom URLs)"
+  }
+end
 
 Then(/^I should see how many mappings will be overwritten$/) do
   steps %{

--- a/features/step_definitions/mappings_import_interaction_steps.rb
+++ b/features/step_definitions/mappings_import_interaction_steps.rb
@@ -25,6 +25,17 @@ When(/^I submit the form with a small valid CSV$/) do
   click_button 'Continue'
 end
 
+When(/^I submit the form with a small CSV of archive mappings$/) do
+  raw_csv = <<-CSV.strip_heredoc
+                        old url,new url
+                        /archive-me,TNA
+                        /archive-me-as-well,http://webarchive.nationalarchives.gov.uk/20120816224015/http://bis.gov.uk/about
+                        /dont-forget-me,http://webarchive.nationalarchives.gov.uk/20120816224015/http://bis.gov.uk/faq
+                      CSV
+  fill_in 'import_batch_raw_csv', with: raw_csv
+  click_button 'Continue'
+end
+
 When(/^I navigate away to the bis mappings page$/) do
   visit(site_mappings_path('bis'))
 end

--- a/features/step_definitions/mappings_interaction_steps.rb
+++ b/features/step_definitions/mappings_interaction_steps.rb
@@ -127,7 +127,7 @@ When(/^I make the new mapping paths "(.*?)" unresolved$/) do |paths|
 end
 
 When(/^I enter an archive URL but then click "Cancel"$/) do
-  fill_in 'Alternative National Archives URL', with: 'anything'
+  fill_in 'Custom National Archives URL', with: 'anything'
   click_link 'Cancel'
 end
 

--- a/lib/transition/import/csv/import_batch_row.rb
+++ b/lib/transition/import/csv/import_batch_row.rb
@@ -53,6 +53,10 @@ module Transition
           archive? && new_value && new_url_is_a_national_archives_url?
         end
 
+        def archive_without_custom_url?
+          archive? && !archive_with_custom_url?
+        end
+
         def redirect?
           type == 'redirect'
         end
@@ -67,6 +71,10 @@ module Transition
           elsif redirect?
             1
           elsif archive? && other.redirect?
+            -1
+          elsif archive_with_custom_url? && other.archive_without_custom_url?
+            1
+          elsif archive_without_custom_url? && other.archive_with_custom_url?
             -1
           elsif archive? && other.archive?
             other.line_number <=> line_number

--- a/lib/transition/import/csv/import_batch_row.rb
+++ b/lib/transition/import/csv/import_batch_row.rb
@@ -41,8 +41,16 @@ module Transition
           new_value if redirect?
         end
 
+        def archive_url
+          new_value if archive_with_custom_url?
+        end
+
         def archive?
           type == 'archive'
+        end
+
+        def archive_with_custom_url?
+          archive? && new_value && new_url_is_a_national_archives_url?
         end
 
         def redirect?

--- a/lib/transition/import/csv/import_batch_row.rb
+++ b/lib/transition/import/csv/import_batch_row.rb
@@ -68,6 +68,8 @@ module Transition
             1
           elsif archive? && other.redirect?
             -1
+          elsif archive? && other.archive?
+            other.line_number <=> line_number
           elsif archive?
             1
           else

--- a/spec/helpers/versions_helper_spec.rb
+++ b/spec/helpers/versions_helper_spec.rb
@@ -5,7 +5,7 @@ describe VersionsHelper do
   describe '#friendly_field_name' do
     specify { helper.friendly_field_name('type').should == 'Type' }
 
-    specify { helper.friendly_field_name('archive_url').should == 'Alternative Archive URL' }
+    specify { helper.friendly_field_name('archive_url').should == 'Custom Archive URL' }
 
     specify { helper.friendly_field_name('miscellaneous').should == 'Miscellaneous' }
   end
@@ -21,7 +21,7 @@ describe VersionsHelper do
   describe '#friendly_changeset_title' do
     specify { helper.friendly_changeset_title({'id' => 1}).should == 'Mapping created' }
 
-    specify { helper.friendly_changeset_title({'archive_url' => 1}).should == 'Alternative Archive URL updated' }
+    specify { helper.friendly_changeset_title({'archive_url' => 1}).should == 'Custom Archive URL updated' }
 
     specify { helper.friendly_changeset_title({'miscellaneous' => 1}).should == 'Miscellaneous updated' }
 

--- a/spec/lib/transition/import/csv/import_batch_row_spec.rb
+++ b/spec/lib/transition/import/csv/import_batch_row_spec.rb
@@ -166,6 +166,10 @@ describe Transition::Import::CSV::ImportBatchRow do
     let(:later_archive)  { make_a_row_with_line_number(2, '/old', 'TNA') }
     let(:unresolved)     { make_a_row('/old') }
 
+    let(:archive_url)           { 'http://webarchive.nationalarchives.gov.uk/*/http://a.com' }
+    let(:custom_archive)        { make_a_row('/old', archive_url) }
+    let(:later_custom_archive)  { make_a_row_with_line_number(2, '/old', archive_url) }
+
     context 'comparing rows for different paths' do
       it 'raises an error' do
         different_path = make_a_row('/different')
@@ -199,6 +203,18 @@ describe Transition::Import::CSV::ImportBatchRow do
       it 'trumps a later archive' do
         archive.should > later_archive
         later_archive.should < archive
+      end
+    end
+
+    context 'an archive with a custom URL' do
+      it 'trumps a regular archive' do
+        custom_archive.should > archive
+        archive.should < custom_archive
+      end
+
+      it 'trumps a later custom archive' do
+        custom_archive.should > later_custom_archive
+        later_custom_archive.should < custom_archive
       end
     end
   end

--- a/spec/lib/transition/import/csv/import_batch_row_spec.rb
+++ b/spec/lib/transition/import/csv/import_batch_row_spec.rb
@@ -163,6 +163,7 @@ describe Transition::Import::CSV::ImportBatchRow do
     let(:redirect)       { make_a_row('/old', 'https://a.gov.uk/new') }
     let(:later_redirect) { make_a_row_with_line_number(2, '/old', 'https://a.gov.uk/later') }
     let(:archive)        { make_a_row('/old', 'TNA') }
+    let(:later_archive)  { make_a_row_with_line_number(2, '/old', 'TNA') }
     let(:unresolved)     { make_a_row('/old') }
 
     context 'comparing rows for different paths' do
@@ -193,6 +194,11 @@ describe Transition::Import::CSV::ImportBatchRow do
       it 'trumps an unresolved' do
         archive.should > unresolved
         unresolved.should < archive
+      end
+
+      it 'trumps a later archive' do
+        archive.should > later_archive
+        later_archive.should < archive
       end
     end
   end

--- a/spec/lib/transition/import/csv/import_batch_row_spec.rb
+++ b/spec/lib/transition/import/csv/import_batch_row_spec.rb
@@ -140,6 +140,25 @@ describe Transition::Import::CSV::ImportBatchRow do
     end
   end
 
+  describe '#archive_url' do
+    context 'with a custom archive URL' do
+      let(:archive_url) { 'http://webarchive.nationalarchives.gov.uk/*/http://a.com' }
+      let(:row) { make_a_row('', archive_url) }
+
+      it 'returns the custom URL' do
+        expect(row.archive_url).to eq(archive_url)
+      end
+    end
+
+    context 'for a regular archive mapping' do
+      let(:row) { make_a_row('', 'TNA') }
+
+      it 'returns nil' do
+        expect(row.archive_url).to be_nil
+      end
+    end
+  end
+
   describe '<=> - comparison for being able to sort mappings for the same Old URL' do
     let(:redirect)       { make_a_row('/old', 'https://a.gov.uk/new') }
     let(:later_redirect) { make_a_row_with_line_number(2, '/old', 'https://a.gov.uk/later') }

--- a/spec/models/bulk_add_batch_spec.rb
+++ b/spec/models/bulk_add_batch_spec.rb
@@ -122,11 +122,16 @@ describe BulkAddBatch do
 
     subject(:mappings_batch) do
       create(:bulk_add_batch, site: site,
-              paths: ['/a', '/b'],
-              type: 'redirect', new_url: 'http://a.gov.uk', tag_list: 'a tag')
+              paths: [path, '/b'],
+              type: 'redirect', new_url: new_url, tag_list: tag_list)
     end
 
+    let(:path) { '/a' }
+    let(:new_url) { 'http://a.gov.uk' }
+    let(:tag_list) { 'a tag' }
+
     include_examples 'creates mappings'
+    include_examples 'creates redirect mapping'
   end
 
   describe 'recording history', versioning: true do

--- a/spec/models/import_batch_spec.rb
+++ b/spec/models/import_batch_spec.rb
@@ -223,9 +223,10 @@ describe ImportBatch do
       describe 'the first entry' do
         subject(:entry) { mappings_batch.entries.first }
 
-        its(:path)    { should == '/old' }
-        its(:new_url) { should be_nil }
-        its(:type)    { should == 'archive' }
+        its(:path)        { should == '/old' }
+        its(:new_url)     { should be_nil }
+        its(:archive_url) { should be_nil }
+        its(:type)        { should == 'archive' }
       end
     end
 

--- a/spec/models/import_batch_spec.rb
+++ b/spec/models/import_batch_spec.rb
@@ -352,17 +352,32 @@ describe ImportBatch do
       create(:import_batch, site: site,
              tag_list: tag_list,
              raw_csv: <<-CSV.strip_heredoc
-                        #{path},#{new_url}
-                        /b,http://a.gov.uk
+                        #{path_to_be_redirected},#{new_url}
+                        #{path_to_be_archived},#{archive_url}
                       CSV
                  )
     end
 
-    let(:path) { '/a' }
+    let(:path_to_be_redirected) { '/a' }
     let(:new_url) { 'http://a.gov.uk' }
+
+    let(:path_to_be_archived) { '/b' }
+    let(:archive_url) { 'http://webarchive.nationalarchives.gov.uk/*/http://a.com/foo' }
+
     let(:tag_list) { 'a tag' }
 
     include_examples 'creates mappings'
-    include_examples 'creates redirect mapping'
+
+    context 'with a redirect mapping' do
+      let(:path) { path_to_be_redirected }
+
+      include_examples 'creates redirect mapping'
+    end
+
+    context 'with a custom archive URL mapping' do
+      let(:path) { path_to_be_archived }
+
+      include_examples 'creates custom archive URL mapping'
+    end
   end
 end

--- a/spec/models/import_batch_spec.rb
+++ b/spec/models/import_batch_spec.rb
@@ -309,14 +309,19 @@ describe ImportBatch do
 
     subject(:mappings_batch) do
       create(:import_batch, site: site,
-             tag_list: 'a tag',
+             tag_list: tag_list,
              raw_csv: <<-CSV.strip_heredoc
-                        /a,http://a.gov.uk
+                        #{path},#{new_url}
                         /b,http://a.gov.uk
                       CSV
                  )
     end
 
+    let(:path) { '/a' }
+    let(:new_url) { 'http://a.gov.uk' }
+    let(:tag_list) { 'a tag' }
+
     include_examples 'creates mappings'
+    include_examples 'creates redirect mapping'
   end
 end

--- a/spec/models/import_batch_spec.rb
+++ b/spec/models/import_batch_spec.rb
@@ -139,6 +139,24 @@ describe ImportBatch do
         end
       end
     end
+
+    describe 'archive URLs' do
+      describe 'validating all archive URLs for length' do
+        let(:too_long_url) { 'http://webarchive.nationalarchives.gov.uk/*/http://a.com'.ljust(65536, 'x') }
+        subject(:mappings_batch) do
+          build(:import_batch, raw_csv: <<-CSV.strip_heredoc
+              old url,new url
+              /old,#{too_long_url}
+            CSV
+          )
+        end
+
+        before { mappings_batch.should_not be_valid }
+        it 'should declare it invalid' do
+          mappings_batch.errors[:archive_urls].should include("A new URL is too long")
+        end
+      end
+    end
   end
 
   describe 'creating entries' do
@@ -212,21 +230,43 @@ describe ImportBatch do
     end
 
     context 'archives' do
-      let(:raw_csv) { <<-CSV.strip_heredoc
-                  /old,TNA
-                CSV
-              }
-      it 'should create an entry for each data row' do
-        mappings_batch.entries.count.should == 1
+      context 'without a custom archive URL' do
+        let(:raw_csv) { <<-CSV.strip_heredoc
+                    /old,TNA
+                  CSV
+                }
+        it 'should create an entry for each data row' do
+          mappings_batch.entries.count.should == 1
+        end
+
+        describe 'the first entry' do
+          subject(:entry) { mappings_batch.entries.first }
+
+          its(:path)        { should == '/old' }
+          its(:new_url)     { should be_nil }
+          its(:archive_url) { should be_nil }
+          its(:type)        { should == 'archive' }
+        end
       end
 
-      describe 'the first entry' do
-        subject(:entry) { mappings_batch.entries.first }
+      context 'with custom archive URL' do
+        let(:archive_url) { 'http://webarchive.nationalarchives.gov.uk/*/http://a.com' }
+        let(:raw_csv) { <<-CSV.strip_heredoc
+                    /old,#{archive_url}
+                  CSV
+                }
+        it 'should create an entry for each data row' do
+          mappings_batch.entries.count.should == 1
+        end
 
-        its(:path)        { should == '/old' }
-        its(:new_url)     { should be_nil }
-        its(:archive_url) { should be_nil }
-        its(:type)        { should == 'archive' }
+        describe 'the first entry' do
+          subject(:entry) { mappings_batch.entries.first }
+
+          its(:path)        { should == '/old' }
+          its(:new_url)     { should be_nil }
+          its(:archive_url) { should == archive_url }
+          its(:type)        { should == 'archive' }
+        end
       end
     end
 

--- a/spec/support/shared_examples/mappings_batch.rb
+++ b/spec/support/shared_examples/mappings_batch.rb
@@ -13,6 +13,22 @@ shared_examples 'creates redirect mapping' do
   end
 end
 
+shared_examples 'creates custom archive URL mapping' do
+  context 'some context' do
+    before { mappings_batch.process }
+
+    let(:mapping) { site.mappings.where(path: path).first }
+
+    it 'should populate the fields on the new mapping' do
+      mapping.path.should == path
+      mapping.type.should == 'archive'
+      mapping.new_url.should == nil
+      mapping.archive_url.should == archive_url
+      mapping.tag_list.should == tag_list.split(",")
+    end
+  end
+end
+
 shared_examples 'creates mappings' do
   context 'rosy case' do
     before { mappings_batch.process }

--- a/spec/support/shared_examples/mappings_batch.rb
+++ b/spec/support/shared_examples/mappings_batch.rb
@@ -1,17 +1,24 @@
+shared_examples 'creates redirect mapping' do
+  context 'some context' do
+    before { mappings_batch.process }
+
+    let(:mapping) { site.mappings.where(path: path).first }
+
+    it 'should populate the fields on the new mapping' do
+      mapping.path.should == path
+      mapping.type.should == 'redirect'
+      mapping.new_url.should == new_url
+      mapping.tag_list.should == tag_list.split(",")
+    end
+  end
+end
+
 shared_examples 'creates mappings' do
   context 'rosy case' do
     before { mappings_batch.process }
 
     it 'should create mappings for each entry' do
       site.mappings.count.should == 2
-    end
-
-    it 'should populate the fields on the new mapping' do
-      mapping = site.mappings.where(path: '/a').first
-      mapping.path.should == '/a'
-      mapping.type.should == 'redirect'
-      mapping.new_url.should == 'http://a.gov.uk'
-      mapping.tag_list.should == ['a tag']
     end
 
     it 'should mark each entry as processed' do


### PR DESCRIPTION
A Site has many Mappings and user can bulk import mappings from a CSV.

One of the available types of Mappings is an Archive Mapping. An Archive Mapping has an Old URL and an Archive URL.

A Site has a National Archives timestamp and its Archive Mappings can either construct their Archive URL using that timestamp or they can specify their own custom Archive URL.

Until now we've ignored any custom Archive URLs that were defined in an imported CSV (and instead let the imported Archive Mappings default to constructing their Archive URLs from their Site's timestamp as described above).

These updates change that behaviour, so that we now respect custom Archive URLs in CSVs and persist them along with their Mapping.