### PR TITLE
Add a spec to cover WhitehallOrgs#load_orgs_from_api

### DIFF
--- a/spec/lib/transition/import/whitehall_orgs_spec.rb
+++ b/spec/lib/transition/import/whitehall_orgs_spec.rb
@@ -1,10 +1,11 @@
 require 'rails_helper'
 require 'transition/import/whitehall_orgs'
+require 'gds_api/test_helpers/organisations'
 
 describe Transition::Import::WhitehallOrgs do
   context 'with an API response stubbed to fixtures' do
     subject(:whitehall_orgs) do
-      Transition::Import::WhitehallOrgs.new('spec/fixtures/whitehall/orgs_abridged.yml')
+      described_class.new('spec/fixtures/whitehall/orgs_abridged.yml')
     end
 
     it 'has 6 organisations' do
@@ -27,6 +28,41 @@ describe Transition::Import::WhitehallOrgs do
           subject { super()['slug'] }
           it { is_expected.to eq('attorney-generals-office') }
         end
+      end
+    end
+  end
+
+  context 'with the real API' do
+    include GdsApi::TestHelpers::Organisations
+
+    subject(:whitehall_orgs) { described_class.new }
+
+    context 'when there are some organisations in the API' do
+      before do
+        organisations_api_has_organisations ['ministry-of-funk', 'department-of-soul', 'hm-rock-and-roll']
+      end
+
+      it 'extracts all the organisations from the API' do
+        expect(subject.organisations.size).to eq(3)
+      end
+    end
+
+    context 'when there are so many organisations in the API that it paginates' do
+      before do
+        # The default pagination is 20, so make 21 to trigger this
+        organisations_api_has_organisations [
+          'ministry-of-funk-1', 'department-of-soul-1', 'hm-rock-and-roll-1',
+          'ministry-of-funk-2', 'department-of-soul-2', 'hm-rock-and-roll-2',
+          'ministry-of-funk-3', 'department-of-soul-3', 'hm-rock-and-roll-3',
+          'ministry-of-funk-4', 'department-of-soul-4', 'hm-rock-and-roll-4',
+          'ministry-of-funk-5', 'department-of-soul-5', 'hm-rock-and-roll-5',
+          'ministry-of-funk-6', 'department-of-soul-6', 'hm-rock-and-roll-6',
+          'ministry-of-funk-7', 'department-of-soul-7', 'hm-rock-and-roll-7',
+        ]
+      end
+
+      it 'extracts all organisations from each page of the API' do
+        expect(subject.organisations.size).to eq(21)
       end
     end
   end

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,0 +1,3 @@
+require 'webmock/rspec'
+
+WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
In #526 we bumped gds-api-adapters to get a fix for list responses from
the api.  We only spotted the failure when trying to run the whitehall
orgs import in production because our existing specs have a different
codepath that uses a fixture instead of the API.  We add a spec that does
use the API (albeit stubbed via the gds_api/test_helpers) which should
protect us against similar failures when the API changes in the future.