### PR TITLE
Validate that hostnames are unique

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -9,6 +9,12 @@ class Host < ApplicationRecord
   belongs_to :canonical_host, class_name: "Host"
 
   validates :hostname, presence: true
+  validates :hostname, uniqueness: {
+    message: lambda do |_object, data|
+      site = Host.find_by(hostname: data[:value]).site.abbr
+      "The hostname #{data[:value]} already exists. You must delete the #{site} site to remove it"
+    end,
+  }
   validates :hostname, hostname: true
   validates :site, presence: true
   validate :canonical_host_id_xor_aka_present, if: -> { hostname.present? }

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -87,6 +87,23 @@ describe Host do
           expect(host.errors_on(:hostname)).to include("must be lowercase")
         end
       end
+
+      context "does not already exist" do
+        let!(:existing_host) { create :host, hostname: "www.cabinetoffice.gov.uk", site: }
+        let(:site) { create :site, abbr: "cabinetoffice" }
+
+        subject(:host) { build :host, hostname: "www.cabinetoffice.gov.uk" }
+
+        describe "#valid?" do
+          subject { super().valid? }
+          it { is_expected.to be false }
+        end
+
+        it "should have an error for invalid hostname" do
+          message = "The hostname www.cabinetoffice.gov.uk already exists. You must delete the cabinetoffice site to remove it"
+          expect(host.errors_on(:hostname)).to include(message)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
https://trello.com/c/Aaao9833

The current import process will move a host to a new site if a site with that
same host already exists (documented in
`spec/lib/transition/import/site_yaml_file_spec.rb:177`).

We think this will not happen frequently, so have decided to disallow adding or
updating a host where the hostname is not unique.

All hostnames in the database are currently unique, so this validation can run
on create and update without invalidating any current records.

Note that this executes 2 SQL queries, whereas we could perform this in 1 if
using custom validation, however I think using the built in validation in
clearer for this use case.

<img width="1012" alt="image" src="https://github.com/alphagov/transition/assets/47089130/ba8f9729-dcaa-44da-ad7f-abc32d22d5ca">
<img width="1008" alt="image" src="https://github.com/alphagov/transition/assets/47089130/37b376f8-d63d-4727-ac21-594d1998c245">


---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
