### PR TITLE
Add new transition form

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -1,11 +1,26 @@
 class SitesController < ApplicationController
-  before_action :find_site
+  before_action :find_site, only: %i[edit update show]
+  before_action :find_organisation, only: %i[new create]
   before_action :check_user_is_gds_editor, only: %i[edit update]
+
+  def new
+    @site_form = SiteForm.new(organisation_slug: @organisation.whitehall_slug)
+  end
+
+  def create
+    @site_form = SiteForm.new(create_params)
+
+    if (site = @site_form.save)
+      redirect_to site_path(site), flash: { success: "Transition site created" }
+    else
+      render :new
+    end
+  end
 
   def edit; end
 
   def update
-    if @site.update(site_params)
+    if @site.update(update_params)
       redirect_to site_path(@site), flash: { success: "Transition date updated" }
     else
       redirect_to edit_site_path(@site), flash: { alert: "We couldn't save your change" }
@@ -24,7 +39,30 @@ private
     @site = Site.find_by!(abbr: params[:id])
   end
 
-  def site_params
+  def find_organisation
+    @organisation = Organisation.find_by(whitehall_slug: params[:organisation_id])
+  end
+
+  def create_params
+    params.require(:site_form).permit(
+      :organisation_slug,
+      :abbr,
+      :tna_timestamp,
+      :homepage,
+      :homepage_title,
+      :global_type,
+      :global_new_url,
+      :global_redirect_append_path,
+      :homepage_furl,
+      :hostname,
+      :query_params,
+      :special_redirect_strategy,
+      :aliases,
+      extra_organisations: [],
+    )
+  end
+
+  def update_params
     params.require(:site).permit(:launch_date)
   end
 

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -2,6 +2,7 @@ class SitesController < ApplicationController
   before_action :find_site, only: %i[edit update show]
   before_action :find_organisation, only: %i[new create]
   before_action :check_user_is_gds_editor, only: %i[edit update]
+  before_action :check_user_is_site_manager, only: %i[new create]
 
   def new
     @site_form = SiteForm.new(organisation_slug: @organisation.whitehall_slug)
@@ -70,6 +71,13 @@ private
     unless current_user.gds_editor?
       message = "Only GDS Editors can access that."
       redirect_to site_path(@site), alert: message
+    end
+  end
+
+  def check_user_is_site_manager
+    unless current_user.site_manager?
+      message = "Only Site Managers can access that."
+      redirect_to organisation_path(@organisation), alert: message
     end
   end
 end

--- a/app/forms/site_form.rb
+++ b/app/forms/site_form.rb
@@ -1,0 +1,105 @@
+class SiteForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :organisation_slug
+  attribute :abbr
+  attribute :tna_timestamp, :datetime
+  attribute :homepage
+  attribute :homepage_title
+  attribute :extra_organisations
+  attribute :global_type
+  attribute :global_new_url
+  attribute :homepage_furl
+  attribute :query_params
+  attribute :global_redirect_append_path, :boolean, default: false
+  attribute :special_redirect_strategy
+
+  attribute :hostname
+  attribute :aliases
+
+  validate :validate_children
+  validate :validate_aliases
+  validate :aliases_are_unique
+
+  def save
+    return false if invalid?
+
+    ActiveRecord::Base.transaction do
+      site.save!
+      hosts.each(&:save!)
+      aka_hosts.each(&:save!)
+    end
+
+    site
+  end
+
+  def organisations
+    Organisation.where.not(whitehall_slug: organisation_slug)
+  end
+
+private
+
+  def site
+    @site ||= Site.new(
+      abbr:,
+      tna_timestamp:,
+      homepage:,
+      organisation: Organisation.find_by(whitehall_slug: organisation_slug),
+      extra_organisations: Organisation.where(title: extra_organisations),
+      homepage_title:,
+      homepage_furl:,
+      global_type:,
+      global_new_url:,
+      global_redirect_append_path:,
+      query_params:,
+      special_redirect_strategy:,
+    )
+  end
+
+  def hosts
+    [default_host].concat(alias_hosts)
+  end
+
+  def aka_hosts
+    hosts.map { |host| build_aka_host(host) }
+  end
+
+  def default_host
+    @default_host ||= Host.new(hostname:, site:)
+  end
+
+  def alias_hosts
+    return [] if aliases.nil?
+
+    @alias_hosts ||= aliases.split(",").map do |host|
+      Host.new(hostname: host, site:)
+    end
+  end
+
+  def build_aka_host(host)
+    Host.new(hostname: host.aka_hostname, canonical_host: host, site:)
+  end
+
+  def validate_children
+    [site, default_host].each do |child|
+      errors.merge!(child.errors) if child.invalid?
+    end
+  end
+
+  def validate_aliases
+    alias_hosts.each do |host|
+      next if host.valid?
+
+      host.errors.each do |error|
+        errors.add(:aliases, "\"#{host.hostname}\" #{error.message}")
+      end
+    end
+  end
+
+  def aliases_are_unique
+    if alias_hosts.length != alias_hosts.map(&:hostname).uniq.length
+      errors.add(:aliases, "must be unique")
+    end
+  end
+end

--- a/app/models/concerns/nilify_blanks.rb
+++ b/app/models/concerns/nilify_blanks.rb
@@ -7,7 +7,15 @@ module NilifyBlanks
 
   def nilify_blanks
     attributes.each do |column, value|
+      next if nilify_except.include?(column.to_sym)
+
       self[column] = nil if value.blank?
     end
+  end
+
+private
+
+  def nilify_except
+    []
   end
 end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -12,6 +12,7 @@ class Host < ApplicationRecord
   validates :hostname, hostname: true
   validates :site, presence: true
   validate :canonical_host_id_xor_aka_present, if: -> { hostname.present? }
+  validate :hostname_is_downcased, if: -> { hostname.present? }
 
   after_update :update_hits_relations, if: :saved_change_to_site_id?
 
@@ -70,5 +71,11 @@ class Host < ApplicationRecord
     host_paths.update_all(mapping_id: nil, canonical_path: nil)
     hits.update_all(mapping_id: nil)
     Transition::Import::HitsMappingsRelations.refresh!(site)
+  end
+
+  def hostname_is_downcased
+    if hostname != hostname.downcase
+      errors.add(:hostname, "must be lowercase")
+    end
   end
 end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -11,7 +11,7 @@ class Host < ApplicationRecord
   validates :hostname, presence: true
   validates :hostname, hostname: true
   validates :site, presence: true
-  validate :canonical_host_id_xor_aka_present
+  validate :canonical_host_id_xor_aka_present, if: -> { hostname.present? }
 
   after_update :update_hits_relations, if: :saved_change_to_site_id?
 

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -25,6 +25,7 @@ class Site < ApplicationRecord
   validates :abbr, uniqueness: true, presence: true, format: { with: /\A[a-zA-Z0-9_-]+\z/, message: "can only contain alphanumeric characters, underscores and dashes" }
   validates :special_redirect_strategy, inclusion: { in: SPECIAL_REDIRECT_STRATEGY_TYPES, allow_nil: true }
   validates :global_new_url, presence: { if: :global_redirect? }
+  validates :global_new_url, absence: { if: :global_archive? }
   validates :global_new_url,
             format: { without: /\?/,
                       message: "cannot contain a query when the path is appended",

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -2,6 +2,8 @@ require "postgres/materialized_view"
 require "./lib/transition/path_or_url"
 
 class Site < ApplicationRecord
+  include NilifyBlanks
+
   GLOBAL_TYPES = %w[redirect archive].freeze
   SPECIAL_REDIRECT_STRATEGY_TYPES = %w[via_aka supplier].freeze
 
@@ -23,7 +25,7 @@ class Site < ApplicationRecord
   validates :organisation, presence: true
   validates :homepage, presence: true, non_blank_url: true
   validates :abbr, uniqueness: true, presence: true, format: { with: /\A[a-zA-Z0-9_-]+\z/, message: "can only contain alphanumeric characters, underscores and dashes" }
-  validates :special_redirect_strategy, inclusion: { in: SPECIAL_REDIRECT_STRATEGY_TYPES, allow_nil: true }
+  validates :special_redirect_strategy, inclusion: { in: SPECIAL_REDIRECT_STRATEGY_TYPES, allow_blank: true }
   validates :global_new_url, presence: { if: :global_redirect? }
   validates :global_new_url, absence: { if: :global_archive? }
   validates :global_new_url,
@@ -134,5 +136,9 @@ private
 
   def remove_all_hits_view
     Postgres::MaterializedView.drop(precomputed_view_name)
+  end
+
+  def nilify_except
+    %i[global_redirect_append_path query_params precompute_all_hits_view]
   end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -2,6 +2,9 @@ require "postgres/materialized_view"
 require "./lib/transition/path_or_url"
 
 class Site < ApplicationRecord
+  GLOBAL_TYPES = %w[redirect archive].freeze
+  SPECIAL_REDIRECT_STRATEGY_TYPES = %w[via_aka supplier].freeze
+
   belongs_to :organisation
 
   has_many :hosts
@@ -20,7 +23,7 @@ class Site < ApplicationRecord
   validates :organisation, presence: true
   validates :homepage, presence: true, non_blank_url: true
   validates :abbr, uniqueness: true, presence: true, format: { with: /\A[a-zA-Z0-9_-]+\z/, message: "can only contain alphanumeric characters, underscores and dashes" }
-  validates :special_redirect_strategy, inclusion: { in: %w[via_aka supplier], allow_nil: true }
+  validates :special_redirect_strategy, inclusion: { in: SPECIAL_REDIRECT_STRATEGY_TYPES, allow_nil: true }
   validates :global_new_url, presence: { if: :global_redirect? }
   validates :global_new_url,
             format: { without: /\?/,

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -10,6 +10,8 @@
   <%= render 'in_conjunction_with' %>
 </header>
 
+<%= link_to "Add a transition site", new_organisation_site_path(@organisation), class: "btn btn-default" %>
+
 <% unless @sites.empty? %>
   <h2>Sites</h2>
   <table class="sites table table-hover table-striped table-bordered" data-module="filterable-table">

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -10,7 +10,9 @@
   <%= render 'in_conjunction_with' %>
 </header>
 
-<%= link_to "Add a transition site", new_organisation_site_path(@organisation), class: "btn btn-default" %>
+<% if current_user.site_manager? %>
+  <%= link_to "Add a transition site", new_organisation_site_path(@organisation), class: "btn btn-default" %>
+<% end %>
 
 <% unless @sites.empty? %>
   <h2>Sites</h2>

--- a/app/views/sites/new.html.erb
+++ b/app/views/sites/new.html.erb
@@ -1,0 +1,96 @@
+<% breadcrumb(:new_site, @organisation) %>
+
+<div class="page-title-with-border">
+  <h1>New transition site</h1>
+</div>
+
+<%= form_for @site_form, html: { role: "form" }, url: organisation_sites_path do |form| %>
+  <%= render "shared/error_messages", error_messages: form.object.errors.full_messages %>
+
+  <div class="form-group row">
+    <div class="col-md-8">
+      <%= form.hidden_field :organisation_slug, value: @organisation.whitehall_slug %>
+
+      <div class="form-group">
+        <%= form.label :abbr %>
+        <%= form.text_field :abbr, class: "form-control" %>
+      </div>
+
+      <div class="form-group">
+        <%= form.label :tna_timestamp %>
+        <%= form.text_field :tna_timestamp, class: "form-control" %>
+      </div>
+
+      <div class="form-group">
+        <%= form.label :homepage %>
+        <%= form.text_field :homepage, class: "form-control" %>
+      </div>
+
+      <div class="form-group">
+        <%= form.label :hostname %>
+        <%= form.text_field :hostname, class: "form-control" %>
+      </div>
+
+      <div class="form-group">
+        <%= form.label :homepage_title %>
+        <%= form.text_field :homepage_title, class: "form-control" %>
+      </div>
+
+      <div class="form-group">
+        <%= form.label :extra_organisations %>
+        <%= form.collection_select :extra_organisations,
+                                   form.object.organisations,
+                                   :id,
+                                   :title,
+                                   {},
+                                   { multiple: true, class: "form-control" }
+        %>
+      </div>
+
+      <div class="form-group">
+        <%= form.label :homepage_furl %>
+        <%= form.text_field :homepage_furl, class: "form-control" %>
+      </div>
+
+      <div class="form-group">
+        <%= form.label :global_type %>
+        <%= form.collection_radio_buttons :global_type,
+                                          Site::GLOBAL_TYPES,
+                                          :to_s,
+                                          :humanize
+        %>
+      </div>
+
+      <div class="form-group">
+        <%= form.label :global_new_url %>
+        <%= form.text_field :global_new_url, class: "form-control" %>
+      </div>
+
+      <div class="form-group">
+        <%= form.label :query_params %>
+        <%= form.text_field :query_params, class: "form-control" %>
+      </div>
+
+      <div class="form-group">
+        <%= form.label :global_redirect_append_path %>
+        <%= form.check_box :global_redirect_append_path %>
+      </div>
+
+      <div class="form-group">
+        <%= form.label :special_redirect_strategy %>
+        <%= form.collection_radio_buttons :special_redirect_strategy,
+                                          Site::SPECIAL_REDIRECT_STRATEGY_TYPES,
+                                          :to_s,
+                                          :humanize
+        %>
+      </div>
+
+      <div class="form-group">
+        <%= form.label :aliases %>
+        <%= form.text_area :aliases, class: "form-control" %>
+      </div>
+
+      <%= form.submit 'Save', class: 'add-top-margin btn btn-success' %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/sites/new.html.erb
+++ b/app/views/sites/new.html.erb
@@ -13,27 +13,32 @@
 
       <div class="form-group">
         <%= form.label :abbr %>
-        <%= form.text_field :abbr, class: "form-control" %>
+        <%= form.text_field :abbr, class: "form-control", aria: { describedby: "abbr-help" } %>
+        <small id="abbr-help" class="form-text text-muted"><%= I18n.t("activemodel.hint.site_form.abbr") %></small>
       </div>
 
       <div class="form-group">
         <%= form.label :tna_timestamp %>
-        <%= form.text_field :tna_timestamp, class: "form-control" %>
+        <%= form.text_field :tna_timestamp, class: "form-control", aria: { describedby: "tna-timestamp-help" } %>
+        <small id="tna-timestamp-help" class="form-text text-muted"><%= I18n.t("activemodel.hint.site_form.tna_timestamp").html_safe %></small>
       </div>
 
       <div class="form-group">
         <%= form.label :homepage %>
-        <%= form.text_field :homepage, class: "form-control" %>
+        <%= form.text_field :homepage, class: "form-control", aria: { describedby: "homepage-help" } %>
+        <small id="homepage-help" class="form-text text-muted"><%= I18n.t("activemodel.hint.site_form.homepage") %></small>
       </div>
 
       <div class="form-group">
         <%= form.label :hostname %>
-        <%= form.text_field :hostname, class: "form-control" %>
+        <%= form.text_field :hostname, class: "form-control", aria: { describedby: "hostname-help" } %>
+        <small id="hostname-help" class="form-text text-muted"><%= I18n.t("activemodel.hint.site_form.hostname") %></small>
       </div>
 
       <div class="form-group">
         <%= form.label :homepage_title %>
-        <%= form.text_field :homepage_title, class: "form-control" %>
+        <%= form.text_field :homepage_title, class: "form-control", aria: { describedby: "homepage-title-help" } %>
+        <small id="homepage-title-help" class="form-text text-muted"><%= I18n.t("activemodel.hint.site_form.homepage_title") %></small>
       </div>
 
       <div class="form-group">
@@ -43,13 +48,15 @@
                                    :id,
                                    :title,
                                    {},
-                                   { multiple: true, class: "form-control" }
+                                   { multiple: true, class: "form-control", aria: { describedby: "extra-organisations-help" } }
         %>
+        <small id="extra-organisations-help" class="form-text text-muted"><%= I18n.t("activemodel.hint.site_form.extra_organisations") %></small>
       </div>
 
       <div class="form-group">
         <%= form.label :homepage_furl %>
-        <%= form.text_field :homepage_furl, class: "form-control" %>
+        <%= form.text_field :homepage_furl, class: "form-control", aria: { describedby: "homepage-furl-help" } %>
+        <small id="homepage-furl-help" class="form-text text-muted"><%= I18n.t("activemodel.hint.site_form.homepage_furl") %></small>
       </div>
 
       <div class="form-group">
@@ -57,13 +64,15 @@
         <%= form.collection_radio_buttons :global_type,
                                           Site::GLOBAL_TYPES,
                                           :to_s,
-                                          :humanize do |button| %>
+                                          :humanize,
+                                          aria: { describedby: "global-type-help" } do |button| %>
           <div class="radio">
             <%= button.label do %>
               <%= button.radio_button + button.text %>
             <% end %>
           </div>
         <% end %>
+        <small id="global-type-help" class="form-text text-muted"><%= I18n.t("activemodel.hint.site_form.global_type") %></small>
       </div>
 
       <div class="form-group">
@@ -73,12 +82,14 @@
 
       <div class="form-group">
         <%= form.label :query_params %>
-        <%= form.text_field :query_params, class: "form-control" %>
+        <%= form.text_field :query_params, class: "form-control", aria: { describedby: "query-params-help" } %>
+        <small id="query-params-help" class="form-text text-muted row"><%= I18n.t("activemodel.hint.site_form.query_params") %></small>
       </div>
 
-      <div class="form-group">
+      <div class="form-check">
         <%= form.label :global_redirect_append_path %>
-        <%= form.check_box :global_redirect_append_path %>
+        <%= form.check_box :global_redirect_append_path, aria: { describedby: "global-redirect-append-path-help" } %>
+        <small id="global-redirect-append-path-help" class="form-text text-muted row"><%= I18n.t("activemodel.hint.site_form.global_redirect_append_path") %></small>
       </div>
 
       <div class="form-group">
@@ -86,18 +97,21 @@
         <%= form.collection_radio_buttons :special_redirect_strategy,
                                           Site::SPECIAL_REDIRECT_STRATEGY_TYPES,
                                           :to_s,
-                                          :humanize do |button| %>
+                                          :humanize,
+                                          aria: { describedby: "special-redirect-strategy-help" } do |button| %>
           <div class="radio">
             <%= button.label do %>
               <%= button.radio_button + button.text %>
             <% end %>
           </div>
         <% end %>
+        <small id="special-redirect-strategy-help" class="form-text text-muted"><%= I18n.t("activemodel.hint.site_form.special_redirect_strategy") %></small>
       </div>
 
       <div class="form-group">
         <%= form.label :aliases %>
-        <%= form.text_area :aliases, class: "form-control" %>
+        <%= form.text_area :aliases, class: "form-control", aria: { describedby: "aliases-help" } %>
+        <small id="aliases-help" class="form-text text-muted"><%= I18n.t("activemodel.hint.site_form.aliases") %></small>
       </div>
 
       <%= form.submit 'Save', class: 'add-top-margin btn btn-success' %>

--- a/app/views/sites/new.html.erb
+++ b/app/views/sites/new.html.erb
@@ -57,8 +57,13 @@
         <%= form.collection_radio_buttons :global_type,
                                           Site::GLOBAL_TYPES,
                                           :to_s,
-                                          :humanize
-        %>
+                                          :humanize do |button| %>
+          <div class="radio">
+            <%= button.label do %>
+              <%= button.radio_button + button.text %>
+            <% end %>
+          </div>
+        <% end %>
       </div>
 
       <div class="form-group">
@@ -81,8 +86,13 @@
         <%= form.collection_radio_buttons :special_redirect_strategy,
                                           Site::SPECIAL_REDIRECT_STRATEGY_TYPES,
                                           :to_s,
-                                          :humanize
-        %>
+                                          :humanize do |button| %>
+          <div class="radio">
+            <%= button.label do %>
+              <%= button.radio_button + button.text %>
+            <% end %>
+          </div>
+        <% end %>
       </div>
 
       <div class="form-group">

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -7,6 +7,11 @@ crumb :organisation do |organisation|
   parent :root
 end
 
+crumb :new_site do |organisation|
+  link "New transition site"
+  parent :organisation, organisation
+end
+
 crumb :site do |site|
   link site.default_host.hostname, site_path(site)
   parent :organisation, site.organisation

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,21 @@ en:
         query_params: Query params (Optional)
         special_redirect_strategy: Special redirect strategy (Optional)
         aliases: Aliases (Optional)
+    hint:
+      site_form:
+        abbr: This is the owning organisation abbreviation followed by the abbreviated site name, separated by an underscore. For example, the "Obesity West Midlands" site which is owned by Public Health England would be "phe_obesitywm"
+        host: This is the primary hostname for the site. For example, "www.example.com".
+        tna_timestamp: This is the last good capture from the <a href="https://www.nationalarchives.gov.uk/webarchive/" class="govuk-link">UK Government Web Archives</a>. For example, "20131002172858". If the site has not been crawled by the National Archives, set a stub timestamp "20201010101010".
+        homepage: This is the URL for the new site.
+        hostname: This is the primary hostname for the site.
+        homepage_title: This is the title for 404/410 pages, it defaults to the organisation title. It should fit into the sentence "Visit the new [title] site at [full URL or homepage]"
+        extra_organisations: These are the additional organisations which own this site. They are used for access control in Transition.
+        homepage_furl: This is the friendly URL displayed on 404/410 pages. It should redirect to the homepage. It doesn't need to include 'http' or 'https'.
+        global_type: This sets a global redirect or archive for all paths. If "Redirect", all site URLs will redirect to the Global new URL. If "Archive", all site URLs will show a page saying the site has been archived.
+        query_params:  A significant querystring parameter is one which on the old website changes the content in a meaningful way - which we might therefore need to map to a different place. Query string parameters should be specified in lowercase; uppercase parameters will not be preserved during canonicalisation. Enter as a colon-separated list.
+        global_redirect_append_path: Should the path the user supplied be appended to the URL for the global redirect?
+        special_redirect_strategy: When the transition is partial, some tools or content will be left behind and managed by the previous supplier. If "Via aka", the supplier is redirecting some paths to our aka domain. If "supplier", the supplier is managing redirects to gov.uk. No traffic comes through Bouncer for this site.
+        aliases: This is a list of alias domains. Enter as a comma-separated list.
   mappings:
     success:
       all_created: '%{created}%{tagged_with}'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,23 @@ en:
         new_url: 'The URL to redirect to'
       mappings_batch:
         paths: Old URLs
+  activemodel:
+    attributes:
+      site_form:
+        abbr: Abbreviated name
+        host: Host
+        tna_timestamp: TNA timestamp
+        homepage: Homepage
+        homepage_title: Homepage title (Optional)
+        global_type: Global type (Optional)
+        global_new_url: Global new URL (Optional)
+        extra_organisations: Extra organisations (Optional)
+        homepage_furl: Homepage full URL (Optional)
+        options: Options (Optional)
+        global_redirect_append_path: Global redirect append path (Optional)
+        query_params: Query params (Optional)
+        special_redirect_strategy: Special redirect strategy (Optional)
+        aliases: Aliases (Optional)
   mappings:
     success:
       all_created: '%{created}%{tagged_with}'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,9 @@ Rails.application.routes.draw do
 
   resources :hosts, only: [:index]
 
-  resources :organisations, only: %i[show index]
+  resources :organisations, only: %i[show index] do
+    resources :sites, only: %i[new create], controller: :sites
+  end
 
   get "mappings/find_global", to: "mappings#find_global"
   get "hits", to: "hits#universal_summary"

--- a/features/site.feature
+++ b/features/site.feature
@@ -102,6 +102,19 @@ Scenario: Jumping to a non-existent site
   And I jump to the site or mapping "http://not-a-site.gov.uk"
   Then I should see the header "Unknown site"
 
+Scenario: Creating a site
+  Given I have logged in as a GDS Editor
+  And there are these organisations without sites:
+    | whitehall_slug  | title                         |
+    | ukti            | UK Trade & Industry           |
+    | go-science      | Government Office for Science |
+  When I visit the page for the UK Trade & Industry organisation
+  And I click the link "Add a transition site"
+  Then I should be on the new transition site page for the UK Trade & Industry organisation
+  When I fill in the new transition site fields
+  And I save my changes
+  Then I should be redirected to the new site
+
 Scenario: Editing a site's transition date as a GDS Editor
   Given I have logged in as a GDS Editor
   And the date is 29/11/19

--- a/features/site.feature
+++ b/features/site.feature
@@ -103,7 +103,7 @@ Scenario: Jumping to a non-existent site
   Then I should see the header "Unknown site"
 
 Scenario: Creating a site
-  Given I have logged in as a GDS Editor
+  Given I have logged in as a Site Manager
   And there are these organisations without sites:
     | whitehall_slug  | title                         |
     | ukti            | UK Trade & Industry           |

--- a/features/step_definitions/site_interaction_steps.rb
+++ b/features/step_definitions/site_interaction_steps.rb
@@ -1,3 +1,8 @@
+When(/^I visit the page for the (.*) organisation$/) do |organisation_title|
+  organisation = Organisation.find_by(title: organisation_title)
+  visit organisation_path(organisation)
+end
+
 When(/^I visit this site page$/) do
   visit site_path(@site)
 end
@@ -8,4 +13,29 @@ When(/^I edit this site's transition date$/) do
   select("September", from: "site_launch_date_2i")
   select("20", from: "site_launch_date_3i")
   click_button "Save"
+end
+
+When(/^I fill in the new transition site fields/) do
+  fill_in "Abbreviated name", with: "aaib"
+  fill_in "TNA timestamp", with: "20141104112824"
+  fill_in "Homepage", with: "https://www.gov.uk/government/organisations/air-accidents-investigation-branch"
+  fill_in "Hostname", with: "www.aaib.gov.uk"
+  fill_in "Homepage title", with: "Air accidents investigation branch"
+  select "Government Office for Science"
+  fill_in "Homepage full URL", with: "www.gov.uk/aaib"
+  choose "Redirect"
+  fill_in "Global new URL", with: "https://www.gov.uk/government/organisations/air-accidents-investigation-branch/about"
+  fill_in "Query params", with: "file"
+  check "Global redirect append path"
+  choose "Via aka"
+  fill_in "Aliases", with: "aaib.gov.uk,aaib.com"
+end
+
+Then(/^I should be on the new transition site page for the (.*) organisation$/) do |organisation_title|
+  organisation = Organisation.find_by(title: organisation_title)
+  i_should_be_on_the_path new_organisation_site_path(organisation)
+end
+
+Then(/^I should be redirected to the new site$/) do
+  i_should_be_on_the_path site_path(Site.last)
 end

--- a/spec/controllers/sites_controller_spec.rb
+++ b/spec/controllers/sites_controller_spec.rb
@@ -4,6 +4,18 @@ describe SitesController do
   let(:site)    { create :site, abbr: "moj" }
   let(:gds_bob) { create(:gds_editor, name: "Bob Terwhilliger") }
 
+  describe "#new" do
+    let(:organisation) { create(:organisation) }
+
+    before { login_as gds_bob }
+
+    it "returns a success response" do
+      get :new, params: { organisation_id: organisation.whitehall_slug }
+
+      expect(response.status).to eql(200)
+    end
+  end
+
   describe "#edit" do
     context "when the user does have permission" do
       before do

--- a/spec/controllers/sites_controller_spec.rb
+++ b/spec/controllers/sites_controller_spec.rb
@@ -3,16 +3,46 @@ require "rails_helper"
 describe SitesController do
   let(:site)    { create :site, abbr: "moj" }
   let(:gds_bob) { create(:gds_editor, name: "Bob Terwhilliger") }
+  let(:site_manager) { create(:site_manager) }
 
   describe "#new" do
     let(:organisation) { create(:organisation) }
 
-    before { login_as gds_bob }
+    before { login_as site_manager }
 
     it "returns a success response" do
       get :new, params: { organisation_id: organisation.whitehall_slug }
 
       expect(response.status).to eql(200)
+    end
+
+    context "when the user does not have permission" do
+      def make_request
+        get :new, params: { organisation_id: organisation.whitehall_slug }
+      end
+
+      it_behaves_like "disallows editing by non-Site managers"
+    end
+  end
+
+  describe "#create" do
+    let(:organisation) { create(:organisation) }
+    let(:params) { attributes_for(:site_form) }
+
+    before { login_as site_manager }
+
+    it "returns a success response" do
+      post :create, params: { organisation_id: organisation.whitehall_slug, site_form: params }
+
+      expect(response.status).to eql(200)
+    end
+
+    context "when the user does not have permission" do
+      def make_request
+        post :create, params: { organisation_id: organisation.whitehall_slug, site_form: params }
+      end
+
+      it_behaves_like "disallows editing by non-Site managers"
     end
   end
 

--- a/spec/factories/site_forms.rb
+++ b/spec/factories/site_forms.rb
@@ -5,9 +5,9 @@ FactoryBot.define do
     homepage { "https://www.gov.uk/government/organisations/air-accidents-investigation-branch" }
     tna_timestamp { "20141104112824" }
     hostname { "www.aaib.gov.uk" }
-    homepage_title { "Air accidents investigation branch" }
 
     trait :with_optional_fields do
+      homepage_title { "Air accidents investigation branch" }
       homepage_furl { "www.gov.uk/aaib" }
       global_type { "redirect" }
       global_new_url { "https://www.gov.uk/government/organisations/air-accidents-investigation-branch/about" }

--- a/spec/factories/site_forms.rb
+++ b/spec/factories/site_forms.rb
@@ -1,0 +1,27 @@
+FactoryBot.define do
+  factory :site_form do
+    abbr { "aaib" }
+    organisation_slug { "air-accidents-investigation-branch" }
+    homepage { "https://www.gov.uk/government/organisations/air-accidents-investigation-branch" }
+    tna_timestamp { "20141104112824" }
+    hostname { "www.aaib.gov.uk" }
+    homepage_title { "Air accidents investigation branch" }
+
+    trait :with_optional_fields do
+      homepage_furl { "www.gov.uk/aaib" }
+      global_type { "redirect" }
+      global_new_url { "https://www.gov.uk/government/organisations/air-accidents-investigation-branch/about" }
+      query_params { "file" }
+      global_redirect_append_path { true }
+      special_redirect_strategy { "via_aka" }
+    end
+
+    trait :with_aliases do
+      aliases { "aaib.gov.uk,aaib.com" }
+    end
+
+    trait :with_extra_organisations do
+      extra_organisations { ["The adjudicator's office", "Government digital service"] }
+    end
+  end
+end

--- a/spec/factories/site_forms.rb
+++ b/spec/factories/site_forms.rb
@@ -16,6 +16,16 @@ FactoryBot.define do
       special_redirect_strategy { "via_aka" }
     end
 
+    trait :with_blank_optional_fields do
+      homepage_title { "" }
+      homepage_furl { "" }
+      global_type { "" }
+      global_new_url { "" }
+      query_params { "" }
+      global_redirect_append_path { false }
+      special_redirect_strategy { "" }
+    end
+
     trait :with_aliases do
       aliases { "aaib.gov.uk,aaib.com" }
     end

--- a/spec/forms/site_form_spec.rb
+++ b/spec/forms/site_form_spec.rb
@@ -1,0 +1,139 @@
+require "rails_helper"
+
+describe SiteForm do
+  describe "validations" do
+    it "surfaces errors on the site model" do
+      site_form = build(:site_form, tna_timestamp: nil)
+
+      expect(site_form.valid?).to be false
+      expect(site_form.errors[:tna_timestamp]).to include("can't be blank")
+    end
+
+    it "surfaces errors on the default host model" do
+      site_form = build(:site_form, hostname: nil)
+
+      expect(site_form.valid?).to be false
+      expect(site_form.errors[:hostname]).to include("can't be blank")
+    end
+
+    describe "#aliases" do
+      context "when there is a validation error on an alias host" do
+        it "adds the error message and problematic hostname to the errors" do
+          site_form = build(:site_form, aliases: "aaib.gov.uk,,aaib.com")
+
+          expect(site_form.valid?).to be false
+          expect(site_form.errors[:aliases]).to include("\"\" can't be blank") # hostname is blank, hence ""
+        end
+      end
+
+      context "when the list contains duplicates" do
+        it "adds the error message and problematic hostname to the errors" do
+          site_form = build(:site_form, aliases: "aaib.gov.uk,aaib.gov.uk")
+
+          expect(site_form.valid?).to be false
+          expect(site_form.errors[:aliases]).to include("must be unique")
+        end
+      end
+    end
+  end
+
+  describe "#organisations" do
+    let!(:organisation) { create(:organisation, whitehall_slug: organisation_slug) }
+    let!(:other_organisation) { create(:organisation, whitehall_slug: "the-adjudicator-s-office", title: "The adjudicator's office") }
+    let(:organisation_slug) { "air-accidents-investigation-branch" }
+
+    it "returns all organisation except the current organisation" do
+      site_form = build(:site_form, organisation_slug:)
+
+      expect(site_form.organisations.length).to be 1
+      expect(site_form.organisations.last).to eq other_organisation
+    end
+  end
+
+  describe "#save" do
+    let!(:organisation) { create(:organisation, whitehall_slug: organisation_slug) }
+    let(:organisation_slug) { "air-accidents-investigation-branch" }
+
+    context "when invalid" do
+      it "returns false" do
+        site_form = build(:site_form, tna_timestamp: nil)
+
+        expect(site_form.save).to be false
+      end
+    end
+
+    it "returns an instance of the new Site" do
+      site_form = build(:site_form)
+
+      site = site_form.save
+
+      expect(site).to be_a Site
+      expect(site).to have_attributes(
+        abbr: "aaib",
+        organisation:,
+        homepage: "https://www.gov.uk/government/organisations/air-accidents-investigation-branch",
+        tna_timestamp: Time.strptime("20141104112824", "%Y%m%d%H%M%S"),
+      )
+    end
+
+    it "creates the default host and aka host" do
+      site_form = build(:site_form)
+
+      site = site_form.save
+
+      expect(site.hosts.count).to be 2
+      expect(site.hosts.first.hostname).to eq "www.aaib.gov.uk"
+      expect(site.hosts.last.hostname).to eq "aka.aaib.gov.uk"
+    end
+
+    context "with optional fields" do
+      it "returns an instance of the new Site" do
+        site_form = build(:site_form, :with_optional_fields)
+
+        site = site_form.save
+
+        expect(site).to be_a Site
+        expect(site).to have_attributes(
+          homepage_title: "Air accidents investigation branch",
+          homepage_furl: "www.gov.uk/aaib",
+          global_type: "redirect",
+          global_new_url: "https://www.gov.uk/government/organisations/air-accidents-investigation-branch/about",
+          global_redirect_append_path: true,
+          query_params: "file",
+          special_redirect_strategy: "via_aka",
+        )
+      end
+    end
+
+    context "with a comma-separated list of alias hosts" do
+      it "creates the alias hosts and aka hosts" do
+        site_form = build(:site_form, :with_aliases)
+
+        site = site_form.save
+
+        alias_site_1 = site.hosts.where(hostname: "aaib.gov.uk")
+        alias_site_2 = site.hosts.where(hostname: "aaib.com")
+
+        expect(alias_site_1).to exist
+        expect(alias_site_2).to exist
+        expect(site.hosts.where(hostname: "aka-aaib.gov.uk", canonical_host: alias_site_1)).to exist
+        expect(site.hosts.where(hostname: "aka-aaib.com", canonical_host: alias_site_2)).to exist
+      end
+    end
+
+    context "with extra organisations" do
+      let!(:extra_organisation) { create(:organisation, whitehall_slug: "the-adjudicator-s-office", title: "The adjudicator's office") }
+      let!(:extra_organisation_2) { create(:organisation, whitehall_slug: "government-digital-service", title: "Government digital service") }
+
+      it "creates extra organisations" do
+        site_form = build(:site_form, :with_extra_organisations)
+
+        site = site_form.save
+
+        expect(site.extra_organisations.count).to be 2
+        expect(site.extra_organisations.where(title: "The adjudicator's office")).to exist
+        expect(site.extra_organisations.where(title: "Government digital service")).to exist
+      end
+    end
+  end
+end

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -75,6 +75,18 @@ describe Host do
           expect(host.errors_on(:hostname)).to include("is an invalid hostname")
         end
       end
+
+      context "is downcased" do
+        subject(:host) { build :host, hostname: "AB.com" }
+
+        describe "#valid?" do
+          subject { super().valid? }
+          it { is_expected.to be_falsey }
+        end
+        it "should have an error for invalid hostname" do
+          expect(host.errors_on(:hostname)).to include("must be lowercase")
+        end
+      end
     end
   end
 

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -143,6 +143,40 @@ describe Site do
     end
   end
 
+  describe "nillifying blanks before validation" do
+    let(:site) { create :site, homepage_furl: "" }
+
+    subject { site.homepage_furl }
+
+    it { is_expected.to be_nil }
+
+    context "attributes not nilified" do
+      describe "#global_redirect_append_path" do
+        let(:site) { create :site, global_redirect_append_path: false }
+
+        subject { site.global_redirect_append_path }
+
+        it { is_expected.to be false }
+      end
+
+      describe "#global_redirect_append_path" do
+        let(:site) { create :site, query_params: "" }
+
+        subject { site.query_params }
+
+        it { is_expected.to eq "" }
+      end
+
+      describe "#precompute_all_hits_view" do
+        let(:site) { create :site, precompute_all_hits_view: false }
+
+        subject { site.precompute_all_hits_view }
+
+        it { is_expected.to be false }
+      end
+    end
+  end
+
   describe "#transition_status" do
     let!(:site) { create :site_without_host }
 

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -41,6 +41,15 @@ describe Site do
       end
     end
 
+    context "global archive" do
+      subject(:site) { build(:site, global_type: "archive", global_new_url: "http://a.com/") }
+
+      before { expect(site).not_to be_valid }
+      it "should validate absence of global_new_url" do
+        expect(site.errors[:global_new_url]).to eq(["must be blank"])
+      end
+    end
+
     context "global redirect with path appended" do
       subject(:site) { build(:site, global_type: "redirect", global_redirect_append_path: true, global_new_url: "http://a.com/?") }
 

--- a/spec/requests/site_creation_spec.rb
+++ b/spec/requests/site_creation_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe "Site creation" do
   render_views
 
-  let!(:gds_bob) { create(:gds_editor, name: "Bob Terwhilliger") }
+  let!(:site_manager) { create(:site_manager) }
   let(:organisation) { create(:organisation, whitehall_slug: "air-accidents-investigation-branch") }
   let(:params) { attributes_for :site_form, :with_optional_fields, :with_aliases, organisation_slug: "air-accidents-investigation-branch" }
 

--- a/spec/requests/site_creation_spec.rb
+++ b/spec/requests/site_creation_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+describe "Site creation" do
+  render_views
+
+  let!(:gds_bob) { create(:gds_editor, name: "Bob Terwhilliger") }
+  let(:organisation) { create(:organisation, whitehall_slug: "air-accidents-investigation-branch") }
+  let(:params) { attributes_for :site_form, :with_optional_fields, :with_aliases, organisation_slug: "air-accidents-investigation-branch" }
+
+  it "redirects to the new site path" do
+    post organisation_sites_path(organisation), params: { site_form: params }
+
+    expect(response).to redirect_to(site_path(Site.last))
+  end
+
+  it "creates the new site" do
+    post organisation_sites_path(organisation), params: { site_form: params }
+
+    attributes = {
+      abbr: "aaib",
+      global_new_url: "https://www.gov.uk/government/organisations/air-accidents-investigation-branch/about",
+      global_redirect_append_path: true,
+      global_type: "redirect",
+      homepage: "https://www.gov.uk/government/organisations/air-accidents-investigation-branch",
+      homepage_furl: "www.gov.uk/aaib",
+      homepage_title: "Air accidents investigation branch",
+      query_params: "file",
+      special_redirect_strategy: "via_aka",
+      tna_timestamp: Time.strptime("20141104112824", "%Y%m%d%H%M%S"),
+    }
+
+    expect(Site.last.attributes.with_indifferent_access).to include attributes
+    expect(Site.last.organisation).to eq organisation
+  end
+
+  it "creates related hosts and aka hosts" do
+    post organisation_sites_path(organisation), params: { site_form: params }
+
+    alias_site_1 = Host.where(hostname: "www.aaib.gov.uk")
+    alias_site_2 = Host.where(hostname: "aaib.gov.uk")
+    alias_site_3 = Host.where(hostname: "aaib.com")
+
+    expect(alias_site_1).to exist
+    expect(alias_site_2).to exist
+    expect(alias_site_3).to exist
+    expect(Host.where(hostname: "aka.aaib.gov.uk", canonical_host: alias_site_1)).to exist
+    expect(Host.where(hostname: "aka-aaib.gov.uk", canonical_host: alias_site_2)).to exist
+    expect(Host.where(hostname: "aka-aaib.com", canonical_host: alias_site_3)).to exist
+  end
+
+  context "with extra organisations" do
+    let!(:extra_organisation) { create(:organisation, whitehall_slug: "the-adjudicator-s-office", title: "The adjudicator's office") }
+    let!(:extra_organisation_2) { create(:organisation, whitehall_slug: "government-digital-service", title: "Government digital service") }
+    let(:params) { attributes_for(:site_form, :with_extra_organisations) }
+
+    it "creates extra organisations" do
+      post organisation_sites_path(organisation), params: { site_form: params }
+
+      expect(Site.last.extra_organisations.count).to be 2
+      expect(Site.last.extra_organisations.where(title: "The adjudicator's office")).to exist
+      expect(Site.last.extra_organisations.where(title: "Government digital service")).to exist
+    end
+  end
+end

--- a/spec/requests/site_creation_spec.rb
+++ b/spec/requests/site_creation_spec.rb
@@ -61,4 +61,28 @@ describe "Site creation" do
       expect(Site.last.extra_organisations.where(title: "Government digital service")).to exist
     end
   end
+
+  context "with blank optional fields" do
+    let(:params) { attributes_for(:site_form, :with_blank_optional_fields) }
+
+    it "nullifies blanks when creating the new site" do
+      post organisation_sites_path(organisation), params: { site_form: params }
+
+      attributes = {
+        abbr: "aaib",
+        homepage: "https://www.gov.uk/government/organisations/air-accidents-investigation-branch",
+        tna_timestamp: Time.strptime("20141104112824", "%Y%m%d%H%M%S"),
+        global_redirect_append_path: false,
+        global_new_url: nil,
+        special_redirect_strategy: nil,
+        global_type: nil,
+        homepage_title: nil,
+        homepage_furl: nil,
+        query_params: "",
+      }
+
+      expect(Site.last.attributes.with_indifferent_access).to include attributes
+      expect(Site.last.organisation).to eq organisation
+    end
+  end
 end

--- a/spec/support/shared_examples/authentication.rb
+++ b/spec/support/shared_examples/authentication.rb
@@ -28,6 +28,21 @@ shared_examples "disallows editing by non-GDS Editors" do
   end
 end
 
+shared_examples "disallows editing by non-Site managers" do
+  before do
+    login_as stub_user
+    make_request
+  end
+
+  it "redirects to the organisation page" do
+    expect(response).to redirect_to organisation_path(organisation)
+  end
+
+  it "sets a flash message" do
+    expect(flash[:alert]).to eql("Only Site Managers can access that.")
+  end
+end
+
 shared_examples "disallows editing of a global site" do
   before do
     make_request


### PR DESCRIPTION
> [!NOTE]  
> This is not the finished article, this is for us to refine as we learn more about how it will be used.

https://trello.com/c/3NYAPZs4

### Add constants for global and special redirect types
We want to add a new site form. In order to do this we will need an easy way to
access these values.

We might want to consider refining these further into enums, as this would
allow us to remove some of the methods in the site model.

### Add routes for site creation
We want to add sites per organisation.

This add nested routes for site creation.

### Add site form object
We are aiming to archive Transition Config which is currently used to create
sites in Transition.

This adds a form object for the creation of a site. 

It's worth noting that the process currently moves existing hosts and aka hosts
to the new site if they already exist (see
`lib/transition/import/site_yaml_file.rb`). We aren't yet sure whether we want
to create a new UI for that functionality, or to use this form. For now, this
form does not have that functionality.

### Only validate presence of canonical host or aka if hostname is present
If hostname is not provided for the host, this validation will raise an error.

Add a condition that this validation only runs when hostname is present.

### Add site creation actions and views
We are aiming to archive Transition Config which is currently used to create
sites in Transition.

This adds the actions and views necessary for a user to add a new transition.

### Validate that host hostname is lowercase
Currently the site importer (`lib/transition/import/site_yaml_file.rb`)
downcases any hostnames.

This adds validation to the host model which will be surfaced on the new site
form.

### Only allow `Site managers` to create new sites
This adds authorization that only people with the `Site manager` role in GOV.UK
Signon can create new sites.

This is so that we can safely test new features before we officially archive
Transition Config.

### Validate that global new URL is absent if the global type is "archive"
Currently, there is validation in place to prevent the creation of sites which
have a global type of "redirect" without a global new URL, but the opposite
validation is missing.

### Improve appearance of radio buttons
In order to style these using Bootstrap, we need to provide a block to `collection_radio_buttons`.

### Nilify blanks on the Site model
The optional fields of the site form come through as empty strings when left
blank. These are then saved in the database, when ideally these would be saved
as `nil` in order to preserve the previous behaviour of adding them through
Transition Config for consistency.

We already have a module that handles the nilification of blanks, however we
need to make a couple of changes:
- We add an "except list" of attributes that we don't want to nilify, such as
  Booleans that should be false and not nil (false.blank? == true).
- We allow blank for `special_redirect_strategy` as this will now be nilified
  before save.

### Add hints to new site form inputs
This copies the guidance fro Transition Config over to the new site form.

This will need later refinement.


![image](https://github.com/alphagov/transition/assets/47089130/99d0c542-c77c-412d-ae8f-8a1cd79b2f20)


---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
