### PR TITLE
Refactor database.yml for ENV["DATABASE_URL"]

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,22 +1,28 @@
-development:
+default: &default
   adapter: postgresql
-  database: transition_development
   template: template0
   encoding: utf8
+  url: <%= ENV["DATABASE_URL"] %>
   variables:
     work_mem: 10MB
     maintenance_work_mem: 128MB
+
+development:
+  <<: *default
+  database: transition_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test: &test
-  adapter: postgresql
+  <<: *default
   database: transition_test<%= ENV['TEST_ENV_NUMBER'] %>
-  template: template0
-  encoding: utf8
+  url: <%= ENV["DATABASE_URL"].try(:sub, /([-_]development)?$/, "_test#{ENV['TEST_ENV_NUMBER']}") %>
   variables:
     work_mem: 1MB
 
 cucumber:
   <<: *test
+
+production:
+  <<: *default


### PR DESCRIPTION
This is to remove the need for [database.yml][] to be copied in at the
time of deployment.

This switches this script to be based around the use of DATABASE_URL env
vars which already exist in [govuk-puppet][]

[database.yml]:
https://github.com/alphagov/alphagov-deployment/blob/5cca0de76b1c1e4a122933aac199f8f0587ded70/transition/to_upload/database.yml
[govuk-puppet]:
https://github.com/alphagov/govuk-puppet/blob/f127d3c209c38ee95c3b222c7fa102ad988ed915/modules/govuk/manifests/apps/transition.pp#L98-L104