### PR TITLE
Remove original lock onces a safe time has passed

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -21,26 +21,6 @@
       "note": "Ultimately this is interpolating a list of integers into the SQL for a WHERE...IN check"
     },
     {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "94f3e2aaf38a3b488ead3bf57d58874602d71ddf785008e1431ab5b63bef08fe",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "lib/transition/distributed_lock.rb",
-      "line": 12,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "Redis.new.lock(\"transition:#{Rails.env}:#{lock_name}\", :life => (LIFETIME))",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Transition::DistributedLock",
-        "method": "lock"
-      },
-      "user_input": "Rails.env",
-      "confidence": "Weak",
-      "note": "This is only called with constant, safe, strings"
-    },
-    {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
       "fingerprint": "38b7bf3af8733d01999c901c03369bf71414a355a3b6b12f84c68fb117365470",

--- a/lib/transition/distributed_lock.rb
+++ b/lib/transition/distributed_lock.rb
@@ -5,19 +5,16 @@ module Transition
     LIFETIME = (5 * 60) # seconds
 
     def initialize(lock_name)
-      @lock_name = lock_name
       @full_lock_name = ActiveRecord::Base.sanitize_sql("transition:#{lock_name}")
     end
 
     def lock
-      Redis.new.lock("transition:#{Rails.env}:#{@lock_name}", life: LIFETIME) do
-        Redis.new.lock(@full_lock_name, life: LIFETIME) do
-          Rails.logger.debug("Successfully got a lock. Running...")
-          yield
-        end
+      Redis.new.lock(@full_lock_name, life: LIFETIME) do
+        Rails.logger.debug("Successfully got a lock. Running...")
+        yield
       end
     rescue Redis::Lock::LockNotAcquired => e
-      Rails.logger.debug("Failed to get lock for #{@lock_name} (#{e.message}). Another process probably got there first.")
+      Rails.logger.debug("Failed to get lock for #{@full_lock_name} (#{e.message}). Another process probably got there first.")
     end
   end
 end


### PR DESCRIPTION
Removes the original lock, moving us to the simplified lock name added here: https://github.com/alphagov/transition/pull/1314

Can be merged once a safe period of time has passed (min 24 hours after original pull merged, so Thu May 11th would be reasonable)

https://trello.com/c/84yWQ0NJ/1662-ps-15-clean-up-brakeman-errors-following-on-from-rediscurrent-redisnew-updates

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
