### PR TITLE
Fix name of Signon environment variable

### DIFF
--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -1,6 +1,6 @@
 GDS::SSO.config do |config|
   config.user_model   = 'User'
-  config.oauth_id     = ENV['SIGNON_OAUTH_ID']
-  config.oauth_secret = ENV['SIGNON_OAUTH_SECRET']
+  config.oauth_id     = ENV['OAUTH_ID']
+  config.oauth_secret = ENV['OAUTH_SECRET']
   config.oauth_root_url = Plek.current.find("signon")
 end


### PR DESCRIPTION
This isn't prefixed with `SIGNON`.