### PR TITLE
Fix date specific test

### DIFF
--- a/features/site.feature
+++ b/features/site.feature
@@ -116,6 +116,7 @@ Scenario: Jumping to a non-existent site
 
 Scenario: Editing a site's transition date as a GDS Editor
   Given I have logged in as a GDS Editor
+  And the date is 29/11/19
   And a site bis exists
   And I visit this site page
   When I edit this site's transition date


### PR DESCRIPTION
2014 doesn't appear in the select list once the date rolls around to 2020.