### PR TITLE
(853) Remove unused methods

### DIFF
--- a/app/models/mapping.rb
+++ b/app/models/mapping.rb
@@ -93,14 +93,6 @@ class Mapping < ApplicationRecord
     "http://webarchive.nationalarchives.gov.uk/#{tna_timestamp}/#{old_url}"
   end
 
-  def last_editor
-    # This will return nil if the mapping was imported from transition-config and has
-    # not been edited since.
-    if versions.present? && versions.last.user_id.present?
-      User.find_by(id: versions.last.user_id)
-    end
-  end
-
   def hit_percentage
     site.hit_total_count.zero? ? 0 : (hit_count.to_f / site.hit_total_count) * 100
   end

--- a/app/models/mapping.rb
+++ b/app/models/mapping.rb
@@ -93,26 +93,8 @@ class Mapping < ApplicationRecord
     "http://webarchive.nationalarchives.gov.uk/#{tna_timestamp}/#{old_url}"
   end
 
-  def edited_by_human?
-    # Intent: has this mapping (ever) been edited by a human? We treat
-    # mappings that were imported from redirector (now called transition-config)
-    # as human-edited because they are curated.
-    #
-    # Assumptions:
-    #
-    #   * humans only edit when paper trail is recording changes
-    #   * all machine edits are done by a 'robot' user or when paper trail is
-    #     turned off or isn't applicable (eg redirector import)
-    #
-    if from_redirector == true
-      true
-    else
-      last_editor.present? && last_editor.is_human?
-    end
-  end
-
   def last_editor
-    # This will return nil if the mapping was imported from redirector and has
+    # This will return nil if the mapping was imported from transition-config and has
     # not been edited since.
     if versions.present? && versions.last.user_id.present?
       User.find_by(id: versions.last.user_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,10 +34,6 @@ class User < ApplicationRecord
     end
   end
 
-  def is_human?
-    !is_robot?
-  end
-
 private
 
   def site_is_editable?(site_to_edit)

--- a/features/mapping_history.feature
+++ b/features/mapping_history.feature
@@ -27,7 +27,7 @@ Feature: History of edits to a mapping
     And I should see "New URL updated"
     And I should see a link to "Edit"
 
-  Scenario: Looking at a mapping that was imported from redirector (now called transition-config)
+  Scenario: Looking at a mapping that was imported from transition-config
     Given I log in as a SIRO
     And there is a mapping that has no history
     When I go to edit that mapping

--- a/spec/models/mapping_spec.rb
+++ b/spec/models/mapping_spec.rb
@@ -513,46 +513,4 @@ describe Mapping do
       end
     end
   end
-
-  describe "last_editor" do
-    context "no versions exist" do
-      subject(:mapping) { create(:mapping, from_redirector: true) }
-
-      describe "#last_editor" do
-        subject { super().last_editor }
-        it { is_expected.to be_nil }
-      end
-    end
-
-    context "versions exist", versioning: true do
-      let(:user) { create :user }
-      subject(:mapping) { create(:mapping, as_user: user) }
-
-      context "only one version exists" do
-        describe "#last_editor" do
-          subject { super().last_editor }
-          it { is_expected.to eql(user) }
-        end
-      end
-
-      context "several versions exist" do
-        let(:other_user) { create :user }
-        before do
-          Transition::History.as_a_user(other_user) do
-            mapping.update!(type: "redirect", new_url: "http://updated.gov.uk")
-            mapping.update!(type: "redirect", new_url: "http://new.gov.uk")
-          end
-        end
-
-        it "has 3 versions" do
-          expect(subject.versions.size).to eq(3)
-        end
-
-        describe "#last_editor" do
-          subject { super().last_editor }
-          it { is_expected.to eql(other_user) }
-        end
-      end
-    end
-  end
 end

--- a/spec/models/mapping_spec.rb
+++ b/spec/models/mapping_spec.rb
@@ -514,39 +514,6 @@ describe Mapping do
     end
   end
 
-  describe "edited_by_human" do
-    context "imported from redirector" do
-      subject(:mapping) { create(:mapping, from_redirector: true) }
-
-      describe "#edited_by_human?" do
-        subject { super().edited_by_human? }
-        it { is_expected.to be_truthy }
-      end
-    end
-
-    context "has been edited by a human", versioning: true do
-      let(:human) { create :user }
-
-      subject(:mapping) { create(:mapping, as_user: human) }
-
-      describe "#edited_by_human?" do
-        subject { super().edited_by_human? }
-        it { is_expected.to be_truthy }
-      end
-    end
-
-    context "has been edited by a robot", versioning: true do
-      let(:robot) { create :user, is_robot: true }
-
-      subject(:mapping) { create(:mapping, as_user: robot) }
-
-      describe "#edited_by_human?" do
-        subject { super().edited_by_human? }
-        it { is_expected.to be_falsey }
-      end
-    end
-  end
-
   describe "last_editor" do
     context "no versions exist" do
       subject(:mapping) { create(:mapping, from_redirector: true) }


### PR DESCRIPTION
[Trello](https://trello.com/c/cWDsJqHc/853-remove-unused-method-and-field-from-transition)

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
