### PR TITLE
Comment out some migrations so that first time setup runs cleanly

### DIFF
--- a/db/migrate/20140613165318_add_postgres_crypto.rb
+++ b/db/migrate/20140613165318_add_postgres_crypto.rb
@@ -1,9 +1,9 @@
 class AddPostgresCrypto < ActiveRecord::Migration
   def up
-    enable_extension 'pgcrypto'
+#    enable_extension 'pgcrypto'
   end
 
   def down
-    disable_extension 'pgcrypto'
+#    disable_extension 'pgcrypto'
   end
 end

--- a/db/migrate/20141120164444_drop_pgcrypto.rb
+++ b/db/migrate/20141120164444_drop_pgcrypto.rb
@@ -1,9 +1,9 @@
 class DropPgcrypto < ActiveRecord::Migration
   def up
-    disable_extension 'pgcrypto'
+#    disable_extension 'pgcrypto'
   end
 
   def down
-    enable_extension 'pgcrypto'
+#    enable_extension 'pgcrypto'
   end
 end


### PR DESCRIPTION
- Setting up Transition on a new laptop, I replicated data and then had
  to run `rake db:migrate`. It failed on the "enable pgcrypto" migration
  because it requires database superuser access to enable extensions. We
  don't need this extension anymore (it was removed in November 2014),
  so comment out migrations that reference it so that `db:migrate` can
  run cleanly. Commenting out rather than deleting because I don't know
  how Rails behaves when you delete migrations, and so that we preserve
  history of these changes.