### PR TITLE
Make hosts endpoint expire immediately

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -1,9 +1,7 @@
-# rubocop:disable Rails/ApplicationController
-class HostsController < ActionController::Base
+class HostsController < ActionController::API
   def index
     @hosts = Host.with_cname_or_ip_address.order(:hostname)
 
     render json: HostsPresenter.new(@hosts).as_hash.to_json
   end
 end
-# rubocop:enable Rails/ApplicationController

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -1,7 +1,7 @@
 class HostsController < ActionController::API
   def index
     @hosts = Host.with_cname_or_ip_address.order(:hostname)
-
+    expires_now
     render json: HostsPresenter.new(@hosts).as_hash.to_json
   end
 end

--- a/spec/controllers/hosts_controller_spec.rb
+++ b/spec/controllers/hosts_controller_spec.rb
@@ -18,5 +18,9 @@ describe HostsController do
         expect(@parsed_response).to have_key(key)
       end
     end
+
+    it "will not be cached" do
+      expect(response.headers["Cache-Control"]).to eq("no-cache")
+    end
   end
 end


### PR DESCRIPTION
This should help new hosts appear in that endpoint very soon after they are imported. We're seeing an issue where the [Bouncer import job](https://github.com/alphagov/govuk-cdn-config/blob/master/lib/deploy_bouncer.rb#L109) is running too soon after the [Transition import job](https://github.com/alphagov/transition/blob/master/lib/transition/import/sites.rb) and misses some of the newly importers hosts as the controller is likely to be cached by Nginx/Varnish.