### PR TITLE
Split off orgs_sites_hosts import task

### DIFF
--- a/lib/tasks/import/all.rake
+++ b/lib/tasks/import/all.rake
@@ -6,18 +6,24 @@ namespace :import do
   desc "Import Organisations, Sites, Hosts, Hits and update DNS details"
   task :all,
        [:bucket] => [
-         "import:all:orgs_sites_hosts",
+         "import:all:organisations",
+         "import:all:sites_hosts",
          "import:all:hits",
          "import:dns_details",
        ]
 
   namespace :all do
-    desc "Import all Organisations, Sites and Hosts"
-    task orgs_sites_hosts: :environment do
+    desc "Import all Organisations"
+    task organisations: :environment do
+      Rake::Task["import:organisations"].invoke
+    end
+
+    desc "Import all Sites and Hosts"
+    task sites_hosts: :environment do
       patterns = [
         "data/transition-config/data/transition-sites/*.yml",
       ]
-      Rake::Task["import:orgs_sites_hosts"].invoke(glob_from_array(patterns))
+      Rake::Task["import:sites_hosts"].invoke(glob_from_array(patterns))
     end
 
     desc "Import all hits from s3"

--- a/lib/tasks/import/orgs_sites_hosts.rake
+++ b/lib/tasks/import/orgs_sites_hosts.rake
@@ -1,9 +1,14 @@
 require "transition/import/orgs_sites_hosts"
 
 namespace :import do
-  desc "Import all Organisations, and Sites and Hosts from the given filename or mask"
-  task :orgs_sites_hosts, [:filename_or_mask] => :environment do |_, args|
-    Transition::Import::OrgsSitesHosts.from_yaml!(args.filename_or_mask)
+  desc "Import all Organisations"
+  task organisations: :environment do
+    Transition::Import::Organisations.from_yaml!
+  end
+
+  desc "Import all Sites and Hosts from the given filename or mask"
+  task :sites_hosts, [:filename_or_mask] => :environment do |_, args|
+    Transition::Import::SitesHosts.from_yaml!(args.filename_or_mask)
   rescue Transition::Import::Sites::NoYamlFound
     warn <<~TEXT
       Warning: no sites YAML found at #{args.filename_or_mask}

--- a/lib/transition/import/orgs_sites_hosts.rb
+++ b/lib/transition/import/orgs_sites_hosts.rb
@@ -3,9 +3,14 @@ require "transition/import/organisations"
 
 module Transition
   module Import
-    class OrgsSitesHosts
-      def self.from_yaml!(mask, whitehall_orgs = nil)
+    class Organisations
+      def self.from_yaml!(whitehall_orgs = nil)
         Organisations.from_whitehall!(whitehall_orgs)
+      end
+    end
+
+    class SitesHosts
+      def self.from_yaml!(mask)
         Sites.new(mask).import!
       end
     end

--- a/spec/lib/transition/import/orgs_sites_hosts_spec.rb
+++ b/spec/lib/transition/import/orgs_sites_hosts_spec.rb
@@ -1,14 +1,70 @@
 require "rails_helper"
 require "transition/import/orgs_sites_hosts"
 
-describe Transition::Import::OrgsSitesHosts do
+describe Transition::Import::Organisations do
+  describe ".from_yaml!" do
+    context "importing valid yaml files", testing_before_all: true do
+      before :all do
+        Transition::Import::Organisations.from_yaml!(
+          Transition::Import::WhitehallOrgs.new("spec/fixtures/whitehall/orgs_abridged.yml"),
+        )
+        @ukti = Site.find_by(abbr: "ukti")
+      end
+
+      it "has imported orgs" do
+        expect(Organisation.count).to eq(6)
+      end
+
+      describe "a child organisation with its own hosted site" do
+        let(:bis) { Organisation.find_by! whitehall_slug: "department-for-business-innovation-skills" }
+
+        subject { Organisation.find_by! whitehall_slug: "uk-atomic-energy-authority" }
+
+        describe "#parent_organisations" do
+          subject { super().parent_organisations }
+          it { is_expected.to match_array([bis]) }
+        end
+
+        describe "#abbreviation" do
+          subject { super().abbreviation }
+          it { is_expected.to eql "UKAEA" }
+        end
+
+        describe "#whitehall_type" do
+          subject { super().whitehall_type }
+          it { is_expected.to eql "Executive non-departmental public body" }
+        end
+      end
+
+      context "the import is run again" do
+        before :all do
+          Transition::Import::Organisations.from_yaml!(
+            Transition::Import::WhitehallOrgs.new("spec/fixtures/whitehall/orgs_abridged.yml"),
+          )
+        end
+
+        describe "a pre-existing parent-child relationship is not duplicated" do
+          let(:bis) { Organisation.find_by! whitehall_slug: "department-for-business-innovation-skills" }
+
+          subject { Organisation.find_by! whitehall_slug: "uk-atomic-energy-authority" }
+
+          describe "#parent_organisations" do
+            subject { super().parent_organisations }
+            it { is_expected.to match_array([bis]) }
+          end
+        end
+      end
+    end
+  end
+end
+
+describe Transition::Import::SitesHosts do
   describe ".from_yaml!" do
     context "there are no valid yaml files" do
       it "reports the lack" do
         expect {
-          Transition::Import::OrgsSitesHosts.from_yaml!(
+          Transition::Import::SitesHosts.from_yaml!(
             "spec/fixtures/sites/noyaml/*.yml",
-            Transition::Import::WhitehallOrgs.new("spec/fixtures/whitehall/orgs_abridged.yml"),
           )
         }.to raise_error(Transition::Import::Sites::NoYamlFound)
       end
@@ -16,9 +72,11 @@ describe Transition::Import::OrgsSitesHosts do
 
     context "importing valid yaml files", testing_before_all: true do
       before :all do
-        Transition::Import::OrgsSitesHosts.from_yaml!(
-          "spec/fixtures/sites/someyaml/**/*.yml",
+        Transition::Import::Organisations.from_yaml!(
           Transition::Import::WhitehallOrgs.new("spec/fixtures/whitehall/orgs_abridged.yml"),
+        )
+        Transition::Import::SitesHosts.from_yaml!(
+          "spec/fixtures/sites/someyaml/**/*.yml",
         )
         @ukti = Site.find_by(abbr: "ukti")
       end
@@ -62,9 +120,8 @@ describe Transition::Import::OrgsSitesHosts do
 
       context "the import is run again" do
         before :all do
-          Transition::Import::OrgsSitesHosts.from_yaml!(
+          Transition::Import::SitesHosts.from_yaml!(
             "spec/fixtures/sites/someyaml/*.yml",
-            Transition::Import::WhitehallOrgs.new("spec/fixtures/whitehall/orgs_abridged.yml"),
           )
         end
 

--- a/spec/lib/transition/import/revert_entirely_unsafe_spec.rb
+++ b/spec/lib/transition/import/revert_entirely_unsafe_spec.rb
@@ -6,9 +6,11 @@ describe Transition::Import::RevertEntirelyUnsafe::RevertSite do
     before do
       @bona_vacantia = create :organisation, whitehall_slug: "bona-vacantia"
       @treasury_office = create :organisation, whitehall_slug: "treasury-solicitor-s-office"
-      Transition::Import::OrgsSitesHosts.from_yaml!(
-        "spec/fixtures/sites/someyaml/**/*.yml",
+      Transition::Import::Organisations.from_yaml!(
         Transition::Import::WhitehallOrgs.new("spec/fixtures/whitehall/orgs_abridged.yml"),
+      )
+      Transition::Import::SitesHosts.from_yaml!(
+        "spec/fixtures/sites/someyaml/**/*.yml",
       )
 
       @site_abbr = "ago"

--- a/spec/lib/transition/import/revert_spec.rb
+++ b/spec/lib/transition/import/revert_spec.rb
@@ -5,9 +5,11 @@ describe Transition::Import::Revert::Sites do
   describe "#revert_all!" do
     before do
       @bona_vacantia = create :organisation, whitehall_slug: "bona-vacantia"
-      Transition::Import::OrgsSitesHosts.from_yaml!(
-        "spec/fixtures/sites/someyaml/**/*.yml",
+      Transition::Import::Organisations.from_yaml!(
         Transition::Import::WhitehallOrgs.new("spec/fixtures/whitehall/orgs_abridged.yml"),
+      )
+      Transition::Import::SitesHosts.from_yaml!(
+        "spec/fixtures/sites/someyaml/**/*.yml",
       )
 
       @original_site_count = 8


### PR DESCRIPTION
**Note**:  should be coordinated with https://github.com/alphagov/govuk-helm-charts/pull/1296

Separate the responsibilities so we can invoke separate tasks for importing organisations and importing sites and hosts, respectively.

This allows us to keep as much of the existing tests as possible, to make the path towards removing the dependency on transition-config safer and clearer.

This separation will also allow us to modify the cron job to only invoke the importing of organisations from whitehall.

[Trello](https://trello.com/c/toGB61iI/809-remove-cron-job-that-imports-site-data-from-transition-config-to-transition-then-archive-the-transition-config-repo)

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
