### PR TITLE
Add new Bouncer IP addresses

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -20,8 +20,9 @@ class Host < ActiveRecord::Base
   }
 
   FASTLY_BOUNCER_SERVICE_MAP = %w(151.101.2.30 151.101.66.30 151.101.130.30 151.101.194.30).freeze # bouncer.gds.map.fastly.net.
+  FASTLY_NEW_BOUNCER_IPS = %w(151.101.0.204 151.101.64.204 151.101.128.204 151.101.192.204).freeze
   FASTLY_ANYCAST_IPS = ['23.235.33.144', '23.235.37.144'].freeze # FIXME: These IPs are deprecated, Fastly would like to reallocate them
-  REDIRECTOR_IPS     = FASTLY_ANYCAST_IPS + FASTLY_BOUNCER_SERVICE_MAP
+  REDIRECTOR_IPS     = FASTLY_ANYCAST_IPS + FASTLY_BOUNCER_SERVICE_MAP + FASTLY_NEW_BOUNCER_IPS
 
   REDIRECTOR_CNAME = /^(redirector|bouncer)-cdn[^.]*\.production\.govuk\.service\.gov\.uk$/.freeze
 

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -182,8 +182,8 @@ describe Host do
       end
     end
 
-    context 'no CNAME (A-record only)' do
-      subject { build(:host, cname: nil) }
+    context 'no CNAME or A records' do
+      subject { build(:host, cname: nil, ip_address: nil) }
 
       describe '#redirected_by_gds?' do
         subject { super().redirected_by_gds? }

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -199,6 +199,15 @@ describe Host do
         it { is_expected.to be_falsey }
       end
     end
+
+    context 'IP pointing at Bouncer' do
+      subject { build(:host, cname: nil, ip_address: '151.101.0.204') }
+
+      describe '#redirected_by_gds?' do
+        subject { super().redirected_by_gds? }
+        it { is_expected.to be_truthy }
+      end
+    end
   end
 
   describe 'moving to a different site' do


### PR DESCRIPTION
Transition needs to know the IP addresses and hostnames used by Bouncer in order to correctly report the transition status of sites and hosts.

@timblair asked us to use these IP addresses if we weren't able to use CNAME, ANAME or ALIAS records, rather than the anycast IPs.

Also tweak the tests for `redirected_by_gds?` to cover these cases better.