### PR TITLE
Fix release version in footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
 <% end %>
 
 <% content_for :page_title do %> | GOV.UK Transition<% end %>
-<% content_for :footer_version do %><%= CURRENT_RELEASE_SHA %><% end %>
+<% content_for :footer_version, ENV.fetch("SENTRY_RELEASE", "null")[0..18] %>
 <% content_for :content do %>
   <% # Map bootstrap alerts to Rails flashes, but keep notice and alert as they are pecial cased with redirect_to %>
   <% [:success, :info, :warning, :danger, :notice, :alert].select { |k| flash[k].present? }.each do |k| %>

--- a/app/views/layouts/error_page.html.erb
+++ b/app/views/layouts/error_page.html.erb
@@ -35,7 +35,7 @@
     </main>
 
     <footer class="page-footer">
-      <a class="inherit" href="http://www.nationalarchives.gov.uk/information-management/our-services/crown-copyright.htm">&copy; Crown Copyright</a> <span class="pull-right">Version: <%= CURRENT_RELEASE_SHA %></span></p>
+      <a class="inherit" href="http://www.nationalarchives.gov.uk/information-management/our-services/crown-copyright.htm">&copy; Crown Copyright</a> <span class="pull-right">Version: <%= ENV.fetch("SENTRY_RELEASE", "null")[0..18] %></span></p>
     </footer>
   </section>
 </body>

--- a/config/initializers/current_release_sha.rb
+++ b/config/initializers/current_release_sha.rb
@@ -1,6 +1,0 @@
-if File.exist?(Rails.root.join("/REVISION"))
-  revision = `cat #{Rails.root}/REVISION`.chomp
-  CURRENT_RELEASE_SHA = revision[0..10] # Just get the short SHA
-else
-  CURRENT_RELEASE_SHA = "development".freeze
-end


### PR DESCRIPTION
This has been broken since we moved to EKS and the SHA is no longer provided.

We can use the [SENTRY_RELEASE](https://github.com/alphagov/govuk-helm-charts/blob/077117e7f40c096a958f9e0b853a2bd76cf43f26/charts/generic-govuk-app/templates/deployment.yaml#L92C1-L92C1) environment variable which is defined for every app and takes its value from the container image's tag.

If for whatever reason the image tag is not defined it will display `null`, which should make it clearer (instead of displaying `development`) that this data is not being pulled in successfully.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Trello card: https://trello.com/c/uoKDUcbV/3182-fix-broken-version-footer-in-publishing-apps-2

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
