### PR TITLE
Use postgres 13 when running tests in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,5 +3,8 @@
 library("govuk")
 
 node {
+  // Run against the Postgres 13 Docker instance on GOV.UK CI
+  govuk.setEnvar("TEST_DATABASE_URL", "postgresql://postgres@127.0.0.1:54313/transition-test")
+
   govuk.buildProject()
 }

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,7 +17,7 @@ development:
 test: &test
   <<: *default
   database: transition_test<%= ENV['TEST_ENV_NUMBER'] %>
-  url: <%= ENV["DATABASE_URL"].try(:sub, /([-_]development)?$/, "_test#{ENV['TEST_ENV_NUMBER']}") %>
+  url: <%= ENV["TEST_DATABASE_URL"] %>
   variables:
     work_mem: 1MB
 


### PR DESCRIPTION
This changes the JenkinsFile to use postgres 13.

Postgres 13 is available at port `54313` on the CI server. By explicitly 
setting the `TEST_DATABASE_URL`, we're telling Rails to use that 
Postgres server.

Previously, Rails implicitly used the default Postgres port `5432` which 
is a Postgres 9.6 server.

Trello ticket: https://trello.com/c/zVdVJqFM