### PR TITLE
Remove `AMAZON_LEGACY_IP`

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -17,8 +17,7 @@ class Host < ActiveRecord::Base
 
   FASTLY_ANYCAST_IPS = ['23.235.33.144', '23.235.37.144'].freeze # To be used for new root domains
   DYN_DNS_IPS        = ['216.146.46.10', '216.146.46.11'].freeze # Used for a few domains we control
-  AMAZON_LEGACY_IP   = ['46.137.92.159'].freeze                  # We're migrating domains off this
-  REDIRECTOR_IPS     = FASTLY_ANYCAST_IPS + DYN_DNS_IPS + AMAZON_LEGACY_IP
+  REDIRECTOR_IPS     = FASTLY_ANYCAST_IPS + DYN_DNS_IPS
 
   REDIRECTOR_CNAME = /^redirector-cdn[^.]*\.production\.govuk\.service\.gov\.uk$/
 

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -148,15 +148,6 @@ describe Host do
       end
     end
 
-    context 'IP pointing at the redirector EC2 box' do
-      subject { build(:host, cname: nil, ip_address: '46.137.92.159') }
-
-      describe '#redirected_by_gds?' do
-        subject { super().redirected_by_gds? }
-        it { is_expected.to be_truthy }
-      end
-    end
-
     context 'external CNAME' do
       subject { build(:host, cname: 'bis-tms-101-L01.eduserv.org.uk') }
 


### PR DESCRIPTION
Nothing in production is using this IP address anymore:

```
irb(main):002:0> Host.where(ip_address: '46.137.92.159').count
=> 0
```