### PR TITLE
Import hits with .jsp extension

### DIFF
--- a/lib/transition/import/hits/ignore.rb
+++ b/lib/transition/import/hits/ignore.rb
@@ -33,7 +33,7 @@ module Transition
         PATTERNS = [
           # Generic site furniture
           '.*\.css',
-          '.*\.js',
+          '.*\.js(\W|$)',
           '.*\.gif',
           '.*\.ico',
           '.*\.jpg',

--- a/spec/fixtures/hits/furniture_paths.tsv
+++ b/spec/fixtures/hits/furniture_paths.tsv
@@ -1,5 +1,6 @@
 date	count	status	host	path
 2012-10-14	11	200	www.businesslink.gov.uk	/legitimate
+2012-10-14	11	200	www.businesslink.gov.uk	/index.jsp
 2012-10-14	11	200	www.businesslink.gov.uk	/static/css/theme3.css
 2012-10-14	11	200	www.businesslink.gov.uk	/syntegra/js/s_code_remote.js
 2012-10-14	11	200	www.businesslink.gov.uk	/foo.eot

--- a/spec/lib/transition/import/hits_spec.rb
+++ b/spec/lib/transition/import/hits_spec.rb
@@ -88,7 +88,7 @@ describe Transition::Import::Hits do
       end
 
       it 'should ignore hits that are furniture so are uninteresting and unlikely to be mapped' do
-        expect(Hit.pluck(:path).sort).to eql(['/legitimate'])
+        expect(Hit.pluck(:path).sort).to eql(['/index.jsp', '/legitimate'])
       end
     end
 


### PR DESCRIPTION
We already ignore hits rows which contain various patterns which indicate that we don't need to map them, such as `.js`, but we do want to import hits rows with `.jsp` - this is an extension used by Java Spring apps.

This commit updates the pattern to match either `.js$` or `.js<any non-word character>` so that any `.js` paths with query strings are still matched. This enables us to import `.jsp` hits.

I don't intend to reimport all the hits files after this change has been deployed. There's one site in particular which I know is affected by this (`directgov_local`) so we will reimport those hits files from pre-transition-stats.

I found this problem while working on mappings for that site - we know that we want to map URLs like http://local.direct.gov.uk/LDGRedirect/index.jsp?LGSL=57 but those mappings didn't exist after [creating mappings from host paths](https://github.com/alphagov/transition/blob/master/lib/tasks/import/mappings_from_host_paths.rake).