### PR TITLE
Add rake task to remove a host

### DIFF
--- a/lib/tasks/import/revert.rake
+++ b/lib/tasks/import/revert.rake
@@ -10,5 +10,16 @@ namespace :import do
 
       Transition::Import::Revert::Sites.new(site_abbrs).revert_all!
     end
+
+    desc "Delete specified hosts"
+    task :hosts, [:hostnames] => :environment do |_, args|
+      hosts = args[:hostnames].split(",")
+      if hosts.empty?
+        puts "Usage: rake import:revert:hosts[host_1,host_2]"
+        abort
+      end
+
+      Host.where(hostname: hosts).destroy_all
+    end
   end
 end

--- a/spec/lib/tasks/import/revert_spec.rb
+++ b/spec/lib/tasks/import/revert_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe "rake import:revert:hosts", type: :task do
+  context "with host names" do
+    it "deletes the host records" do
+      site = create(:site)
+      alias_1 = create(:host, site:)
+      alias_2 = create(:host, site:)
+
+      Rake::Task["import:revert:hosts"].invoke("#{alias_1.hostname},#{alias_2.hostname}")
+
+      expect(Host.all.to_a).to eq([site.default_host])
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,6 +11,8 @@ require "spec_helper"
 require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
+Rails.application.load_tasks
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end


### PR DESCRIPTION
There may be times that a host needs to be removed. This is currently not possible (although will be when we make the edit site UI available to users).

Therefore adding a rake task to allow us to remove hosts when they are no longer needed.

The corresponding change will also need to be made in `transition-config` to stop the host being reimported again.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
