### PR TITLE
Fix filter navigation on pressing enter for sites

### DIFF
--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -32,7 +32,7 @@
     <% @sites.each do |site| %>
       <tr>
         <td>
-          <%= link_to site.default_host.hostname, site_path(site), class: 'breakable' %>
+          <%= link_to site.default_host.hostname, site_path(site), class: 'breakable js-open-on-submit' %>
           <% if site.organisation != @organisation %>
             <br><span class="text-muted">owned by</span>
             <%= link_to site.organisation.title, site.organisation, class: 'link-muted' %>

--- a/features/organisation.feature
+++ b/features/organisation.feature
@@ -45,7 +45,7 @@ Feature: View organisation
       | companies_welsh  | https://www.gov.uk/government/organisations/companies-house |
     When I visit the path /organisations/companies-house
     And I filter sites by "welsh"
-    Then I should see an sites table with 1 row
+    Then I should see a sites table with 1 row
     And I should see "companies_welsh.gov.uk"
     But I should not see "companies.gov.uk"
 


### PR DESCRIPTION
When filtering sites from the org show page, pressing enter to go to the top
result didn't work because I missed this class out of #520. Add it to fix it.