### PR TITLE
Revise tech docs in README to favour GOV.UK Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,31 +3,37 @@
 Rails app for managing the transition of websites to GOV.UK. Specifically, it's for the production of and handling
 of mappings for use with [Bouncer](https://github.com/alphagov/bouncer).
 
-## Dependencies
+## Technical documentation
 
-* Redis
-* PostgreSQL 9.3+ (the app uses materialized views, which were introduced in 9.3).
-  This is included in the Trusty dev VM, which is now the default.
+This is a Ruby on Rails app, and should follow [our Rails app conventions](https://docs.publishing.service.gov.uk/manual/conventions-for-rails-applications.html).
 
-## Running the app
+You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-docker) to run the application and its tests with all the necessary dependencies. Follow [the usage instructions](https://github.com/alphagov/govuk-docker#usage) to get started.
 
-The web application itself is run like any other Rails app, for example:
+**Use GOV.UK Docker to run any commands that follow.**
 
-```sh
-script/rails s
+### Running the tests
+
+```
+bundle exec rake
 ```
 
-In development, you can run sidekiq to process background jobs:
+### Running the worker
 
-```sh
+```
 bundle exec sidekiq -C config/sidekiq.yml
 ```
 
-## Style guide
+### Style guide
 
 Available at /style, the guide documents how transition is using bootstrap, where the app has diverged from default
 styles and any custom styles needed to fill in the gaps.
 
-## Adding data to the transition app
+### Adding data
 
 You can add new URLs and update existing configurations for sites and organisations within the Transition app using the [Transition config](https://github.com/alphagov/transition-config) repo.
+
+To import locally, clone the config repo into `data/` and then run:
+
+```
+bundle exec rake import:all:orgs_sites_hosts
+```

--- a/startup.sh
+++ b/startup.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-bundle install
-bundle exec rails s -p 3044
-


### PR DESCRIPTION
https://trello.com/c/Psf7EzPB/204-move-away-from-startupsh

Depends on: https://github.com/alphagov/govuk-docker/pull/476

This follows the pattern established in [1]. I've added a little
more detail about importing orgs/sites, as this isn't obvious in
the Transition Config README.

[1]: alphagov/content-publisher#2257