### PR TITLE
The dev VM is Trusty by default now, so no need for `govuk_dev_dist`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,8 @@ of mappings for use with [Bouncer](https://github.com/alphagov/bouncer).
 ## Dependencies
 
 * Redis
-* PostgreSQL 9.3+ (the app uses materialized views, which were introduced in 9.3)
-    * To get PostgreSQL 9.3 in the development VM, build a new one on Trusty with
-`govuk_dev_dist=trusty vagrant up`.
+* PostgreSQL 9.3+ (the app uses materialized views, which were introduced in 9.3).
+  This is included in the Trusty dev VM, which is now the default.
 
 ## Running the app
 


### PR DESCRIPTION
- If you've not got a Trusty VM (with PostgreSQL 9.3 by default),
  you'll need to destroy and reprovision to get the latest one, but
  it's the default now, so don't recommend `govuk_dev_dist=trusty`.

(Found this looking through the branches list. It's still relevant, so I'm raising a very delayed PR!)