### PR TITLE
Fix missing `require` in hits import script

### DIFF
--- a/lib/transition/import/hits.rb
+++ b/lib/transition/import/hits.rb
@@ -1,4 +1,5 @@
 require "pathname"
+require "services"
 require "transition/import/console_job_wrapper"
 require "transition/import/postgresql_settings"
 require "transition/import/hits/ignore"


### PR DESCRIPTION
- This has been failing on Production for a few days (since the Rails
  6 upgrade last week):

```
rake aborted!
NameError: uninitialized constant Transition::Import::Hits::Services
/data/vhost/transition/releases/20200313120259/lib/transition/import/hits.rb:80:in `from_s3!'
```

- It was missing `require "services"`. I have no idea why all these
  explicit `require`s have suddenly needed to happen, but we fixed a few
  of them in 4a81e0bed4d808a23116a52b47fe6d5ae6590526, but obviously not enough.
- It's probably worth doing a deeper investigation into what changed in
  Rails 6 to make them not implicit any more, but this fixes the
  immediate problem that hits data for transitioned sites is not getting
  in.