### PR TITLE
Make the sites table filterable

### DIFF
--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -12,12 +12,20 @@
 
 <% unless @sites.empty? %>
   <h2>Sites</h2>
-  <table class="sites table table-hover table-striped table-bordered">
+  <table class="sites table table-hover table-striped table-bordered" data-module="filterable-table">
     <thead>
       <tr class="table-header">
         <th scope="col">Old site</th>
         <th scope="col">Transition status</th>
         <th scope="col">Transition date</th>
+      </tr>
+      <tr class="if-no-js-hide table-header-secondary">
+        <td colspan="3">
+          <form>
+            <label for="site-filter" class="rm">Filter sites</label>
+            <input id="site-filter" type="text" class="form-control normal js-filter-table-input" placeholder="Filter list of sites">
+          </form>
+        </td>
       </tr>
     </thead>
     <tbody>

--- a/features/organisation.feature
+++ b/features/organisation.feature
@@ -36,6 +36,19 @@ Feature: View organisation
     Then I should see the site that the organisation is trusted to edit
     And I should see the organisation's own site
 
+  @javascript
+  Scenario: Filter the list of sites
+    Given I have logged in as a GDS Editor
+    And there is a bis organisation named Companies House abbreviated companies-house with these sites:
+      | abbr             | homepage                                                    |
+      | companies        | https://www.gov.uk/government/organisations/companies-house |
+      | companies_welsh  | https://www.gov.uk/government/organisations/companies-house |
+    When I visit the path /organisations/companies-house
+    And I filter sites by "welsh"
+    Then I should see an sites table with 1 row
+    And I should see "companies_welsh.gov.uk"
+    But I should not see "companies.gov.uk"
+
   @allow-rescue
   Scenario: Visit the page of an non-existent organisation
     Given I have logged in as a GDS Editor

--- a/features/step_definitions/organisation_interaction_steps.rb
+++ b/features/step_definitions/organisation_interaction_steps.rb
@@ -1,3 +1,7 @@
 When(/^I filter organisations by "(.*?)"$/) do |text|
   fill_in 'Filter organisations', with: text
 end
+
+When(/^I filter sites by "(.*?)"$/) do |text|
+  fill_in 'Filter sites', with: text
+end


### PR DESCRIPTION
Several organisations have lots of sites now, which makes it harder to find the one you're looking for in the table. Making the table filterable, as we do for the organisations index, helps with this.

GDS has by far the most sites (214; FCO has 163, BIS 66 and UKTI 58) and the majority of organisations have only one site, so this is very much scratching our own itch. Should we only add the filter header row if there are more than 5 sites, or are we happy for it to be there for everyone?

![screen shot 2016-08-05 at 17 41 10](https://cloud.githubusercontent.com/assets/1822424/17443678/e00b208c-5b33-11e6-8a1a-a6770ee67786.png)
