### PR TITLE
Dockerfile fixes and cleanup.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,12 @@
 .github
 Dockerfile
 Jenkinsfile
+Procfile
 README.md
+coverage
 docs
+features
+log
+node_modules
+spec
 tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,25 @@
-ARG base_image=ghcr.io/alphagov/govuk-ruby-base:3.1.2
-ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:3.1.2
- 
+ARG ruby_version=3.1.2
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
+
 FROM $builder_image AS builder
 
-WORKDIR /app
-
-COPY Gemfile* .ruby-version /app/
-
+WORKDIR $APP_HOME
+COPY Gemfile* .ruby-version ./
 RUN bundle install
-
-COPY . /app
-
-RUN bundle exec rails assets:precompile && \
-    rm -fr /app/log
+COPY . .
+RUN bootsnap precompile --gemfile .
+RUN rails assets:precompile && rm -fr log
 
 
 FROM $base_image
 
 ENV GOVUK_APP_NAME=transition
 
-WORKDIR /app
-
-COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
-COPY --from=builder /app /app/
+WORKDIR $APP_HOME
+COPY --from=builder $BUNDLE_PATH $BUNDLE_PATH
+COPY --from=builder $BOOTSNAP_CACHE_DIR $BOOTSNAP_CACHE_DIR
+COPY --from=builder $APP_HOME .
 
 USER app
-
-CMD bundle exec puma
+CMD ["puma"]

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "activerecord-import"
 gem "activerecord-session_store"
 gem "acts-as-taggable-on"
 gem "aws-sdk-s3"
+gem "bootsnap", require: false
 gem "gds-api-adapters"
 gem "gds-sso"
 gem "google-api-client"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,8 @@ GEM
     aws-sigv4 (1.5.2)
       aws-eventstream (~> 1, >= 1.0.2)
     bindex (0.8.1)
+    bootsnap (1.15.0)
+      msgpack (~> 1.2)
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
@@ -300,6 +302,7 @@ GEM
     minitest (5.17.0)
     mlanett-redis-lock (0.2.7)
       redis
+    msgpack (1.6.0)
     multi_json (1.15.0)
     multi_test (1.1.0)
     multi_xml (0.6.0)
@@ -581,6 +584,7 @@ DEPENDENCIES
   activerecord-session_store
   acts-as-taggable-on
   aws-sdk-s3
+  bootsnap
   capybara-select-2
   cucumber-rails
   database_cleaner

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,6 +39,10 @@ module Transition
     # Disable origin-checking CSRF mitigation.
     config.action_controller.forgery_protection_origin_check = false
 
+    # Set asset path to be application specific so that we can put all GOV.UK
+    # assets into an S3 bucket and distinguish app by path.
+    config.assets.prefix = "/assets/transition"
+
     # TODO: this is no longer an encouraged pattern for dynamic error pages
     # as it has many edgecases (See: https://github.com/rails/rails/pull/17815)
     # We should consider changing how we do this.

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,4 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
+require "bootsnap/setup"

--- a/spec/support/jasmine-browser.json
+++ b/spec/support/jasmine-browser.json
@@ -1,5 +1,5 @@
 {
-  "srcDir": "public/assets",
+  "srcDir": "public/assets/transition",
   "srcFiles": [
     "govuk-admin-template-*.js",
     "application-*.js"


### PR DESCRIPTION
- Fix Rails assets deployment to S3 by including the app name in the Rails assets path.
- Parameterise the Ruby version.
- Enable [bootsnap](https://github.com/Shopify/bootsnap#bootsnap-).
- Remove some hard-coded paths.
- Clean up `.dockerignore`.
- Make better use of `WORKDIR`.
- Remove the now-redundant `bundle exec` from the default command.

Tested: builds and comes up healthy on the integration Kubernetes cluster.