### PR TITLE
Strip whitespace from the URL in MappingsController#find_global

### DIFF
--- a/app/controllers/mappings_controller.rb
+++ b/app/controllers/mappings_controller.rb
@@ -89,10 +89,13 @@ class MappingsController < ApplicationController
     # This allows finding a mapping without knowing the site first.
     render_error(400) and return unless params[:url].present?
 
-    url = if !Transition::PathOrURL.starts_with_http_scheme?(params[:url])
-            'http://' + params[:url] # Add a dummy scheme
+    # Strip leading and trailing whitespace before any processing.
+    stripped_url = params[:url].strip
+
+    url = if !Transition::PathOrURL.starts_with_http_scheme?(stripped_url)
+            'http://' + stripped_url # Add a dummy scheme
           else
-            params[:url]
+            stripped_url
           end
 
     begin

--- a/spec/controllers/mappings_controller_spec.rb
+++ b/spec/controllers/mappings_controller_spec.rb
@@ -177,6 +177,14 @@ describe MappingsController do
           expect(response.status).to eq(404)
         end
       end
+
+      context 'when the URL starts or ends with whitespace' do
+        let!(:host) { create :host, hostname: "example.com" }
+        it 'strips both leading and trailing whitespace' do
+          get :find_global, url: " http://example.com/hello "
+          expect(response).to redirect_to site_mapping_find_url(host.site, path: "/hello")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
- This caused me problems when copying and pasting from a spreadsheet
  into the "go to site or mapping box" - I pasted something with
  trailing whitespace and it didn't go anywhere.
- So, strip both leading and trailing whitespace from the
  `params[:url]` field before processing it further.