### PR TITLE
Change column types on mappings_batch_entries to match mappings

### DIFF
--- a/db/migrate/20161111172455_change_column_types_on_mappings_batch_entries.rb
+++ b/db/migrate/20161111172455_change_column_types_on_mappings_batch_entries.rb
@@ -1,0 +1,14 @@
+class ChangeColumnTypesOnMappingsBatchEntries < ActiveRecord::Migration
+  def up
+    change_column :mappings_batch_entries, :new_url, :text
+    change_column :mappings_batch_entries, :archive_url, :text
+  end
+
+  def down
+    # This is what we would need to do, but data would be lost by doing it,
+    # so don't:
+    # change_column :mappings_batch_entries, :new_url, :string, limit: 2048
+    # change_column :mappings_batch_entries, :archive_url, :string, limit: 255
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160314150053) do
+ActiveRecord::Schema.define(version: 20161111172455) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -105,9 +105,9 @@ ActiveRecord::Schema.define(version: 20160314150053) do
     t.integer "mapping_id"
     t.boolean "processed",                      default: false
     t.string  "klass",             limit: 255
-    t.string  "new_url",           limit: 2048
+    t.text    "new_url"
     t.string  "type",              limit: 255
-    t.string  "archive_url",       limit: 255
+    t.text    "archive_url"
   end
 
   add_index "mappings_batch_entries", ["mappings_batch_id"], name: "index_mappings_batch_entries_on_mappings_batch_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,7 +16,7 @@ ActiveRecord::Schema.define(version: 20160314150053) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "daily_hit_totals", force: true do |t|
+  create_table "daily_hit_totals", force: :cascade do |t|
     t.integer "host_id",               null: false
     t.string  "http_status", limit: 3, null: false
     t.integer "count",                 null: false
@@ -25,7 +25,7 @@ ActiveRecord::Schema.define(version: 20160314150053) do
 
   add_index "daily_hit_totals", ["host_id", "total_on", "http_status"], name: "index_daily_hit_totals_on_host_id_and_total_on_and_http_status", unique: true, using: :btree
 
-  create_table "hits", force: true do |t|
+  create_table "hits", force: :cascade do |t|
     t.integer "host_id",                  null: false
     t.string  "path",        limit: 2048, null: false
     t.string  "http_status", limit: 3,    null: false
@@ -39,15 +39,15 @@ ActiveRecord::Schema.define(version: 20160314150053) do
   add_index "hits", ["host_id", "path", "hit_on", "http_status"], name: "index_hits_on_host_id_and_path_and_hit_on_and_http_status", unique: true, using: :btree
   add_index "hits", ["mapping_id"], name: "index_hits_on_mapping_id", using: :btree
 
-  create_table "hits_staging", id: false, force: true do |t|
-    t.string  "hostname"
+  create_table "hits_staging", id: false, force: :cascade do |t|
+    t.string  "hostname",    limit: 255
     t.text    "path"
     t.string  "http_status", limit: 3
     t.integer "count"
     t.date    "hit_on"
   end
 
-  create_table "host_paths", force: true do |t|
+  create_table "host_paths", force: :cascade do |t|
     t.string  "path",           limit: 2048
     t.integer "host_id"
     t.integer "mapping_id"
@@ -58,15 +58,15 @@ ActiveRecord::Schema.define(version: 20160314150053) do
   add_index "host_paths", ["host_id", "path"], name: "index_host_paths_on_host_id_and_path", unique: true, using: :btree
   add_index "host_paths", ["mapping_id"], name: "index_host_paths_on_mapping_id", using: :btree
 
-  create_table "hosts", force: true do |t|
-    t.integer  "site_id",           null: false
-    t.string   "hostname",          null: false
+  create_table "hosts", force: :cascade do |t|
+    t.integer  "site_id",                       null: false
+    t.string   "hostname",          limit: 255, null: false
     t.integer  "ttl"
-    t.string   "cname"
-    t.string   "live_cname"
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
-    t.string   "ip_address"
+    t.string   "cname",             limit: 255
+    t.string   "live_cname",        limit: 255
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
+    t.string   "ip_address",        limit: 255
     t.integer  "canonical_host_id"
   end
 
@@ -74,23 +74,23 @@ ActiveRecord::Schema.define(version: 20160314150053) do
   add_index "hosts", ["hostname"], name: "index_hosts_on_host", unique: true, using: :btree
   add_index "hosts", ["site_id"], name: "index_hosts_on_site_id", using: :btree
 
-  create_table "imported_hits_files", force: true do |t|
-    t.string   "filename"
-    t.string   "content_hash"
+  create_table "imported_hits_files", force: :cascade do |t|
+    t.string   "filename",     limit: 255
+    t.string   "content_hash", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   add_index "imported_hits_files", ["filename"], name: "index_imported_hits_files_on_filename", unique: true, using: :btree
 
-  create_table "mappings", force: true do |t|
+  create_table "mappings", force: :cascade do |t|
     t.integer "site_id",                                      null: false
     t.string  "path",            limit: 2048,                 null: false
     t.text    "new_url"
     t.text    "suggested_url"
     t.text    "archive_url"
     t.boolean "from_redirector",              default: false
-    t.string  "type",                                         null: false
+    t.string  "type",            limit: 255,                  null: false
     t.integer "hit_count"
   end
 
@@ -99,36 +99,36 @@ ActiveRecord::Schema.define(version: 20160314150053) do
   add_index "mappings", ["site_id", "type"], name: "index_mappings_on_site_id_and_type", using: :btree
   add_index "mappings", ["site_id"], name: "index_mappings_on_site_id", using: :btree
 
-  create_table "mappings_batch_entries", force: true do |t|
+  create_table "mappings_batch_entries", force: :cascade do |t|
     t.string  "path",              limit: 2048
     t.integer "mappings_batch_id"
     t.integer "mapping_id"
     t.boolean "processed",                      default: false
-    t.string  "klass"
+    t.string  "klass",             limit: 255
     t.string  "new_url",           limit: 2048
-    t.string  "type"
-    t.string  "archive_url"
+    t.string  "type",              limit: 255
+    t.string  "archive_url",       limit: 255
   end
 
   add_index "mappings_batch_entries", ["mappings_batch_id"], name: "index_mappings_batch_entries_on_mappings_batch_id", using: :btree
 
-  create_table "mappings_batches", force: true do |t|
-    t.string   "tag_list"
+  create_table "mappings_batches", force: :cascade do |t|
+    t.string   "tag_list",        limit: 255
     t.string   "new_url",         limit: 2048
     t.boolean  "update_existing"
     t.integer  "user_id"
     t.integer  "site_id"
     t.datetime "created_at",                                        null: false
     t.datetime "updated_at",                                        null: false
-    t.string   "state",                        default: "unqueued"
+    t.string   "state",           limit: 255,  default: "unqueued"
     t.boolean  "seen_outcome",                 default: false
-    t.string   "type"
-    t.string   "klass"
+    t.string   "type",            limit: 255
+    t.string   "klass",           limit: 255
   end
 
   add_index "mappings_batches", ["user_id", "site_id"], name: "index_mappings_batches_on_user_id_and_site_id", using: :btree
 
-  create_table "organisational_relationships", force: true do |t|
+  create_table "organisational_relationships", force: :cascade do |t|
     t.integer "parent_organisation_id"
     t.integer "child_organisation_id"
   end
@@ -136,68 +136,68 @@ ActiveRecord::Schema.define(version: 20160314150053) do
   add_index "organisational_relationships", ["child_organisation_id"], name: "index_organisational_relationships_on_child_organisation_id", using: :btree
   add_index "organisational_relationships", ["parent_organisation_id"], name: "index_organisational_relationships_on_parent_organisation_id", using: :btree
 
-  create_table "organisations", force: true do |t|
-    t.string   "title",                     null: false
-    t.string   "homepage"
-    t.string   "furl"
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
-    t.string   "css"
+  create_table "organisations", force: :cascade do |t|
+    t.string   "title",          limit: 255, null: false
+    t.string   "homepage",       limit: 255
+    t.string   "furl",           limit: 255
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.string   "css",            limit: 255
     t.string   "ga_profile_id",  limit: 16
-    t.string   "whitehall_slug"
-    t.string   "whitehall_type"
-    t.string   "abbreviation"
-    t.string   "content_id",                null: false
+    t.string   "whitehall_slug", limit: 255
+    t.string   "whitehall_type", limit: 255
+    t.string   "abbreviation",   limit: 255
+    t.string   "content_id",     limit: 255, null: false
   end
 
   add_index "organisations", ["content_id"], name: "index_organisations_on_content_id", unique: true, using: :btree
   add_index "organisations", ["title"], name: "index_organisations_on_title", using: :btree
   add_index "organisations", ["whitehall_slug"], name: "index_organisations_on_whitehall_slug", unique: true, using: :btree
 
-  create_table "organisations_sites", id: false, force: true do |t|
+  create_table "organisations_sites", id: false, force: :cascade do |t|
     t.integer "site_id",         null: false
     t.integer "organisation_id", null: false
   end
 
   add_index "organisations_sites", ["site_id", "organisation_id"], name: "index_organisations_sites_on_site_id_and_organisation_id", unique: true, using: :btree
 
-  create_table "sessions", force: true do |t|
-    t.string   "session_id", null: false
+  create_table "sessions", force: :cascade do |t|
+    t.string   "session_id", limit: 255, null: false
     t.text     "data"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
   end
 
   add_index "sessions", ["session_id"], name: "index_sessions_on_session_id", using: :btree
   add_index "sessions", ["updated_at"], name: "index_sessions_on_updated_at", using: :btree
 
-  create_table "sites", force: true do |t|
-    t.integer  "organisation_id",                             null: false
-    t.string   "abbr",                                        null: false
-    t.string   "query_params"
-    t.datetime "tna_timestamp",                               null: false
-    t.string   "homepage"
-    t.datetime "created_at",                                  null: false
-    t.datetime "updated_at",                                  null: false
+  create_table "sites", force: :cascade do |t|
+    t.integer  "organisation_id",                                         null: false
+    t.string   "abbr",                        limit: 255,                 null: false
+    t.string   "query_params",                limit: 255
+    t.datetime "tna_timestamp",                                           null: false
+    t.string   "homepage",                    limit: 255
+    t.datetime "created_at",                                              null: false
+    t.datetime "updated_at",                                              null: false
     t.text     "global_new_url"
     t.date     "launch_date"
-    t.string   "special_redirect_strategy"
-    t.boolean  "global_redirect_append_path", default: false, null: false
-    t.string   "global_type"
-    t.string   "homepage_title"
-    t.string   "homepage_furl"
-    t.boolean  "precompute_all_hits_view",    default: false, null: false
+    t.string   "special_redirect_strategy",   limit: 255
+    t.boolean  "global_redirect_append_path",             default: false, null: false
+    t.string   "global_type",                 limit: 255
+    t.string   "homepage_title",              limit: 255
+    t.string   "homepage_furl",               limit: 255
+    t.boolean  "precompute_all_hits_view",                default: false, null: false
   end
 
   add_index "sites", ["abbr"], name: "index_sites_on_site", unique: true, using: :btree
   add_index "sites", ["organisation_id"], name: "index_sites_on_organisation_id", using: :btree
 
-  create_table "taggings", force: true do |t|
+  create_table "taggings", force: :cascade do |t|
     t.integer  "tag_id"
     t.integer  "taggable_id"
-    t.string   "taggable_type"
+    t.string   "taggable_type", limit: 255
     t.integer  "tagger_id"
-    t.string   "tagger_type"
+    t.string   "tagger_type",   limit: 255
     t.string   "context",       limit: 128
     t.datetime "created_at"
   end
@@ -206,32 +206,32 @@ ActiveRecord::Schema.define(version: 20160314150053) do
   add_index "taggings", ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context", using: :btree
   add_index "taggings", ["taggable_type", "taggable_id"], name: "index_taggings_on_taggable_type_and_taggable_id", using: :btree
 
-  create_table "tags", force: true do |t|
-    t.string  "name"
-    t.integer "taggings_count", default: 0
+  create_table "tags", force: :cascade do |t|
+    t.string  "name",           limit: 255
+    t.integer "taggings_count",             default: 0
   end
 
   add_index "tags", ["name"], name: "index_tags_on_name", unique: true, using: :btree
 
-  create_table "users", force: true do |t|
-    t.string   "name"
-    t.string   "email"
-    t.string   "uid"
+  create_table "users", force: :cascade do |t|
+    t.string   "name",                    limit: 255
+    t.string   "email",                   limit: 255
+    t.string   "uid",                     limit: 255
     t.text     "permissions"
-    t.boolean  "remotely_signed_out",     default: false
-    t.datetime "created_at",                              null: false
-    t.datetime "updated_at",                              null: false
-    t.string   "organisation_slug"
-    t.boolean  "is_robot",                default: false
-    t.boolean  "disabled",                default: false
-    t.string   "organisation_content_id"
+    t.boolean  "remotely_signed_out",                 default: false
+    t.datetime "created_at",                                          null: false
+    t.datetime "updated_at",                                          null: false
+    t.string   "organisation_slug",       limit: 255
+    t.boolean  "is_robot",                            default: false
+    t.boolean  "disabled",                            default: false
+    t.string   "organisation_content_id", limit: 255
   end
 
-  create_table "versions", force: true do |t|
-    t.string   "item_type",      null: false
-    t.integer  "item_id",        null: false
-    t.string   "event",          null: false
-    t.string   "whodunnit"
+  create_table "versions", force: :cascade do |t|
+    t.string   "item_type",      limit: 255, null: false
+    t.integer  "item_id",                    null: false
+    t.string   "event",          limit: 255, null: false
+    t.string   "whodunnit",      limit: 255
     t.integer  "user_id"
     t.text     "object_changes"
     t.text     "object"
@@ -240,10 +240,10 @@ ActiveRecord::Schema.define(version: 20160314150053) do
 
   add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
 
-  create_table "whitelisted_hosts", force: true do |t|
-    t.string   "hostname",   null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table "whitelisted_hosts", force: :cascade do |t|
+    t.string   "hostname",   limit: 255, null: false
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
   end
 
   add_index "whitelisted_hosts", ["hostname"], name: "index_whitelisted_hosts_on_hostname", unique: true, using: :btree

--- a/spec/models/import_batch_spec.rb
+++ b/spec/models/import_batch_spec.rb
@@ -265,7 +265,7 @@ describe ImportBatch do
       end
 
       context 'with custom archive URL' do
-        let(:archive_url) { 'http://webarchive.nationalarchives.gov.uk/*/http://a.com' }
+        let(:archive_url) { 'http://webarchive.nationalarchives.gov.uk/20160701131101/http://blogs.bis.gov.uk/exportcontrol/open-licensing/httpblogs-bis-gov-ukexportcontroluncategorizednotice-to-exporters-201415-uk-suspends-all-licences-and-licence-applications-for-export-to-russian-military-that-could-be-used-against-ukraine/' }
         let(:raw_csv) {
           <<-CSV.strip_heredoc
             /old,#{archive_url}


### PR DESCRIPTION
In particular because `archive_url` was too small for National Archives URLs which are usually long. Batch entries are the precursor to mappings so their column types should match where possible, so that users can create mappings via batches with the same constraints as when doing them individually.

Also use a long `archive_url` in a test which fails without this migration.

See Errbit for [examples of data which trigger this problem](https://errbit.publishing.service.gov.uk/apps/530f56010da115868600173d/problems/5825f6646578633fd99a0b00) - the test URL comes from this data.

There's some context for the large schema diff in the first commit message.

https://trello.com/c/MGtcYgQV/549-fix-limit-on-archive-url-length-when-importing-batches-in-transition