### PR TITLE
Remove redundant config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,5 @@
 library("govuk")
 
 node {
-  govuk.buildProject(
-    sassLint: false,
-    rubyLintDiff: false
-  )
+  govuk.buildProject()
 }


### PR DESCRIPTION
The sassLint option was removed in https://github.com/alphagov/govuk-jenkinslib/pull/80
And the rubyLintDiff option was removed in https://github.com/alphagov/govuk-jenkinslib/pull/57