### PR TITLE
Govuk Transition signon config

### DIFF
--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -1,6 +1,6 @@
 GDS::SSO.config do |config|
   config.user_model   = 'User'
-  config.oauth_id     = 'oauth_id_defined_on_rollout'
-  config.oauth_secret = 'secret'
+  config.oauth_id     = ENV['SIGNON_OAUTH_ID']
+  config.oauth_secret = ENV['SIGNON_OAUTH_SECRET']
   config.oauth_root_url = Plek.current.find("signon")
 end


### PR DESCRIPTION
This change will allow transition to use auth tokens defined in hiera when it's deployed.

This should eliminate the need to replace the file each time per environment.