### PR TITLE
Bump admin gem to 4.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'unicorn', '4.6.2'
 gem 'pg', '0.18.4'
 gem 'optic14n', '2.0.0'     # Ideally version should be synced with bouncer
 gem 'gds-sso', '12.0.0'
-gem 'govuk_admin_template', '4.1.1'
+gem 'govuk_admin_template', '4.2.0'
 gem 'plek', '1.12.0'
 gem 'htmlentities', '4.3.4'
 gem 'kaminari', '0.16.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
       addressable (>= 2.3.1)
       extlib (>= 0.9.15)
       multi_json (>= 1.0.0)
-    autoprefixer-rails (6.3.3.1)
+    autoprefixer-rails (6.3.5)
       execjs
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
@@ -146,7 +146,7 @@ GEM
       multi_json (~> 1.11)
       os (~> 0.9)
       signet (~> 0.7)
-    govuk_admin_template (4.1.1)
+    govuk_admin_template (4.2.0)
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
@@ -383,7 +383,7 @@ DEPENDENCIES
   gds-api-adapters (= 29.6.0)
   gds-sso (= 12.0.0)
   google-api-client (= 0.8.6)
-  govuk_admin_template (= 4.1.1)
+  govuk_admin_template (= 4.2.0)
   gretel (= 3.0.8)
   htmlentities (= 4.3.4)
   jasmine (= 2.4.0)
@@ -415,4 +415,4 @@ DEPENDENCIES
   whenever (= 0.9.4)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,4 +1,3 @@
-<%# blocks for govuk_admin_template %>
 <% content_for :head do %>
   <%= stylesheet_link_tag "application", :media => "all" %>
   <%= javascript_include_tag "application" %>
@@ -38,15 +37,8 @@
         "favicon-#{environment_style}.png" : "favicon.png" %>
 <% end %>
 
-<% #content_for concatenates successive calls %>
 <% content_for :page_title do %> | GOV.UK Transition<% end %>
-
-<% content_for :navbar_right do %>
-  Hello, <%= link_to current_user.name, Plek.current.find('signon') %>
-  &bull; <%= link_to 'Sign out', gds_sign_out_path %>
-<% end %>
 <% content_for :footer_version do %><%= CURRENT_RELEASE_SHA %><% end %>
-<% content_for :app_title do %>GOV.UK Transition<% end %>
 <% content_for :content do %>
   <% # Map bootstrap alerts to Rails flashes, but keep notice and alert as they are pecial cased with redirect_to %>
   <% [:success, :info, :warning, :danger, :notice, :alert].select { |k| flash[k].present? }.each do |k| %>
@@ -92,5 +84,5 @@
   <%= yield %>
   <%= render partial: 'shared/go_to' %>
 <% end %>
-<%# use the govuk_admin_foundation layout %>
+
 <%= render :template => 'layouts/govuk_admin_template' %>

--- a/config/initializers/govuk_admin_template.rb
+++ b/config/initializers/govuk_admin_template.rb
@@ -1,0 +1,4 @@
+GovukAdminTemplate.configure do |c|
+  c.app_title = "GOV.UK Transition"
+  c.show_signout = true
+end

--- a/features/organisations.feature
+++ b/features/organisations.feature
@@ -17,7 +17,7 @@ Feature: List organisations
 
   Scenario: Visit the list page
     When I visit the home page
-    Then I should see "Hello"
+    Then I should see "Stub User"
     And I should see the header "Organisations"
     And I should see an organisations table with 3 rows
     And I should see a link to the organisation bis


### PR DESCRIPTION
* Add automatic email stripping on GA events
* Use admin template config
  * Use standard sign out block in navbar
  * Set app title in config

Part of https://trello.com/c/E2aEKfMM/352-automatically-strip-email-addresses-from-ga-events-in-admin-tools