### PR TITLE
Use Redis.new rather than Redis.current

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -23,13 +23,13 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "08b73523fb7765e682b11e5d8a961f63577150388f8f7c191a440d1d963c8e64",
+      "fingerprint": "94f3e2aaf38a3b488ead3bf57d58874602d71ddf785008e1431ab5b63bef08fe",
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "lib/transition/distributed_lock.rb",
       "line": 12,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "Redis.current.lock(\"transition:#{Rails.env}:#{lock_name}\", :life => (LIFETIME))",
+      "code": "Redis.new.lock(\"transition:#{Rails.env}:#{lock_name}\", :life => (LIFETIME))",
       "render_path": null,
       "location": {
         "type": "method",

--- a/lib/transition/distributed_lock.rb
+++ b/lib/transition/distributed_lock.rb
@@ -9,7 +9,7 @@ module Transition
     end
 
     def lock
-      Redis.current.lock("transition:#{Rails.env}:#{@lock_name}", life: LIFETIME) do
+      Redis.new.lock("transition:#{Rails.env}:#{@lock_name}", life: LIFETIME) do
         Rails.logger.debug("Successfully got a lock. Running...")
         yield
       end


### PR DESCRIPTION
As Redis.current ultimately calls Redis.new we can migrate this method now to pave the way for future upgrades.

From Redis changelog from [5.0][1]:

‘Removed Redis.current. You shouldn't assume there is a single global Redis connection, use a connection pool instead, and libaries using Redis should accept a Redis instance (or connection pool) as a config. E.g. MyLibrary.redis = Redis.new(…).’

[Redis.current][2] just calls Redis.new so should just be able to swap methods.

[trello](https://trello.com/c/oGFWhrCO/1551-migrate-away-from-deprecated-redis-method)