### PR TITLE
Hard-code the external api/organisations for config

### DIFF
--- a/lib/transition/import/whitehall_orgs.rb
+++ b/lib/transition/import/whitehall_orgs.rb
@@ -49,7 +49,7 @@ module Transition
       end
 
       def load_orgs_from_api
-        api = GdsApi::Organisations.new(Plek.current.find('whitehall-admin'))
+        api = GdsApi::Organisations.new('https://www.gov.uk:443')
         api.organisations.with_subsequent_pages.to_a
       end
     end


### PR DESCRIPTION
- The Jenkins jobs loading the config for transition are currently
  talking to whitehall-admin.internal/api/organisations, while the api
  is exposed via www.gov.uk/api/organisations as well

- During AWS migration, internal access to whitelladmin is temporary
  unavailable so we need this change for the config updates to work

- After AWS migration I still do not find the idea of keeping it too
  bad, because it is a test of the external facing API if anything...

solo: @schmie