### PR TITLE
Use environment variables for WH basic auth

### DIFF
--- a/config/initializers/govuk_basic_auth.rb
+++ b/config/initializers/govuk_basic_auth.rb
@@ -1,3 +1,0 @@
-# This file is overwritten on deploy from alphagov-deployment
-redacted = nil
-Rails.application.config.govuk_basic_auth = { username: redacted, password: redacted }

--- a/lib/tasks/import/whitehall.rake
+++ b/lib/tasks/import/whitehall.rake
@@ -8,10 +8,9 @@ namespace :import do
       if ENV['FILENAME']
         options = { filename: ENV['FILENAME'] }
       else
-        govuk_basic_auth = Rails.application.config.govuk_basic_auth
         options = {
-          username: govuk_basic_auth[:username] || ENV['AUTH_USERNAME'] || raise('Basic AUTH_USERNAME is required'),
-          password: govuk_basic_auth[:password] || ENV['AUTH_PASSWORD'] || raise('Basic AUTH_PASSWORD is required'),
+          username: ENV['BASIC_AUTH_USERNAME'] || raise('Basic AUTH_USERNAME is required'),
+          password: ENV['BASIC_AUTH_PASSWORD'] || raise('Basic AUTH_PASSWORD is required'),
         }
       end
       Transition::DistributedLock.new('import_whitehall_mappings').lock do


### PR DESCRIPTION
These environment variables are currently available on prod, they were added in https://github.com/alphagov/govuk-puppet/pull/6325 by @boffbowsh.

https://trello.com/c/bxvXAF4S