### PR TITLE
Fix gem deprecation warnings

### DIFF
--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -1,8 +1,8 @@
 <%
 rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
 rerun_opts = rerun.to_s.strip.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
-std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags ~@wip"
+std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags 'not @wip'"
 %>
 default: <%= std_opts %> features
 wip: --tags @wip:3 --wip features
-rerun: <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags ~@wip
+rerun: <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags "not @wip"

--- a/features/support/allow_rescue.rb
+++ b/features/support/allow_rescue.rb
@@ -15,7 +15,7 @@ Before('@allow-rescue') do
   Rails.application.env_config['action_dispatch.show_detailed_exceptions'] = false
 end
 
-Before('~@allow-rescue') do
+Before('not @allow-rescue') do
   # Turn on the default debug exceptions app for local requests
   Rails.application.config.consider_all_requests_local = true
   Rails.application.config.action_dispatch.show_exceptions = false

--- a/features/support/set_javascript_flag.rb
+++ b/features/support/set_javascript_flag.rb
@@ -2,6 +2,6 @@ Before('@javascript') do
   @_javascript = true
 end
 
-Before('~@javascript') do
+Before('not @javascript') do
   @_javascript = false
 end

--- a/spec/lib/transition/import/whitehall_orgs_spec.rb
+++ b/spec/lib/transition/import/whitehall_orgs_spec.rb
@@ -39,7 +39,7 @@ describe Transition::Import::WhitehallOrgs do
 
     context "when there are some organisations in the API" do
       before do
-        organisations_api_has_organisations %w[ministry-of-funk department-of-soul hm-rock-and-roll]
+        stub_organisations_api_has_organisations %w[ministry-of-funk department-of-soul hm-rock-and-roll]
       end
 
       it "extracts all the organisations from the API" do
@@ -50,7 +50,7 @@ describe Transition::Import::WhitehallOrgs do
     context "when there are so many organisations in the API that it paginates" do
       before do
         # The default pagination is 20, so make 21 to trigger this
-        organisations_api_has_organisations %w[
+        stub_organisations_api_has_organisations %w[
           ministry-of-funk-1 department-of-soul-1 hm-rock-and-roll-1
           ministry-of-funk-2 department-of-soul-2 hm-rock-and-roll-2
           ministry-of-funk-3 department-of-soul-3 hm-rock-and-roll-3


### PR DESCRIPTION
- See commits for more detail on the specific deprecations.
- The reason for this is that ahead of upgrading to Rails 6, I ran the
  tests locally to make sure my Docker setup worked. I noticed some of
  these which will only get lost in all of the Rails upgrade related
  deprecations, so fix them first then Dependabot can rebase.