### PR TITLE
Use blocks to define factory fields

### DIFF
--- a/spec/factories/daily_hit_totals.rb
+++ b/spec/factories/daily_hit_totals.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :daily_hit_total do
-    http_status '301'
-    count 10
-    total_on 1.week.ago
+    http_status { '301' }
+    count { 10 }
+    total_on { 1.week.ago }
 
     association :host
   end

--- a/spec/factories/hits.rb
+++ b/spec/factories/hits.rb
@@ -1,18 +1,18 @@
 FactoryBot.define do
   factory :hit do
-    path '/article/123'
-    count 20
-    http_status '301'
-    hit_on 1.week.ago
+    path { '/article/123' }
+    count { 20 }
+    http_status { '301' }
+    hit_on { 1.week.ago }
 
     association :host
 
     trait :error do
-      http_status '404'
+      http_status { '404' }
     end
 
     trait :redirect do
-      http_status '301'
+      http_status { '301' }
     end
   end
 end

--- a/spec/factories/hosts.rb
+++ b/spec/factories/hosts.rb
@@ -4,11 +4,11 @@ FactoryBot.define do
     association :site
 
     trait :with_govuk_cname do
-      cname 'redirector-cdn.production.govuk.service.gov.uk'
+      cname { 'redirector-cdn.production.govuk.service.gov.uk' }
     end
 
     trait :with_third_party_cname do
-      cname 'bis-tms-101-L01.eduserv.org.uk'
+      cname { 'bis-tms-101-L01.eduserv.org.uk' }
     end
 
     trait :with_its_aka_host do

--- a/spec/factories/mappings.rb
+++ b/spec/factories/mappings.rb
@@ -6,17 +6,17 @@ FactoryBot.define do
       as_user { build(:user, id: 1, name: 'test user') }
     end
 
-    type 'archive'
+    type { 'archive' }
     sequence(:path) { |n| "/foo-#{n}" }
     association :site, strategy: :build
 
     factory :archived
     factory :redirect do
-      type 'redirect'
-      new_url 'https://www.gov.uk/somewhere'
+      type { 'redirect' }
+      new_url { 'https://www.gov.uk/somewhere' }
     end
     factory :unresolved do
-      type 'unresolved'
+      type { 'unresolved' }
     end
 
     before(:create) do |_, evaluator|

--- a/spec/factories/mappings_batch.rb
+++ b/spec/factories/mappings_batch.rb
@@ -2,49 +2,53 @@ require 'transition/history'
 
 FactoryBot.define do
   factory :bulk_add_batch do
-    type 'archive'
-    paths ['/a', '/b']
-    state 'unqueued'
+    type { 'archive' }
+    paths { ['/a', '/b'] }
+    state { 'unqueued' }
 
     association :site, strategy: :build
     association :user, strategy: :build
   end
 
   factory :import_batch do
-    state 'unqueued'
+    state { 'unqueued' }
 
-    raw_csv <<-CSV.strip_heredoc
-                /oldurl1
-                /oldurl2
-               CSV
+    raw_csv do
+      <<-CSV.strip_heredoc
+        /oldurl1
+        /oldurl2
+      CSV
+    end
 
     association :site, strategy: :build
     association :user, strategy: :build
   end
 
   factory :large_import_batch, parent: :import_batch do
-    raw_csv <<-CSV.strip_heredoc
-                /1
-                /2
-                /3
-                /4
-                /5
-                /6
-                /7
-                /8
-                /9
-                /10
-                /11
-                /12
-                /13
-                /14
-                /15
-                /16
-                /17
-                /18
-                /19
-                /20
-                /21
-              CSV
+    raw_csv do
+      <<-CSV.strip_heredoc
+        /1
+        /2
+        /3
+        /4
+        /5
+        /6
+        /7
+        /8
+        /9
+        /10
+        /11
+        /12
+        /13
+        /14
+        /15
+        /16
+        /17
+        /18
+        /19
+        /20
+        /21
+      CSV
+    end
   end
 end

--- a/spec/factories/organisations.rb
+++ b/spec/factories/organisations.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :organisation do
-    title 'Orgtastic'
+    title { 'Orgtastic' }
 
-    ga_profile_id '46600000'
-    whitehall_type 'Executive non-departmental public body'
+    ga_profile_id { '46600000' }
+    whitehall_type { 'Executive non-departmental public body' }
     sequence(:whitehall_slug) { |n| "org-#{n}" }
     content_id { SecureRandom.uuid }
 

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :site_without_host, class: Site do
     sequence(:abbr) { |n| "site-#{n}" }
-    homepage 'https://www.gov.uk/government/organisations/example-org'
-    query_params ''
+    homepage { 'https://www.gov.uk/government/organisations/example-org' }
+    query_params { '' }
     launch_date { 1.month.ago }
-    tna_timestamp '2012-08-16 22:40:15'
+    tna_timestamp { '2012-08-16 22:40:15' }
 
     association :organisation
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user do
-    name "Stub User"
+    name { "Stub User" }
     sequence(:email) { |n| "person-#{n}@example.com" }
     permissions { ["signin"] }
 


### PR DESCRIPTION
The way of doing it before will be removed in later versions of factory bot.