### PR TITLE
Add new Fastly IP addresses

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -15,9 +15,10 @@ class Host < ActiveRecord::Base
 
   scope :excluding_aka, -> { where(canonical_host_id: nil) }
 
-  FASTLY_ANYCAST_IPS = ['23.235.33.144', '23.235.37.144'].freeze # To be used for new root domains
-  DYN_DNS_IPS        = ['216.146.46.10', '216.146.46.11'].freeze # Used for a few domains we control
-  REDIRECTOR_IPS     = FASTLY_ANYCAST_IPS + DYN_DNS_IPS
+  FASTLY_BOUNCER_SERVICE_MAP = %w(151.101.2.30 151.101.66.30 151.101.130.30 151.101.194.30).freeze # bouncer.gds.map.fastly.net.
+  FASTLY_ANYCAST_IPS = ['23.235.33.144', '23.235.37.144'].freeze # FIXME: These IPs are deprecated, Fastly would like to reallocate them
+  DYN_DNS_IPS        = ['216.146.46.10', '216.146.46.11'].freeze # FIXME: These IPs are Dyn's redirect service, replace them with Fastly
+  REDIRECTOR_IPS     = FASTLY_ANYCAST_IPS + FASTLY_BOUNCER_SERVICE_MAP + DYN_DNS_IPS
 
   REDIRECTOR_CNAME = /^redirector-cdn[^.]*\.production\.govuk\.service\.gov\.uk$/
 

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -20,7 +20,7 @@ class Host < ActiveRecord::Base
   DYN_DNS_IPS        = ['216.146.46.10', '216.146.46.11'].freeze # FIXME: These IPs are Dyn's redirect service, replace them with Fastly
   REDIRECTOR_IPS     = FASTLY_ANYCAST_IPS + FASTLY_BOUNCER_SERVICE_MAP + DYN_DNS_IPS
 
-  REDIRECTOR_CNAME = /^redirector-cdn[^.]*\.production\.govuk\.service\.gov\.uk$/
+  REDIRECTOR_CNAME = /^(redirector|bouncer)-cdn[^.]*\.production\.govuk\.service\.gov\.uk$/
 
   def aka?
     hostname.start_with?('aka')

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -139,6 +139,15 @@ describe Host do
       end
     end
 
+    context 'alternate CDN CNAME' do
+      subject { build(:host, cname: 'bouncer-cdn.production.govuk.service.gov.uk') }
+
+      describe '#redirected_by_gds?' do
+        subject { super().redirected_by_gds? }
+        it { is_expected.to be_truthy }
+      end
+    end
+
     context 'businesslink events CDN CNAME' do
       subject { build(:host, cname: 'redirector-cdn-ssl-events-businesslink.production.govuk.service.gov.uk') }
 


### PR DESCRIPTION
Fastly have set up a service map for Bouncer and have allocated us new
IP address for that map.

We should be moving things away from the other 2 methods of redirection
and should be using just this one map.