### PR TITLE
Update alphagov domain name in production

### DIFF
--- a/app/validators/host_in_whitelist_validator.rb
+++ b/app/validators/host_in_whitelist_validator.rb
@@ -2,7 +2,7 @@ class HostInWhitelistValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return if value.blank?
     unless in_whitelist?(value)
-      message = (options[:message] || "must be on a whitelisted domain. <a href='https://support.production.alphagov.co.uk/general_request/new'>Raise a support request through the GOV.UK Support form</a> for more information.")
+      message = (options[:message] || "must be on a whitelisted domain. <a href='https://support.publishing.service.gov.uk/general_request/new'>Raise a support request through the GOV.UK Support form</a> for more information.")
       record.errors.add(attribute, message)
     end
   end

--- a/app/views/errors/error_503.html.erb
+++ b/app/views/errors/error_503.html.erb
@@ -7,5 +7,5 @@
   <p><%= @custom_body %></p>
 <% else %>
   <p>Transition is unavailable due to scheduled maintenance</p>
-  <p><a href='https://support.production.alphagov.co.uk/general_request/new'>Raise a support request through the GOV.UK Support form</a> for more information</p>
+  <p><a href='https://support.publishing.service.gov.uk/general_request/new'>Raise a support request through the GOV.UK Support form</a> for more information</p>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,7 +31,7 @@ en:
     bulk:
       type_invalid: 'Please select either redirect, archive or unresolved'
       new_url_invalid: 'Enter a valid URL to redirect to'
-      new_url_must_be_on_whitelist: "The URL to redirect to must be on a whitelisted domain. <a href='https://support.production.alphagov.co.uk/general_request/new'>Raise a support request through the GOV.UK Support form</a> for more information."
+      new_url_must_be_on_whitelist: "The URL to redirect to must be on a whitelisted domain. <a href='https://support.publishing.service.gov.uk/general_request/new'>Raise a support request through the GOV.UK Support form</a> for more information."
       new_url_must_not_be_on_tna: 'You must use an archive mapping to link to the National Archives, not a redirect'
       edit:
         mappings_empty: 'No mappings were selected'

--- a/spec/models/bulk_add_batch_spec.rb
+++ b/spec/models/bulk_add_batch_spec.rb
@@ -57,7 +57,7 @@ describe BulkAddBatch do
         subject(:mappings_batch) { build(:bulk_add_batch, type: 'redirect', new_url: 'http://bad.com') }
 
         it 'errors and asks for a whitelisted one' do
-          mappings_batch.errors[:new_url].should include("The URL to redirect to must be on a whitelisted domain. <a href='https://support.production.alphagov.co.uk/general_request/new'>Raise a support request through the GOV.UK Support form</a> for more information.")
+          mappings_batch.errors[:new_url].should include("The URL to redirect to must be on a whitelisted domain. <a href='https://support.publishing.service.gov.uk/general_request/new'>Raise a support request through the GOV.UK Support form</a> for more information.")
         end
       end
 

--- a/spec/models/import_batch_spec.rb
+++ b/spec/models/import_batch_spec.rb
@@ -116,7 +116,7 @@ describe ImportBatch do
 
         before { mappings_batch.should_not be_valid }
         it 'should declare it invalid' do
-          mappings_batch.errors[:new_urls].should include("The URL to redirect to must be on a whitelisted domain. <a href='https://support.production.alphagov.co.uk/general_request/new'>Raise a support request through the GOV.UK Support form</a> for more information.")
+          mappings_batch.errors[:new_urls].should include("The URL to redirect to must be on a whitelisted domain. <a href='https://support.publishing.service.gov.uk/general_request/new'>Raise a support request through the GOV.UK Support form</a> for more information.")
         end
       end
 

--- a/spec/models/mapping_spec.rb
+++ b/spec/models/mapping_spec.rb
@@ -128,7 +128,7 @@ describe Mapping do
           subject(:mapping) { build(:redirect, new_url: 'http://m.com/foo') }
 
           it 'fails' do
-            mapping.errors[:new_url].should == ["must be on a whitelisted domain. <a href='https://support.production.alphagov.co.uk/general_request/new'>Raise a support request through the GOV.UK Support form</a> for more information."]
+            mapping.errors[:new_url].should == ["must be on a whitelisted domain. <a href='https://support.publishing.service.gov.uk/general_request/new'>Raise a support request through the GOV.UK Support form</a> for more information."]
           end
         end
 


### PR DESCRIPTION
We've moved domain names in production. The old ones are redirected but we should update them anyway.