### PR TITLE
Add a link to transition-config in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ bundle exec sidekiq -C config/sidekiq.yml
 
 Available at /style, the guide documents how transition is using bootstrap, where the app has diverged from default
 styles and any custom styles needed to fill in the gaps.
+
+## Adding data to the transition app
+
+You can add new URLs and update existing configurations for sites and organisations within the Transition app using the [Transition config](https://github.com/alphagov/transition-config) repo.


### PR DESCRIPTION
## What
Adds a link to the [transition config](https://github.com/alphagov/transition-config) repo to the readme of this repo.

## Why
During a recent 2nd line shift, it wasn't clear to me how to add URLs to the transition tool and I had to ask, where I was point to transition-config. This directs devs to the right place quicker.