### PR TITLE
Fix disk space issues by deleting import files after use

### DIFF
--- a/lib/transition/import/whitehall/mappings.rb
+++ b/lib/transition/import/whitehall/mappings.rb
@@ -19,12 +19,12 @@ module Transition
         end
 
         def call
-          filename = if @filename
-                       @filename
-                     else
-                       download
-                     end
-          process(filename)
+          if @filename
+            process(@filename)
+          else
+            filename = download
+            process(filename, delete_after: true)
+          end
         end
 
       private
@@ -51,12 +51,14 @@ module Transition
           filename
         end
 
-        def process(filename)
+        def process(filename, delete_after: false)
           Rails.logger.info('Processing...')
 
           File.open(filename, 'r') { |file|
             Transition::Import::Whitehall::MappingsCSV.new(as_user).from_csv(file)
           }
+
+          FileUtils.rm(filename) if delete_after
         end
       end
     end

--- a/spec/lib/transition/import/whitehall/mappings_spec.rb
+++ b/spec/lib/transition/import/whitehall/mappings_spec.rb
@@ -2,6 +2,12 @@ require 'rails_helper'
 require 'transition/import/whitehall/mappings'
 
 describe Transition::Import::Whitehall::Mappings do
+  let(:tmpdir) { Rails.root + "tmp/" }
+
+  before do
+    tmpdir.mkdir unless tmpdir.exist?
+  end
+
   describe 'as_user' do
     subject { Transition::Import::Whitehall::Mappings.new(filename: 'foo').send(:as_user) }
 
@@ -16,6 +22,48 @@ describe Transition::Import::Whitehall::Mappings do
       describe '#is_robot' do
         subject { super().is_robot }
         it { is_expected.to be_truthy }
+      end
+    end
+  end
+
+  context "when downloading the file from whitehall" do
+    before do
+      stub_request(:get, "http://whitehall-admin.dev.gov.uk/government/mappings.csv")
+        .to_return(body: "some,mappings,csv")
+    end
+
+    it "deletes the downloaded file after processing" do
+      Timecop.freeze do
+        mappings = Transition::Import::Whitehall::Mappings.new(
+          username: "username",
+          password: "password",
+        )
+
+        expect(File.exist?(mappings.send(:default_filename))).to eq(false)
+        mappings.call
+        expect(File.exist?(mappings.send(:default_filename))).to eq(false)
+      end
+    end
+  end
+
+  context "when using a file off disk" do
+    let(:filename) { tmpdir + "test_filename.csv" }
+
+    before do
+      filename.write("some,mappings,csv")
+    end
+
+    after do
+      filename.delete
+    end
+
+    it "does not delete file after processing" do
+      Timecop.freeze do
+        mappings = Transition::Import::Whitehall::Mappings.new(filename: filename)
+
+        expect(File.exist?(filename)).to eq(true)
+        mappings.call
+        expect(File.exist?(filename)).to eq(true)
       end
     end
   end


### PR DESCRIPTION
These files are 30MB each, so downloading one twice a day and never deleting them is eating up disk space in production.

Normally these would be removed as old release directories are deleted, but this app is not deployed very often.

![image](https://user-images.githubusercontent.com/109225/50399089-b6717380-0774-11e9-98a8-91037f18ccde.png)
![image](https://user-images.githubusercontent.com/109225/50399092-bc675480-0774-11e9-999e-64c5ef05c1f2.png)
![image](https://user-images.githubusercontent.com/109225/50399096-c12c0880-0774-11e9-9ffa-589af7527b23.png)
