### PR TITLE
Include ActiveSupport::LoggerSilence

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -4,3 +4,7 @@
 # which shouldn't be used to store highly confidential information
 # (create the session table with "rails generate session_migration")
 Rails.application.config.session_store :active_record_store
+
+# Ensure we have the `silence` method available on our logger. We use a custom logger
+# from govuk_app_config which doesn't have this by default.
+Rails.logger.class.include ActiveSupport::LoggerSilence


### PR DESCRIPTION
After upgrading activerecord-session_store we hit a problem with our logging (see rails/activerecord-session_store#176 for more details).

The logger provided to us by govuk_app_config doesn't have support for the silence method, so we can add it in place here. If we find that we're needing to this to lots of our applications, we should move it into govuk_app_config.

This should resolve https://sentry.io/organizations/govuk/issues/2303356396/?referrer=slack.