### PR TITLE
Replace govuk-lint with rubocop-govuk

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+
 # We like using `render/redirect and return` in controllers, like
 # the rails guides suggest (see: http://guides.rubyonrails.org/layouts_and_rendering.html#avoiding-double-render-errors)
 # so enable this cop only for conditionals

--- a/Gemfile
+++ b/Gemfile
@@ -44,9 +44,9 @@ group :test do
 end
 
 group :development, :test do
-  gem "govuk-lint", "~> 4.2.0"
   gem "jasmine"
   gem "pry"
   gem "rspec-collection_matchers"
   gem "rspec-rails"
+  gem "rubocop-govuk"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,11 +168,6 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (~> 0.12)
-    govuk-lint (4.2.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_admin_template (6.7.0)
       bootstrap-sass (= 3.4.1)
       jquery-rails (~> 4.3.1)
@@ -384,6 +379,10 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-govuk (1.0.0)
+      rubocop (~> 0.76)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
     rubocop-rails (2.3.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
@@ -408,8 +407,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
     select2-rails (3.5.7)
       thor (~> 0.14)
     selenium-webdriver (3.142.6)
@@ -498,7 +495,6 @@ DEPENDENCIES
   gds-api-adapters (~> 61.0)
   gds-sso
   google-api-client
-  govuk-lint (~> 4.2.0)
   govuk_admin_template
   govuk_app_config (~> 2.0)
   govuk_sidekiq (~> 3.0)
@@ -518,6 +514,7 @@ DEPENDENCIES
   rails-controller-testing
   rspec-collection_matchers
   rspec-rails
+  rubocop-govuk
   sass
   sass-rails
   select2-rails (= 3.5.7)

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -2,5 +2,5 @@ desc "Run rubocop with similar params to CI"
 task :lint do
   next if ENV["JENKINS"]
 
-  sh "bundle exec rubocop --diff --format clang app spec lib"
+  sh "bundle exec rubocop --format clang app spec lib"
 end

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,6 +1,6 @@
-desc "Run govuk-lint with similar params to CI"
+desc "Run rubocop with similar params to CI"
 task :lint do
   next if ENV["JENKINS"]
 
-  sh "bundle exec govuk-lint-ruby --diff --format clang app spec lib"
+  sh "bundle exec rubocop --diff --format clang app spec lib"
 end


### PR DESCRIPTION
- The GOV.UK Lint gem is deprecated in favour of using Rubocop directly
  with a set of shared configs.
- See https://github.com/alphagov/govuk-rfcs/pull/ 100 for more context.

https://trello.com/c/CdBFg6yw/1521-replace-govuk-lint-with-rubocop-govuk