### PR TITLE
Add `Site manager` permission

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,10 @@ class User < ApplicationRecord
     permissions.include?("GDS Editor")
   end
 
+  def site_manager?
+    permissions.include?("Site Manager")
+  end
+
   def can_edit_sites
     @can_edit_sites ||= {}
   end

--- a/features/step_definitions/authentication_steps.rb
+++ b/features/step_definitions/authentication_steps.rb
@@ -28,3 +28,7 @@ end
 Given(/^I have logged in as a member of another organisation$/) do
   GDS::SSO.test_user = create(:user, organisation_content_id: SecureRandom.uuid)
 end
+
+Given(/^I have logged in as a Site Manager$/) do
+  GDS::SSO.test_user = create(:site_manager)
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -11,5 +11,9 @@ FactoryBot.define do
     factory :admin do
       permissions { ["signin", "GDS Editor", "admin"] }
     end
+
+    factory :site_manager do
+      permissions { ["signin", "Site Manager"] }
+    end
   end
 end


### PR DESCRIPTION
We are in the process of archiving Transition Config, which requires that we add various bits of functionality to Transition.

In order to test these safely, we have added a new `Site manager` permission to Signon.

This adds the permission to the user model, as well as some test helpers.

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
