### PR TITLE
Accessibile autocomplete multiselect

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ FROM $builder_image AS builder
 WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./
 RUN bundle install
+COPY package.json yarn.lock ./
+RUN yarn set version 3.4.1 && yarn install --immutable
 COPY . .
 RUN bootsnap precompile --gemfile .
 RUN rails assets:precompile && rm -fr log

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -4,3 +4,4 @@
 //= link application.js
 //= link legacy_layout.js
 //= link html5.js
+//= link autocomplete.js

--- a/app/assets/javascripts/autocomplete.js
+++ b/app/assets/javascripts/autocomplete.js
@@ -1,0 +1,11 @@
+//= require accessible-autocomplete
+
+initialiseSelectElement();
+function initialiseSelectElement() {
+  const selectElement = document.querySelector('.autocomplete-enabled');
+
+  accessibleAutocomplete.enhanceSelectElement({
+    selectElement: selectElement,
+    showAllValues: selectElement.multiple,
+  })
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,7 +12,21 @@
  */
 
 @import "govuk_publishing_components/all_components";
+@import "accessible-autocomplete/src/autocomplete";
+
+// The accessible autocomplete component does not use
+// GOV.UK fonts by default for suggestions.
+.autocomplete__wrapper * {
+  @include govuk-typography-common();
+}
 
 .extra-organisations {
   height: 150px;
+}
+
+.autocomplete__input:focus,
+.autocomplete__input--focused {
+  outline: $govuk-focus-width solid $govuk-focus-colour;
+  outline-offset: $govuk-border-width-form-element;
+  box-shadow: $govuk-input-border-colour 0 0 0 $govuk-border-width-form-element;
 }

--- a/app/forms/site_form.rb
+++ b/app/forms/site_form.rb
@@ -31,7 +31,7 @@ class SiteForm
       abbr: site.abbr,
       tna_timestamp: site.tna_timestamp.to_formatted_s(:number),
       homepage: site.homepage,
-      extra_organisations: site.extra_organisations,
+      extra_organisations: site.extra_organisations.map(&:id),
       homepage_title: site.homepage_title,
       homepage_furl: site.homepage_furl,
       global_type: site.global_type,

--- a/app/views/sites/_site_form.html.erb
+++ b/app/views/sites/_site_form.html.erb
@@ -82,7 +82,7 @@
                                    :id,
                                    :title,
                                    {},
-                                   { multiple: true, class: "govuk-select extra-organisations govuk-!-width-two-thirds" }
+                                   { multiple: true, class: "govuk-select extra-organisations govuk-!-width-two-thirds autocomplete-enabled" }
         %>
       </div>
 
@@ -187,3 +187,7 @@
     <% end %>
   </div>
 </div>
+
+<%= content_for :head do %>
+  <%= javascript_include_tag "autocomplete", defer: true %>
+<% end %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -4,7 +4,7 @@
 Rails.application.config.assets.version = "1.0"
 
 # Add additional assets to the asset load path.
-# Rails.application.config.assets.paths << Emoji.images_path
+Rails.application.config.assets.paths << Rails.root.join("node_modules")
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "author": "Government Digital Service",
   "license": "MIT",
+  "dependencies": {
+    "accessible-autocomplete": "alphagov/accessible-autocomplete-multiselect"
+  },
   "devDependencies": {
     "jasmine-browser-runner": "^2.3.0",
     "jasmine-core": "^5.1.1"

--- a/spec/forms/site_form_spec.rb
+++ b/spec/forms/site_form_spec.rb
@@ -61,7 +61,7 @@ describe SiteForm do
         abbr: site.abbr,
         tna_timestamp: "20120816224015",
         homepage: "https://www.gov.uk/government/organisations/example-org",
-        extra_organisations: [extra_organisation],
+        extra_organisations: [extra_organisation.id],
         homepage_title: "Homepage title",
         homepage_furl: "www.gov.uk/site",
         global_type: "redirect",

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,6 +36,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+accessible-autocomplete@alphagov/accessible-autocomplete-multiselect:
+  version: 2.0.4
+  resolution: "accessible-autocomplete@https://github.com/alphagov/accessible-autocomplete-multiselect.git#commit=6b671690189f9a4b32940e60a7df781ed55d4dca"
+  dependencies:
+    preact: ^8.3.1
+  checksum: 8e412446a8b9375ed7d37bf7d5e8cf7079e4a9847e64d7a836cab4df92ef9f3be37a08e4de7375172e834a78205b1d5e63c1982473fca9fef53322e8d32fff9f
+  languageName: node
+  linkType: hard
+
 "ansi-regex@npm:^5.0.1":
   version: 5.0.1
   resolution: "ansi-regex@npm:5.0.1"
@@ -740,6 +749,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"preact@npm:^8.3.1":
+  version: 8.5.3
+  resolution: "preact@npm:8.5.3"
+  checksum: 1a2d90816abdc62673842190b819b7ce2f552b4b412cc0d2118395d8167e79f4e988229993079700277a0cae6b7fd895b3bfe5a43091bbc1f4df43903b04d1e7
+  languageName: node
+  linkType: hard
+
 "process-nextick-args@npm:~2.0.0":
   version: 2.0.1
   resolution: "process-nextick-args@npm:2.0.1"
@@ -996,6 +1012,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "transition@workspace:."
   dependencies:
+    accessible-autocomplete: alphagov/accessible-autocomplete-multiselect
     jasmine-browser-runner: ^2.3.0
     jasmine-core: ^5.1.1
   languageName: unknown


### PR DESCRIPTION
### Load the selected extra organisations into the site form correctly
The values of the extra organisations select component correspond to the record
IDs.

### Add accessible-autocomplete-multiselect

### Install Yarn as part of Dockerfile
This is required now that we want to manage our dependency on the
accessible-autocomplete-multiselect component with Yarn.

### Add node modules to assets path
Because we are using Yarn to manage our dependency on the
accessible-autocomplete-multiselect component, Rails needs to know to look in
node modules for assets.

### Use autocomplete multiselect component for extra organisations
Currently, extra organisations on the site form use a multi-select element.

This is quite hard to use for long lists of organisations, so we want to use
the autocomplete multiselect component instead.

With JavaScript disabled, this will fall back to the multi-select element.


---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
