### PR TITLE
Fix test that leaves data behind

### DIFF
--- a/spec/controllers/glossary_controller_spec.rb
+++ b/spec/controllers/glossary_controller_spec.rb
@@ -4,13 +4,11 @@ describe GlossaryController do
   describe "#index" do
     render_views
 
-    before(:all) do
+    before do
       site = create(:site, abbr: "cabinetoffice")
       create(:archived, site:)
       create(:redirect, site:, path: "/interesting-news-story", new_url: "https://www.gov.uk/new-url-for-interesting-news-story")
-    end
 
-    before do
       login_as_stub_user
       get :index
     end


### PR DESCRIPTION
This test used a `before(:all)` to write to the database which is data that is then not cleaned up. Thus tests that run after it and expect an empty database fail. Example:
https://ci.integration.publishing.service.gov.uk/job/transition/job/main/1357/console

Tests are run inside a database transaction and, of the potential RSpec before hooks, only before(:each) (the default) happens inside a transaction. Thus if any database writes are done inside a `before(:all)` they need to be cleaned up separately.

There is precedence for cleaning up before(:all) hooks with the `testing_before_all` flag [1]. However I felt that this wasn't needed here and would be more idiomatic to just write to the database for both of this files tests.

In general, the use of `before(:all)` to write to the database should be avoided as it shares states between tests and complicates understanding of the tests.

[1]:https://github.com/alphagov/transition/blob/fe9740e9f97dbb380e1a7ab008b6cc59a3c96e11/spec/support/database_cleaner.rb#L30-L39

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
