### PR TITLE
Run RuboCop as part of `bundle exec rake`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,24 +7,6 @@ inherit_mode:
   merge:
     - Exclude
 
-# We like using `render/redirect and return` in controllers, like
-# the rails guides suggest (see: http://guides.rubyonrails.org/layouts_and_rendering.html#avoiding-double-render-errors)
-# so enable this cop only for conditionals
-Style/AndOr:
-  EnforcedStyle: conditionals
-
-AllCops:
-  Exclude:
-    - db/migrate/201*.rb
-    - db/schema.rb
-
-Metrics/BlockLength:
-  Exclude:
-    - 'config/routes.rb'
-    - 'lib/tasks/**/*.rake'
-    - 'spec/**/*.rb'
-    - 'db/migrate/*.rb'
-
 Rails/OutputSafety:
   Enabled: false
 Rails/HelperInstanceVariable:

--- a/Rakefile
+++ b/Rakefile
@@ -7,4 +7,4 @@ require File.expand_path("config/application", __dir__)
 Rails.application.load_tasks
 
 Rake::Task[:default].clear
-task default: [:spec, :cucumber, "jasmine:ci"]
+task default: [:lint, :spec, :cucumber, "jasmine:ci"]

--- a/app/controllers/mappings_controller.rb
+++ b/app/controllers/mappings_controller.rb
@@ -53,7 +53,7 @@ class MappingsController < ApplicationController
   end
 
   def edit_multiple
-    redirect_to(bulk_edit.return_path, notice: bulk_edit.params_errors) and return if bulk_edit.params_invalid?
+    redirect_to(bulk_edit.return_path, notice: bulk_edit.params_errors) && return if bulk_edit.params_invalid?
 
     if request.xhr?
       render "edit_multiple_modal", layout: nil
@@ -61,14 +61,14 @@ class MappingsController < ApplicationController
   end
 
   def update_multiple
-    redirect_to(bulk_edit.return_path, notice: bulk_edit.params_errors) and return if bulk_edit.params_invalid?
+    redirect_to(bulk_edit.return_path, notice: bulk_edit.params_errors) && return if bulk_edit.params_invalid?
 
     if bulk_edit.would_fail?
       if bulk_edit.would_fail_on_new_url?
-        render(action: "edit_multiple") and return
+        render(action: "edit_multiple") && return
       else
         flash[:danger] = "Validation failed"
-        redirect_to(bulk_edit.return_path) and return
+        redirect_to(bulk_edit.return_path) && return
       end
     end
 
@@ -88,7 +88,7 @@ class MappingsController < ApplicationController
 
   def find_global
     # This allows finding a mapping without knowing the site first.
-    render_error(400) and return if params[:url].blank?
+    render_error(400) && return if params[:url].blank?
 
     # Strip leading and trailing whitespace before any processing.
     stripped_url = params[:url].strip
@@ -102,7 +102,7 @@ class MappingsController < ApplicationController
     begin
       url = Addressable::URI.parse(url)
     rescue Addressable::URI::InvalidURIError
-      render_error(400) and return
+      render_error(400) && (return)
     end
 
     url.host = Host.canonical_hostname(url.host)

--- a/app/validators/is_path_validator.rb
+++ b/app/validators/is_path_validator.rb
@@ -4,13 +4,13 @@ class IsPathValidator < ActiveModel::EachValidator
       record.errors.add(
         attribute,
         "can't be blank",
-      ) and return
+      ) && return
     end
     if /^[^\/]/.match?(value)
       record.errors.add(
         attribute,
         'must start with a forward slash "/"',
-      ) and return
+      ) && return
     end
 
     valid_path = begin

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,4 @@
+desc "Run RuboCop"
+task lint: :environment do
+  sh "bundle exec rubocop --format clang"
+end

--- a/lib/transition/import/hits.rb
+++ b/lib/transition/import/hits.rb
@@ -81,10 +81,10 @@ module Transition
         Services.s3.list_objects(bucket: bucket).each do |resp|
           resp.contents.each do |object|
             start "Importing #{object.key}" do |job|
-              job.skip! and next if object.key.end_with? ".csv.metadata"
+              job.skip! && next if object.key.end_with? ".csv.metadata"
 
               import_record = find_import_record(object.key)
-              job.skip! and next if import_record.content_hash == object.etag
+              job.skip! && next if import_record.content_hash == object.etag
 
               is_tsv = object.key.end_with? ".tsv"
               load_data_query = is_tsv ? LOAD_TSV_DATA : LOAD_CSV_DATA
@@ -108,7 +108,7 @@ module Transition
           content_hash = Digest::SHA1.hexdigest(File.read(relative_filename))
 
           import_record = find_import_record(relative_filename)
-          job.skip! and next if import_record.content_hash == content_hash
+          job.skip! && next if import_record.content_hash == content_hash
 
           from_stream!(
             load_data_query,


### PR DESCRIPTION
- This is a prerequisite for being able to move more of our apps to GitHub Actions. We want one single step `bundle exec rake` that runs everything. This ensures parity between local dev and what CI runs (something that we don't always have now).
- The state of `rubocop-govuk` has moved on since we first hand-crafted this `.rubocop.yml`. While we're here I thought we'd better make this as consistent as possible with upstream and stop overriding really old cops, or cops that were easily (ie auto-) fixable.

https://trello.com/c/5Gob6WUL/147-for-everyone-ensure-that-rubocop-runs-as-part-of-bundle-exec-rake-as-one-of-the-default-tasks