### PR TITLE
Add a description for import:orgs_sites_hosts task

### DIFF
--- a/lib/tasks/import/orgs_sites_hosts.rake
+++ b/lib/tasks/import/orgs_sites_hosts.rake
@@ -1,6 +1,7 @@
 require 'transition/import/orgs_sites_hosts'
 
 namespace :import do
+  desc 'Import all Organisations, and Sites and Hosts from the given filename or mask'
   task :orgs_sites_hosts, [:filename_or_mask] => :environment do |_, args|
     begin
       Transition::Import::OrgsSitesHosts.from_yaml!(args.filename_or_mask)


### PR DESCRIPTION
This means that it shows up in the list of rake tasks. This task is useful
if you want to import a single site config file repeatedly as you're working
on it.