### PR TITLE
Reach into paper trail to display originator

### DIFF
--- a/app/views/admin/whitelisted_hosts/index.html.erb
+++ b/app/views/admin/whitelisted_hosts/index.html.erb
@@ -37,7 +37,7 @@
       <tr <% if flash[:hostname] == host.hostname %>class="selected-row"<% end %>>
         <td><%= host.hostname %></td>
         <td><%= I18n.l host.created_at, :format => :govuk_date %></td>
-        <td><%= host.originator %></td>
+        <td><%= host.paper_trail.originator %></td>
       </tr>
     <% end %>
   </tbody>


### PR DESCRIPTION
Navigating to the "Redirection Whitelist" in Transition Admin is error in the admin application with "We're sorry something went wrong". This is reflected in Sentry by a "ActionView::Template::Error: undefined method `originator'"

The WhitelistedHost model does not contain an `originator` field.
Instead this is exposed by `paper_trail` (a gem that provides version
history on a model) which the model has referenced.

Update the view so we refer to `originator` through `paper_trail` rather
than directly on the model. This should fix the error we are seeing.
