### PR TITLE
Move delete site confirmation page to the Design System

### DIFF
--- a/app/forms/delete_site_form.rb
+++ b/app/forms/delete_site_form.rb
@@ -1,0 +1,30 @@
+require "./lib/transition/import/revert_entirely_unsafe"
+
+class DeleteSiteForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :abbr
+  attribute :abbr_confirmation
+
+  validate :confirmation_matches
+
+  def save
+    return false if invalid?
+
+    Transition::Import::RevertEntirelyUnsafe::RevertSite.new(site).revert_all_data!
+    true
+  end
+
+private
+
+  def site
+    Site.find_by(abbr:)
+  end
+
+  def confirmation_matches
+    if abbr_confirmation != abbr
+      errors.add(:abbr_confirmation, "The confirmation did not match")
+    end
+  end
+end

--- a/app/views/sites/confirm_destroy.html.erb
+++ b/app/views/sites/confirm_destroy.html.erb
@@ -1,46 +1,54 @@
 <% content_for(:page_title, @site.default_host.hostname) %>
 
-<div class="page-title-with-border">
-  <h1>
-    <small><%= @site.default_host.hostname %></small>
-    <br />
-    Delete this site and all its associated data
-  </h1>
-</div>
+<% breadcrumb(:edit_site, @site) %>
 
-<div class="callout callout-danger">
-  <div class="callout-title">
-    WAIT!
-  </div>
-  <div class="callout-body">
-    <p>
-      This will delete the site <strong><%= @site.abbr %></strong> and all the data that is associated with it:
-    </p>
-    <ul>
-      <li><%= t("site.confirm_destroy.hosts", count: @site.hosts.count) %></li>
-      <li><%= t("site.confirm_destroy.mappings", count: @site.mappings.count) %></li>
-    </ul>
-    <p>Redirects will stop working.</p>
-    <p>
-      Restoring this site would require readding the site, the host(s), and all the mappings. The hits cannot be restored.
-    </p>
-  </div>
-</div>
+<%= form_for @delete_site_form, method: :delete, url: site_path, html: { role: 'form' } do |form| %>
+  <% if object_has_errors?(form.object) %>
+    <%= render "govuk_publishing_components/components/error_summary", {
+      title: "There is a problem",
+      items: error_messages(form.object)
+    } %>
+  <% end %>
 
-<%= form_for @site, method: :delete, html: { role: 'form' } do |f| %>
-  <div class="form-group row add-top-margin">
-    <div class="col-md-8">
-      <div class="input-group">
-        <dl>
-          <dt>
-            <%= label_tag :confirm_destroy, "Please enter the site slug, #{@site.abbr}, to confirm that you want to delete this site and all its data." %>
-          </dt>
-          <dd>
-            <%= text_field_tag(:confirm_destroy, {}, { class: 'form-control input' }) %>
-          </dd>
-        </dl>
-      </div>
-      <%= f.submit t("site.confirm_destroy.confirm"), class: 'add-top-margin btn btn-danger' %>
-    </div>
-  </div>
+  <span class="govuk-caption-l"><%= @site.default_host.hostname %></span>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Delete this site and all its associated data",
+    heading_level: 1,
+    font_size: "l",
+    margin_bottom: 6,
+  } %>
+
+  <%= render "govuk_publishing_components/components/warning_text", {
+    text: "This will delete the #{@site.abbr} site and all the data that is associated with it.",
+    margin_bottom: true
+  } %>
+
+  <p class="govuk-body">In addition to the site, this action will also remove:</p>
+  <%= render "govuk_publishing_components/components/list", {
+    visible_counters: true,
+    items: [
+      t("site.confirm_destroy.hosts", count: @site.hosts.count),
+      t("site.confirm_destroy.mappings", count: @site.mappings.count),
+    ]
+  } %>
+
+  <p class="govuk-body">Redirects will stop working.</p>
+  <p class="govuk-body govuk-!-margin-bottom-7">
+    Restoring this site would require re-adding the site, the host(s), and all the mappings. The hits cannot be
+    restored.
+  </p>
+
+  <%= render "govuk_publishing_components/components/input", {
+    label: { text: "Enter the site slug, #{@site.abbr}, to confirm that you want to delete this site and all its data." },
+    name: form.field_name(:abbr_confirmation),
+    id: field_id_attribute(form.object, :abbr_confirmation),
+    error_message: error_message(form.object, :abbr_confirmation),
+    value: form.object.abbr_confirmation,
+    heading_size: "s"
+  } %>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: "I understand the consequences, delete this site",
+    destructive: true
+  } %>
 <% end %>

--- a/features/step_definitions/site_interaction_steps.rb
+++ b/features/step_definitions/site_interaction_steps.rb
@@ -45,11 +45,11 @@ When(/^I delete this site$/) do
 end
 
 When(/^I confirm the deletion$/) do
-  fill_in :confirm_destroy, with: @site.abbr
+  fill_in "delete_site_form[abbr_confirmation]", with: @site.abbr
   click_button I18n.t("site.confirm_destroy.confirm")
 end
 
 When(/^I fail to confirm the deletion$/) do
-  fill_in :confirm_destroy, with: "bogus"
+  fill_in "delete_site_form[abbr_confirmation]", with: "bogus"
   click_button I18n.t("site.confirm_destroy.confirm")
 end

--- a/spec/forms/delete_site_form_spec.rb
+++ b/spec/forms/delete_site_form_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+describe DeleteSiteForm do
+  describe "validations" do
+    describe "#abbr_confirmation" do
+      context "when the site abbr does not match" do
+        it "is invalid" do
+          site_form = DeleteSiteForm.new(abbr: "cabinet-office", abbr_confirmation: "dfe")
+
+          expect(site_form.valid?).to be false
+          expect(site_form.errors[:abbr_confirmation]).to include("The confirmation did not match")
+        end
+      end
+    end
+  end
+
+  describe "#save" do
+    let(:mock_reverter_class) { class_double(Transition::Import::RevertEntirelyUnsafe::RevertSite).as_stubbed_const }
+    let(:mock_reverter) { instance_double(Transition::Import::RevertEntirelyUnsafe::RevertSite) }
+
+    before do
+      allow(mock_reverter_class).to receive(:new).and_return(mock_reverter)
+      allow(mock_reverter).to receive(:revert_all_data!)
+    end
+
+    context "when invalid" do
+      it "returns false" do
+        site_form = DeleteSiteForm.new(abbr: "cabinet-office", abbr_confirmation: "dfe")
+
+        expect(site_form.save).to be false
+        expect(mock_reverter_class).to_not have_received(:new)
+        expect(mock_reverter).to_not have_received(:revert_all_data!)
+      end
+    end
+
+    context "when valid" do
+      it "calls the reverter and returns true" do
+        site = create(:site, abbr: "cabinet-office")
+        site_form = DeleteSiteForm.new(abbr: "cabinet-office", abbr_confirmation: "cabinet-office")
+
+        result = site_form.save
+
+        expect(result).to be true
+        expect(mock_reverter_class).to have_received(:new).with(site)
+        expect(mock_reverter).to have_received(:revert_all_data!)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/MP3g273Q

Now that we have introduced a layout for the Design System, we should ensure that we are using it when adding new pages.

The most appropriate way of showing the `The confirmation did not match` message while following the Design System seems to be to use form validation, so this also introduces a form object to back the delete form. This has the additional benefit of moving the deletion logic out of the controller.

|Before|After|
|-|-|
|![image](https://github.com/alphagov/transition/assets/47089130/fb27ad17-7c90-4423-a797-3c3d4d4f9a06)|![image](https://github.com/alphagov/transition/assets/47089130/d1658ea2-f388-4481-ac2e-22b3d008f0ce)|

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
