### PR TITLE
Remove Dyn DNS redirect IP addresses

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -17,8 +17,7 @@ class Host < ActiveRecord::Base
 
   FASTLY_BOUNCER_SERVICE_MAP = %w(151.101.2.30 151.101.66.30 151.101.130.30 151.101.194.30).freeze # bouncer.gds.map.fastly.net.
   FASTLY_ANYCAST_IPS = ['23.235.33.144', '23.235.37.144'].freeze # FIXME: These IPs are deprecated, Fastly would like to reallocate them
-  DYN_DNS_IPS        = ['216.146.46.10', '216.146.46.11'].freeze # FIXME: These IPs are Dyn's redirect service, replace them with Fastly
-  REDIRECTOR_IPS     = FASTLY_ANYCAST_IPS + FASTLY_BOUNCER_SERVICE_MAP + DYN_DNS_IPS
+  REDIRECTOR_IPS     = FASTLY_ANYCAST_IPS + FASTLY_BOUNCER_SERVICE_MAP
 
   REDIRECTOR_CNAME = /^(redirector|bouncer)-cdn[^.]*\.production\.govuk\.service\.gov\.uk$/
 


### PR DESCRIPTION
In the very old days we used a Dyn HTTP redirect service for direct.gov.uk and businesslink.gov.uk. We've now changed those redirects to use Bouncer.

There are only 2 domains left in Transition which use these IP addresses. They are not actively redirecting so they need to be removed before this is merged and deployed.