### PR TITLE
Swap `around(:all)` for `around(:example)`

### DIFF
--- a/spec/controllers/hits_controller_spec.rb
+++ b/spec/controllers/hits_controller_spec.rb
@@ -27,7 +27,7 @@ describe HitsController do
     ]
   end
 
-  around(:all) do |example|
+  around(:example) do |example|
     Timecop.freeze(Date.new(2013, 1, 1)) { example.run }
   end
 

--- a/spec/helpers/sites_helper_spec.rb
+++ b/spec/helpers/sites_helper_spec.rb
@@ -5,7 +5,7 @@ describe SitesHelper do
     let(:site)      { double("site") }
     let(:halloween) { Date.new(2013, 10, 31) }
 
-    around(:all) do |example|
+    around(:example) do |example|
       Timecop.freeze(halloween) { example.run }
     end
 


### PR DESCRIPTION
`around(:all)` is invalid syntax when placed on a context. `around(:example)`
works on contexts and has the desired effect.

Warning from rspec:
```
WARNING: `around(:context)` hooks are not supported and behave like `around(:example).
```