### PR TITLE
Get rid of the weird black vertical grid lines on hits graphs

### DIFF
--- a/app/assets/javascripts/hits.js
+++ b/app/assets/javascripts/hits.js
@@ -44,7 +44,6 @@
                 height: '80%'
               },
               colors: colors,
-              annotations: {style: 'line', stemColor: 'black'},
               focusTarget: 'category' // Highlights all trends in a single tooltip, hovering
                                       // anywhere in the space above or below a point
             };


### PR DESCRIPTION
- There have been weird vertical black lines marking every day on the hits graphs probably due to something weird in the Google Charts API, which makes reading it a problem. This change seems to fix it - it's back to the normal grid lines now. Not sure if it's perfect, but it's certainly easier to read!

Before:

<img width="1075" alt="screenshot 2016-05-16 12 32 48" src="https://cloud.githubusercontent.com/assets/355033/15288446/1c46529e-1b63-11e6-838b-ab30a81e2635.png">

<img width="1092" alt="screenshot 2016-05-16 12 39 27" src="https://cloud.githubusercontent.com/assets/355033/15288464/409ee282-1b63-11e6-9d80-448cd1781c99.png">

After:

<img width="1107" alt="screenshot 2016-05-16 12 46 38" src="https://cloud.githubusercontent.com/assets/355033/15288665/47946188-1b64-11e6-8fe4-473d639d4f82.png">

<img width="1106" alt="screenshot 2016-05-16 12 39 59" src="https://cloud.githubusercontent.com/assets/355033/15288507/5e1e642c-1b63-11e6-971b-f7ee2b7d4b58.png">

One caveat: this removes the "Transition" line marking the date of Transition on the "all hits" graph, but not the text. Should we remove the text, or try and restore the line somehow?

(cc @fofr)
