### PR TITLE
Remove config for Performance/Casecmp Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,11 +4,6 @@
 Style/AndOr:
   EnforcedStyle: conditionals
 
-# "FOO".casecmp("foo").zero? is not as readable as "foo".upcase == "FOO" so
-# we disable this cop entirely
-Performance/Casecmp:
-  Enabled: false
-
 Metrics/BlockLength:
   Exclude:
     - 'config/routes.rb'


### PR DESCRIPTION
- As of govuk-lint 3.11.2, govuk-lint doesn't include Performance
  Rubocops because they were split out from the core Rubocop gem.
- This config here causes warnings in `govuk-lint-ruby` output because
  we don't require 'rubocop-performance' to get these Performance cops:
  `Warning: unrecognized cop Performance/Casecmp found in .rubocop.yml`
- Given that the Performance cops were removed so many versions of
  govuk-lint ago, I'm going to take a punt that we don't need them in
  this app and so we can get rid of this line to get rid of three (!)
  warnings.