### PR TITLE
Fix scheduled rake tasks - destroy_all

### DIFF
--- a/lib/tasks/clear_expired_sessions.rake
+++ b/lib/tasks/clear_expired_sessions.rake
@@ -1,5 +1,5 @@
 desc "Clear the sessions table of records that are over 25 hours old."
 task clear_expired_sessions: :environment do
   puts "Deleting sessions over 25 hours old..."
-  ActiveRecord::SessionStore::Session.delete_all(["updated_at < ?", 25.hours.ago])
+  ActiveRecord::SessionStore::Session.where(["updated_at < ?", 25.hours.ago]).delete_all
 end

--- a/lib/tasks/clear_old_mappings_batches.rake
+++ b/lib/tasks/clear_old_mappings_batches.rake
@@ -1,4 +1,4 @@
 desc "Clear the mappings batches (and entries) that are over 48 hours old."
 task clear_old_mappings_batches: :environment do
-  MappingsBatch.destroy_all(['updated_at < ?', 48.hours.ago])
+  MappingsBatch.where(['updated_at < ?', 48.hours.ago]).destroy_all
 end


### PR DESCRIPTION
The method `destroy_all` no longer receives arguments, it needs a where
clause to be invoked uppon.

Trello:
https://trello.com/c/UunoKJk9/186-overnight-transition-rake-tasks-failing-in-production