### PR TITLE
Remove `lint` Rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,4 +7,4 @@ require File.expand_path('../config/application', __FILE__)
 Rails.application.load_tasks
 
 task(:default).clear
-task :default => [:spec, :cucumber, 'jasmine:ci', :lint, :check_for_bad_time_handling]
+task :default => [:spec, :cucumber, 'jasmine:ci', :check_for_bad_time_handling]

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,6 +1,0 @@
-desc "Run rubocop with similar params to CI"
-task lint: :environment do
-  next if ENV["JENKINS"]
-
-  sh "bundle exec rubocop --format clang app spec lib"
-end


### PR DESCRIPTION
- Now we don't use `govuk-lint` to wrap RuboCop, we _could_ switch this
  to run `bundle exec rubocop`, but that's not very useful as it hides
  the directories that it operates on, and we're trying to move away
  from wrappers.
- Instead, I think we can leave people to run `bundle exec rubocop` on
  their own - it's less typing than `bundle exec rake lint` and
  `rubocop --help` works for options.
- This had "ignore if ENV["CI"]", too.

https://trello.com/c/IEUuFOVa/129-remove-the-lint-rake-task-from-apps-that-have-it
as part of the developer tooling group.