### PR TITLE
Add Rubygem platforms for GOV.UK environments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -319,6 +319,12 @@ GEM
     nokogiri (1.13.9)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    nokogiri (1.13.9-aarch64-linux)
+      racc (~> 1.4)
+    nokogiri (1.13.9-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.9-x86_64-linux)
+      racc (~> 1.4)
     null_logger (0.0.1)
     oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)
@@ -571,7 +577,10 @@ GEM
     zeitwerk (2.6.1)
 
 PLATFORMS
+  aarch64-linux
+  arm64-darwin
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   activerecord-import


### PR DESCRIPTION
This adds Linux, Arm Linux and Arm MacOS platforms for bundler and allows precompiled gems to be installed. This allows faster installation on these platforms and resolves an issue on production where Rubygems can get confused as to which gem to use [1]

[1]: https://github.com/alphagov/publisher/pull/1699/commits/cee149a469376ec9f3ef1577e207de285101783b