### PR TITLE
Update Jenkinsfile to use the external govuk library

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 #!/usr/bin/env groovy
 
+library("govuk")
+
 node {
-  def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
   govuk.buildProject(sassLint: false)
 }


### PR DESCRIPTION
- This was extracted into https://github.com/alphagov/govuk-jenkinslib and the
  docs updated to specify this as the new way of loading the library.