### PR TITLE
Update PaperTrail - part 1

### DIFF
--- a/db/migrate/20231017095753_convert_paper_trail_yaml_to_json.rb
+++ b/db/migrate/20231017095753_convert_paper_trail_yaml_to_json.rb
@@ -1,0 +1,12 @@
+class ConvertPaperTrailYamlToJson < ActiveRecord::Migration[7.0]
+  # https://github.com/paper-trail-gem/paper_trail/blob/v12.3.0/README.md#postgresql-json-column-type-support
+  def change
+    rename_column :versions, :object, :old_object
+    rename_column :versions, :object_changes, :old_object_changes
+
+    change_table :versions, bulk: true do |table|
+      table.jsonb :object
+      table.jsonb :object_changes
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_20_085112) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_17_095753) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -216,9 +216,11 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_20_085112) do
     t.string "event", limit: 255, null: false
     t.string "whodunnit", limit: 255
     t.integer "user_id"
-    t.text "object_changes"
-    t.text "object"
+    t.text "old_object_changes"
+    t.text "old_object"
     t.datetime "created_at", precision: nil
+    t.jsonb "object"
+    t.jsonb "object_changes"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 

--- a/lib/tasks/migrate_paper_trail.rake
+++ b/lib/tasks/migrate_paper_trail.rake
@@ -1,0 +1,19 @@
+require "paper_trail/frameworks/active_record"
+
+desc "Migrate PaperTrail YAML columns to JSON"
+task migrate_paper_trail: :environment do
+  # https://github.com/paper-trail-gem/paper_trail/blob/v12.3.0/README.md#convert-existing-yaml-data-to-json
+  most_recent_record = PaperTrail::Version.last.id
+
+  PaperTrail::Version.where.not(old_object: nil).find_each do |version|
+    puts "Migrating object #{version.id} / #{most_recent_record}"
+
+    version.update_columns(old_object: nil, object: YAML.unsafe_load(version.old_object))
+  end
+
+  PaperTrail::Version.where.not(old_object_changes: nil).find_each do |version|
+    puts "Migrating object_changes #{version.id} / #{most_recent_record}"
+
+    version.update_columns(old_object_changes: nil, object_changes: YAML.unsafe_load(version.old_object_changes))
+  end
+end


### PR DESCRIPTION
https://trello.com/c/FTU5uYu4

> [!NOTE]  
> Once we have successfully run the Rake task in this PR, we can merge [part 2](https://github.com/alphagov/transition/pull/1433)

> [!NOTE]  
> I've tested this by running it in integration, this all looks fine:
> - Adding new PaperTrail versions are now JSON
> - Killing the migration task and restarting it picks up where it left off
> - Migrated objects are as expected

### Migrate PaperTrail columns to JSON
PaperTrail version 13 has a breaking change for users who use the YAML
serialiser for the `object` and `object_changes` columns
(https://github.com/paper-trail-gem/paper_trail/blob/master/doc/pt_13_yaml_safe_load.md).

PaperTrail strongly suggest that best solution is to convert these YAML
columns to JSON.

The first step is to add new JSON columns for `object` and `object_changes`,
following this migration, these will be used for any new PaperTrail versions.

The old `object` and `object_changes` columns are renamed, ready for data
migration.

### Add task to migrate old PaperTrail versions
This task migrates YAML `object` and `object_changes` columns for PaperTrail to
JSON, following the instructions here
https://github.com/paper-trail-gem/paper_trail/blob/v12.3.0/README.md#convert-existing-yaml-data-to-json

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
