### PR TITLE
Remove whitespace from tag_list in cucumber step

### DIFF
--- a/features/step_definitions/mappings_assertion_steps.rb
+++ b/features/step_definitions/mappings_assertion_steps.rb
@@ -158,11 +158,14 @@ end
 Then(/^I should see the tags "([^"]*)"$/) do |tag_list|
   if @_javascript
     field = find(:xpath, '//input[contains(@class, "select2-offscreen")]')
-    expect(field.value.split(',')).to match_array(tag_list.split(','))
   else
     field = find_field('Tags')
-    expect(field.value.split(',')).to match_array(tag_list.split(','))
   end
+
+  expected_values = tag_list.split(/\s*,\s*/)
+  field_values  = field.value.split(/\s*,\s*/)
+
+  expect(field_values).to match_array(expected_values)
 end
 
 Then(/^I should see that all were tagged "([^"]*)"$/) do |tag_list|


### PR DESCRIPTION
The test was failing in CI because when passing a comma-separated string
and turning it into an array, the leading white spaces would not be removed
and therefore elements would not be matched correctly.

```
expected collection contained:  [" fi", " fo", "fee"]
actual collection contained:    [" fee", " fi", "fo"]
```

This commit removes leading and trailing whitespace for the elements.