### PR TITLE
Remove deprecated require_signin_permission!

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
 
-  before_action :require_signin_permission!
+  before_action :authenticate_user!
 
   before_action :exclude_all_users_except_admins_during_maintenance
 


### PR DESCRIPTION
This method has been deprecated in gds-sso v13.3.0 [1] and should be
replaced with authenticate_user!

[1] https://github.com/alphagov/gds-sso/blob/master/CHANGELOG.md#1330

To be merged after https://github.com/alphagov/transition/pull/557