### PR TITLE
Add rake task to remove site and all data

### DIFF
--- a/lib/tasks/import/revert_entirely_unsafe.rake
+++ b/lib/tasks/import/revert_entirely_unsafe.rake
@@ -1,0 +1,22 @@
+namespace :import do
+  desc 'Deletes a site and all associated data'
+  task :revert_entirely_unsafe, [:site_abbr] => :environment do |_, args|
+    if args[:site_abbr].nil?
+      puts 'Usage: rake import:revert_entirely_unsafe[site_abbr]'
+      abort
+    end
+
+    site = Site.find_by_abbr(args[:site_abbr])
+    raise "No site found for #{args[:site_abbr]}" unless site
+
+    STDOUT.flush
+    STDOUT.puts "WAIT! This will delete all data that is associated with this site. \nAre you sure? (y/N)"
+    input = STDIN.gets.chomp
+
+    unless %w(y yes).include?(input)
+      abort("Aborting deletion of site: #{args[:site_abbr]}.")
+    end
+
+    Transition::Import::RevertEntirelyUnsafe::RevertSite.new(site).revert_all_data!
+  end
+end

--- a/lib/transition/import/revert_entirely_unsafe.rb
+++ b/lib/transition/import/revert_entirely_unsafe.rb
@@ -1,0 +1,105 @@
+require 'transition/import/console_job_wrapper'
+
+module Transition
+  module Import
+    module RevertEntirelyUnsafe
+      ##
+      # Reverts the import of a site and deletes all data associated with it
+      class RevertSite
+        include Transition::Import::ConsoleJobWrapper
+
+        def initialize(site)
+          @site = site
+        end
+
+        def revert_all_data!
+          console_puts "Trying to delete site and all associated data: #{@site.abbr}"
+
+          destroy_site_data
+
+          console_puts "***Ensure that the deleted site has also been deleted from the transition-config repo otherwise it will be re-imported.*** \n***This has not removed anything from the hits directory.***"
+        end
+
+      private
+        def destroy_site_data
+          destroy_all_mappings
+
+          destroy_all_hosts
+
+          destroy_organisation
+
+          @site.destroy
+
+          console_puts "Deleted site: #{@site.abbr}"
+        end
+
+        def destroy_all_mappings
+          console_puts "Removing mappings and versions for site: #{@site.abbr}"
+          Mapping.where(site_id: @site.id).each do |map|
+            destroy_all_versions(map)
+
+            console_puts "Removing mapping: #{map.path}"
+            map.destroy
+          end
+        end
+
+        def destroy_all_versions(map)
+          map.versions.each(&:destroy)
+        end
+
+        def destroy_all_hosts
+          @site.hosts.each do |host|
+            destroy_all_hits(host)
+
+            destroy_all_host_paths(host)
+
+            console_puts "Removing host: #{host.hostname}"
+            host.destroy
+          end
+        end
+
+        def destroy_all_hits(host)
+          console_puts "Removing daily hits for host: #{host.hostname}"
+          DailyHitTotal.where(host_id: host.id).each(&:destroy)
+
+          console_puts "Removing hits for host: #{host.hostname}"
+          Hit.where(host_id: host.id).each(&:destroy)
+        end
+
+        def destroy_all_host_paths(host)
+          console_puts "Removing host paths for host: #{host.hostname}"
+          HostPath.where(host_id: host.id).each(&:destroy)
+        end
+
+        def destroy_organisation
+          destroy_organisational_relationships
+
+          destroy_organisations_sites
+
+          console_puts "Removing organisation: #{@site.homepage}"
+          Organisation.where(id: @site.organisation_id).destroy_all
+        end
+
+        def destroy_organisational_relationships
+          console_puts "Removing organisational relationships for site: #{@site.abbr}"
+          OrganisationalRelationship
+            .where(child_organisation_id: @site.organisation_id)
+            .each(&:destroy)
+        end
+
+        def destroy_organisations_sites
+          console_puts "Removing organisations sites: #{@site.abbr}"
+
+          delete = "DELETE FROM organisations_sites WHERE"
+          by_site_id = "site_id = #{@site.id}"
+          by_org_id = "organisation_id = #{@site.organisation_id}"
+
+          ActiveRecord::Base.connection.execute("#{delete} #{by_site_id}")
+
+          ActiveRecord::Base.connection.execute("#{delete} #{by_org_id}")
+        end
+
+      end
+    end
+  end
+end

--- a/spec/lib/transition/import/revert_entirely_unsafe_spec.rb
+++ b/spec/lib/transition/import/revert_entirely_unsafe_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+require 'transition/import/revert_entirely_unsafe'
+
+describe Transition::Import::RevertEntirelyUnsafe::RevertSite do
+  describe '#revert_all_data!' do
+    before do
+      @bona_vacantia = create :organisation, whitehall_slug: 'bona-vacantia'
+      @treasury_office = create :organisation, whitehall_slug: 'treasury-solicitor-s-office'
+      Transition::Import::OrgsSitesHosts.from_yaml!(
+        'spec/fixtures/sites/someyaml/**/*.yml',
+        Transition::Import::WhitehallOrgs.new('spec/fixtures/whitehall/orgs_abridged.yml')
+      )
+
+      @site_abbr = 'ago'
+      @ago = Site.find_by(abbr: @site_abbr)
+      create :mapping, site: @ago
+
+      @original_site_count = 8
+      @original_host_count = 24
+      @extra_sites_count = 2
+
+      Site.count.should eql(@original_site_count)
+      Host.count.should eql(@original_host_count)
+      @bona_vacantia.extra_sites.count.should eql(1)
+      @treasury_office.extra_sites.count.should eql(1)
+
+      @ago.extra_organisations.count.should eql(@extra_sites_count)
+      @ago.mappings.count.should eql(1)
+
+      @ago.hosts.each do |ago_host|
+        create :hit, host: ago_host
+        create :host_path, host: ago_host
+        create :daily_hit_total, host: ago_host
+        ago_host.hits.count.should eql(1)
+        ago_host.host_paths.count.should eql(1)
+        ago_host.daily_hit_totals.count.should eql(1)
+      end
+
+      @host_names = %w(
+        www.attorneygeneral.gov.uk
+        aka.attorneygeneral.gov.uk
+        www.attorney-general.gov.uk
+        aka.attorney-general.gov.uk
+        www.ago.gov.uk
+        aka.ago.gov.uk
+        www.lslo.gov.uk
+        aka.lslo.gov.uk
+      )
+    end
+
+    context 'delete the site and all data' do
+      before do
+        Transition::Import::RevertEntirelyUnsafe::RevertSite.new(@ago).revert_all_data!
+      end
+
+      it 'should only have deleted the site passed in' do
+        Site.count.should eql(7)
+        Site.where(abbr: @site_abbr).should be_empty
+        Site.where(abbr: 'bis').should exist
+      end
+
+      it 'should have deleted the hosts' do
+        Host.count.should eql(16)
+        @host_names.each do |host|
+          Host.find_by(hostname: host).should be_nil
+        end
+      end
+
+      it 'should have deleted the mappings' do
+        @ago.mappings.count.should eql(0)
+      end
+
+      it 'should have deleted all the hits' do
+        @ago.hosts.each do |host|
+          host.hits.count.should eql(0)
+        end
+      end
+
+      it 'should have deleted all the host_paths' do
+        @ago.hosts.each do |host|
+          host.host_paths.count.should eql(0)
+        end
+      end
+
+      it 'should have deleted all the daily_hit_totals' do
+        @ago.hosts.each do |host|
+          host.daily_hit_totals.should eql(0)
+        end
+      end
+
+      it 'should have deleted the sites\' links to extra organisations' do
+        @ago.extra_organisations.count.should eql(0)
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
- ONS domains and data need to be removed from transition as they would like to add a different service

- The rake task takes a site abbreviation as a parameter and removes all associated data from the following tables: 
   - mappings
   - versions
   - daily_hit_totals
   - host_paths
   - sites
   - organisational_relationships
   - organisations_sites

- The hits files in the hits directory are not removed.

https://trello.com/c/WVYEPfxG/252-delete-all-data-for-www-ons-gov-uk-in-transition