### PR TITLE
Fix black lines on hits graphs

### DIFF
--- a/app/helpers/hits_helper.rb
+++ b/app/helpers/hits_helper.rb
@@ -54,7 +54,7 @@ module HitsHelper
       rows << {
         c: [
              { v: "Date(#{date.year}, #{date.month - 1}, #{date.day})" },
-             { v: date == transition_date ? 'Transition' : ''},
+             { v: date == transition_date ? 'Transition' : nil },
              *categories.map do |c|
                count_for_category = category_counts[c.name] || 0
                { v: count_for_category, f: number_with_delimiter(count_for_category) }

--- a/spec/helpers/hits_helper_spec.rb
+++ b/spec/helpers/hits_helper_spec.rb
@@ -62,7 +62,7 @@ describe HitsHelper do
     it { is_expected.not_to include('nil') }
 
     describe 'it includes a normal data row' do
-      it { is_expected.to include('{"c":[{"v":"Date(2012, 11, 31)"},{"v":""},{"v":3,"f":"3"},{"v":3,"f":"3"},{"v":0,"f":"0"}]}') }
+      it { is_expected.to include('{"c":[{"v":"Date(2012, 11, 31)"},{"v":null},{"v":3,"f":"3"},{"v":3,"f":"3"},{"v":0,"f":"0"}]}') }
     end
 
     describe 'it includes an annotation on the transition date' do


### PR DESCRIPTION
Between 28/04/2016 and 03/05/2016 the hits graphs suddenly gained a black line for every day, instead of only for the transition date:

![screen shot 2016-05-17 at 14 23 00](https://cloud.githubusercontent.com/assets/1822424/15323634/e9e74730-1c3a-11e6-88f0-96e799799889.png)

I can't see any relevant changes in the Google Charts release notes [1] - the last documented release was in February, long before we started seeing these problems.

The documentation for chart annotations [2] says that the default value for the annotation role is `''`, which suggests that our existing code should still work, but the examples on that page use `null` for datapoints without annotations. Switching our default value in the helper to `nil` appears to fix the problem, and the annotation for the transition date is shown correctly:

![screen shot 2016-05-17 at 14 23 57](https://cloud.githubusercontent.com/assets/1822424/15323650/0510d4d6-1c3b-11e6-9318-36d4336c7877.png)

[1]: https://developers.google.com/chart/interactive/docs/release_notes#official-releases
[2]: https://developers.google.com/chart/interactive/docs/roles#what-roles-are-available