### PR TITLE
Bump govuk_app_config to 4.6 and install sentry-sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem "paper_trail"
 gem "pg"
 gem "plek"
 gem "select2-rails", "~> 3.5.11" # Version 4 changes CSS classes considerably
+gem "sentry-sidekiq"
 gem "whenever"
 
 gem "sass"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,12 +214,12 @@ GEM
       jquery-rails (~> 4.3)
       plek (>= 2.1)
       rails (>= 6)
-    govuk_app_config (4.5.0)
+    govuk_app_config (4.6.0)
       logstasher (~> 2.1)
       prometheus_exporter (~> 2.0)
       puma (~> 5.6)
-      sentry-rails (~> 5.2)
-      sentry-ruby (~> 5.2)
+      sentry-rails (~> 5.3)
+      sentry-ruby (~> 5.3)
       statsd-ruby (~> 1.5)
       unicorn (~> 6.1)
     govuk_sidekiq (5.0.0)
@@ -270,7 +270,7 @@ GEM
     logstasher (2.1.5)
       activesupport (>= 5.2)
       request_store
-    loofah (2.17.0)
+    loofah (2.18.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -459,14 +459,17 @@ GEM
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2)
-    sentry-rails (5.2.1)
+    sentry-rails (5.3.0)
       railties (>= 5.0)
-      sentry-ruby-core (~> 5.2.1)
-    sentry-ruby (5.2.1)
+      sentry-ruby-core (~> 5.3.0)
+    sentry-ruby (5.3.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      sentry-ruby-core (= 5.2.1)
-    sentry-ruby-core (5.2.1)
+      sentry-ruby-core (= 5.3.0)
+    sentry-ruby-core (5.3.0)
       concurrent-ruby
+    sentry-sidekiq (5.3.0)
+      sentry-ruby-core (~> 5.3.0)
+      sidekiq (>= 3.0)
     shoulda-matchers (4.4.1)
       activesupport (>= 4.2.0)
     sidekiq (5.2.10)
@@ -571,6 +574,7 @@ DEPENDENCIES
   sass
   sass-rails
   select2-rails (~> 3.5.11)
+  sentry-sidekiq
   shoulda-matchers
   simplecov
   sprockets


### PR DESCRIPTION
Trello: https://trello.com/c/CXTgjI76/383-look-at-sidekiqjobretryskip-errors-logged-to-sentry

In order to track sidekiq errors apps that use Sidekiq need to install
sentry-sidekiq, this installs it.

Without it a warning will occur on application initialisation and
Sidekiq errors won't be tracked by Sentry.