### PR TITLE
Use correct domain for Whitehall mappings import

### DIFF
--- a/lib/transition/import/whitehall/mappings.rb
+++ b/lib/transition/import/whitehall/mappings.rb
@@ -5,7 +5,7 @@ module Transition
   module Import
     module Whitehall
       class Mappings
-        WHITEHALL_URL = 'https://whitehall-admin.production.alphagov.co.uk/government/mappings.csv'
+        WHITEHALL_URL = "#{Plek.current.find('whitehall-admin')}/government/mappings.csv"
         AS_USER_EMAIL = 'whitehall-urls-robot@dummy.com'
 
         def initialize(options = {})


### PR DESCRIPTION
We're no longer using the alphagov.co.uk domain for our applications, so
should get the correct domain from the environment via Plek. Since the
migration to the *.publishing.service.gov.uk domains this import [has been
erroring with `OpenURI::HTTPError: 401 Unauthorized`](https://errbit.publishing.service.gov.uk/apps/530f56010da115868600173d/problems/56022747657863061e671402) - I suspect the basic
auth credentials aren't being passed along when following the redirect.

This changes the behaviour to use Whitehall in the current environment rather
than always using Production, but there is no mention in git history of any
reason for doing that. It's more helpful to test against the current
environment so that any errors due to changes in Whitehall can be detected
before getting to Production.