### PR TITLE
Fix tag list field to fill with comma separated tags

### DIFF
--- a/app/models/mapping.rb
+++ b/app/models/mapping.rb
@@ -12,13 +12,7 @@ class Mapping < ActiveRecord::Base
   SUPPORTED_TYPES = %w(redirect archive unresolved)
 
   acts_as_taggable
-  has_paper_trail :ignore => [:tag_list => Proc.new { |mapping|
-    # tag_list appears to ActiveModel::Dirty/paper_trail to be an
-    # ActsAsTaggableOn::TagList but the original value from the database is a
-    # string. This means that it is "different" even though it isn't.
-    # Comparing the stringified version avoids that problem.
-    mapping.tag_list_was == mapping.tag_list.to_s
-  } ]
+  has_paper_trail
 
   belongs_to :site
   has_many :hits

--- a/app/views/shared/_tag_list_field.html.erb
+++ b/app/views/shared/_tag_list_field.html.erb
@@ -26,7 +26,7 @@
   <div class="row">
     <div class="<%= modal ? 'col-md-12' : 'col-md-8' %>">
       <% if defined? form %>
-        <%= form.text_field :tag_list, class: 'form-control js-tag-list' %>
+        <%= form.text_field :tag_list, class: 'form-control js-tag-list', value: form.object.tag_list.to_s %>
       <% else %>
         <%= text_field_tag :tag_list, tag_list.to_s, class: 'form-control js-tag-list' %>
       <% end %>

--- a/features/mapping_tag.feature
+++ b/features/mapping_tag.feature
@@ -11,6 +11,8 @@ Scenario: Adding tags to a mapping
   And I save the mapping
   Then I should see "Mapping saved"
   And the mapping should have the tags "fee, fi, fo"
+  When I edit that mapping
+  Then I should see the tags "fee, fi, fo"
 
 Scenario: Adding tags when bulk adding mappings
   Given I have logged in as a GDS Editor

--- a/features/step_definitions/mappings_assertion_steps.rb
+++ b/features/step_definitions/mappings_assertion_steps.rb
@@ -158,9 +158,10 @@ end
 Then(/^I should see the tags "([^"]*)"$/) do |tag_list|
   if @_javascript
     field = find(:xpath, '//input[contains(@class, "select2-offscreen")]')
-    expect(field.value).to eq(tag_list)
+    expect(field.value.split(',')).to match_array(tag_list.split(','))
   else
-    expect(page).to have_field('Tags', with: tag_list)
+    field = find_field('Tags')
+    expect(field.value.split(',')).to match_array(tag_list.split(','))
   end
 end
 


### PR DESCRIPTION
For https://trello.com/c/ZYSIdD8R/466-tags-in-edit-mapping-form-are-mangled-transition-3

Previously the text_field for a tag_list_field would merge multiple tags into one string (ie with multiple tags would be filled with words only separated by a space, e.g. "fee fi of"). On saving the mapping, this would create a new tag. The problem seems to have been that when using the FormHelper text_field method, calling the `tag_list` method did not return a comma separated string. So we explicitly set the value to be the string-ified array.

In order to make testing easier, we replace `acts_as_taggable` with `acts_as_ordered_taggable` which ensures that the tags remain ordered. Due to some interplay between the 'paper-trail' and the 'acts-as-taggable-on' gems, this requires a change to the ignore block for the 'paper_trail' definition in the Mapping model.

# Before (when editing a mapping with multiple tags)
![screen_shot_2016-07-08_at_14 31 24](https://cloud.githubusercontent.com/assets/5112255/17777293/ea22c3b2-6557-11e6-899f-7ec50cf6d66b.png)

# After
![screen_shot_2016-07-08_at_15 58 51](https://cloud.githubusercontent.com/assets/5112255/17777305/f85da186-6557-11e6-9744-06c1b520635c.png)
