### PR TITLE
Return frozen time to fix flaky tests elsewhere

### DIFF
--- a/spec/controllers/hits_controller_spec.rb
+++ b/spec/controllers/hits_controller_spec.rb
@@ -27,8 +27,11 @@ describe HitsController do
     ]
   end
 
+  around(:all) do |example|
+    Timecop.freeze(Date.new(2013, 1, 1)) { example.run }
+  end
+
   before do
-    Timecop.freeze(Date.new(2013, 01, 01))
     login_as_stub_user
     Transition::Import::DailyHitTotals.from_hits!
   end

--- a/spec/helpers/sites_helper_spec.rb
+++ b/spec/helpers/sites_helper_spec.rb
@@ -5,8 +5,11 @@ describe SitesHelper do
     let(:site)      { double('site') }
     let(:halloween) { Date.new(2013, 10, 31) }
 
+    around(:all) do |example|
+      Timecop.freeze(halloween) { example.run }
+    end
+
     before do
-      Timecop.freeze(halloween)
       allow(site).to receive(:launch_date).and_return(launch_date)
       allow(site).to receive(:transition_status).and_return(transition_status)
     end


### PR DESCRIPTION
It's bad practice to freeze time without returning it afterwards as it can affect other tests as it was doing here.