### PR TITLE
Add a rake task to revert import of some sites

### DIFF
--- a/lib/tasks/import/revert.rake
+++ b/lib/tasks/import/revert.rake
@@ -1,0 +1,14 @@
+namespace :import do
+  namespace :revert do
+    desc 'Delete unneeded sites, if they have no data created since the site config import'
+    task :sites => :environment do |_, args|
+      site_abbrs = args.extras.reject(&:empty?)
+      if site_abbrs.empty?
+        puts 'Usage: rake import:revert:sites[abbr_1,abbr_2]'
+        abort
+      end
+
+      Transition::Import::Revert::Sites.new(site_abbrs).revert_all!
+    end
+  end
+end

--- a/lib/transition/import/revert.rb
+++ b/lib/transition/import/revert.rb
@@ -1,0 +1,54 @@
+require 'transition/import/console_job_wrapper'
+
+module Transition
+  module Import
+    module Revert
+      ##
+      # Reverts the import of sites, if they have no mappings or hits - ie no
+      # associated data beyond that which was created by importing the site
+      # YAML file
+      class Sites
+        include Transition::Import::ConsoleJobWrapper
+
+        def initialize(site_abbrs)
+          @site_abbrs = site_abbrs
+        end
+
+        def revert_all!
+          console_puts "Trying to delete sites: #{@site_abbrs.join(', ')}"
+
+          @site_abbrs.each { |abbr| revert_safely!(abbr) }
+
+          console_puts 'Ensure that the deleted sites have also been deleted from the transition-config repo; otherwise they will be re-imported.'
+        end
+
+      private
+        def revert_safely!(abbr)
+          Site.transaction do
+            site = Site.find_by(abbr: abbr)
+            unless site
+              console_puts "Site #{abbr} doesn't exist; skipping"
+              return
+            end
+
+            mappings_count = site.mappings.count
+            hits_count = site.hits.count
+            # checking hits also accounts for host_paths and daily_hit_totals
+            if mappings_count == 0 && hits_count == 0
+              destroy_site_and_associations(site)
+              console_puts "Deleted site #{abbr}"
+            else
+              console_puts "Site #{abbr} has #{mappings_count} mappings and #{hits_count} hits; not deleting"
+            end
+          end
+        end
+
+        def destroy_site_and_associations(site)
+          # We can ignore mappings batches - they're cleaned up overnight
+          site.hosts.each { |host| host.destroy }
+          site.destroy  # this also deletes the organisations_sites row
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/transition/import/revert_spec.rb
+++ b/spec/lib/transition/import/revert_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+require 'transition/import/revert'
+
+describe Transition::Import::Revert::Sites do
+  describe '#revert_all!' do
+    before do
+      @bona_vacantia = create :organisation, whitehall_slug: 'bona-vacantia'
+      Transition::Import::OrgsSitesHosts.from_yaml!(
+        'spec/fixtures/sites/someyaml/**/*.yml',
+        Transition::Import::WhitehallOrgs.new('spec/fixtures/whitehall/orgs_abridged.yml')
+      )
+
+      @original_site_count = 8
+      @original_host_count = 24
+      @original_bv_extra_sites_count = 1
+      Site.count.should eql(@original_site_count)
+      Host.count.should eql(@original_host_count)
+      @bona_vacantia.extra_sites.count.should eql(@original_bv_extra_sites_count)
+    end
+
+    context 'deleting sites which can be deleted' do
+      site_abbrs = ['ago', 'bis']
+
+      before do
+        Transition::Import::Revert::Sites.new(site_abbrs).revert_all!
+      end
+
+      it 'should have deleted the sites' do
+        Site.count.should eql(6)
+        Site.where(abbr: site_abbrs).should be_empty
+      end
+
+      it 'should have deleted the hosts' do
+        Host.count.should eql(14)
+        Host.find_by(hostname: 'www.bis.gov.uk').should be_nil
+      end
+
+      it 'should have deleted the sites\' links to extra organisations' do
+        @bona_vacantia.extra_sites.size.should eql(0)
+      end
+    end
+
+    context 'trying to delete a site which has a mapping' do
+      before do
+        ago = Site.find_by(abbr: 'ago')
+        create :mapping, site: ago
+        Transition::Import::Revert::Sites.new([ago.abbr]).revert_all!
+      end
+
+      it 'should not delete the site or any related data' do
+        Site.count.should eql(@original_site_count)
+        Host.count.should eql(@original_host_count)
+        @bona_vacantia.extra_sites.count.should eql(@original_bv_extra_sites_count)
+      end
+    end
+
+    context 'trying to delete a site which has hits' do
+      before do
+        ago = Site.find_by(abbr: 'ago')
+        create :hit, host: ago.hosts.first
+        Transition::Import::Revert::Sites.new([ago.abbr]).revert_all!
+      end
+
+      it 'should not delete the site or any related data' do
+        Site.count.should eql(@original_site_count)
+        Host.count.should eql(@original_host_count)
+        @bona_vacantia.extra_sites.count.should eql(@original_bv_extra_sites_count)
+      end
+    end
+
+    context 'trying to delete a site which doesn\'t exist' do
+      before do
+        Transition::Import::Revert::Sites.new(['nonexistent_site']).revert_all!
+      end
+
+      it 'should not delete any sites or any related data' do
+        Site.count.should eql(@original_site_count)
+        Host.count.should eql(@original_host_count)
+        @bona_vacantia.extra_sites.count.should eql(@original_bv_extra_sites_count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We occasionally configure sites and then later decide that they should not be
transitioned via the Transition tool. In these cases it's good to delete the
imported site so that the data reflects our decisions. An example of such a
site is the content planner application on alphagov.co.uk: this app is [no
longer in Production](https://github.com/alphagov/transition-config/pull/1128) before the move to publishing.service.gov.uk so we don't
need to redirect the old domain, but it has already been imported.

This rake task makes it easier to delete these sites and all associated data
which may have been created by the site import: hosts and links to extra
organisations. The site should be removed from the transition-config repo
before running the task, otherwise the site will be re-imported the next time
the `orgs_sites_hosts` import runs.

The task takes an array of site abbrs, eg:

    bundle exec rake import:revert:sites[gds_alphagov_content-planner,another_site]

If any given site has any mappings or hits rows, it will not be deleted. The
presence of these is strongly indicative of us needing to keep the sites in
the database; if we really do want to delete a site which has mappings or hits
rows then that is a very special case and won't be automated.