### PR TITLE
 Allow site to be nil while importing

### DIFF
--- a/lib/transition/import/hits_mappings_relations.rb
+++ b/lib/transition/import/hits_mappings_relations.rb
@@ -67,13 +67,13 @@ module Transition
           canonical_path = site.canonical_path(host_path.path)
           mapping_id = Mapping.where(
             path: canonical_path, site_id: site.id
-).pluck(:id).first
+          ).pluck(:id).first
 
           if host_path.mapping_id != mapping_id || host_path.canonical_path != canonical_path
             host_path.update_columns(
               mapping_id: mapping_id,
               canonical_path: canonical_path
-)
+            )
           end
         end
       end

--- a/lib/transition/import/hits_mappings_relations.rb
+++ b/lib/transition/import/hits_mappings_relations.rb
@@ -62,7 +62,12 @@ module Transition
 
       def connect_mappings_to_host_paths!
         host_paths.includes(:host).find_each do |host_path|
-          site = host_path.host.site
+          site = host_path.host&.site
+
+          unless site
+            warn "#{host_path} not associated with a site"
+            next
+          end
 
           canonical_path = site.canonical_path(host_path.path)
           mapping_id = Mapping.where(


### PR DESCRIPTION
We're seeing [a problem while running the import that the `site` is `nil`](https://deploy.blue.production.govuk.digital/job/transition_import_hits/31/console).

```
Adding missing mapping_id/canonical_path to host paths ... 
rake aborted!
NoMethodError: undefined method `site' for nil:NilClass
/data/vhost/transition/releases/20190715125102/lib/transition/import/hits_mappings_relations.rb:65:in `block in connect_mappings_to_host_paths!'
```

Instead of failing the entire import, we should warn that this is the case.