### PR TITLE
Change URLs to use IDs instead of abbreviations

### DIFF
--- a/app/controllers/bulk_add_batches_controller.rb
+++ b/app/controllers/bulk_add_batches_controller.rb
@@ -77,7 +77,7 @@ private
   end
 
   def find_site
-    @site = Site.find_by!(abbr: params[:site_id])
+    @site = Site.find_by_abbr_or_id(params[:site_id])
   end
 
   def find_batch

--- a/app/controllers/concerns/track_mappings_progress.rb
+++ b/app/controllers/concerns/track_mappings_progress.rb
@@ -17,7 +17,7 @@ module TrackMappingsProgress
 protected
 
   def _find_site
-    @site = Site.find_by!(abbr: params[:site_id])
+    @site = Site.find_by_abbr_or_id(params[:site_id])
   end
 
   def set_saved_mappings

--- a/app/controllers/import_batches_controller.rb
+++ b/app/controllers/import_batches_controller.rb
@@ -54,7 +54,7 @@ protected
   end
 
   def find_site
-    @site = Site.find_by!(abbr: params[:site_id])
+    @site = Site.find_by_abbr_or_id(params[:site_id])
   end
 
   def find_batch

--- a/app/controllers/site_dates_controller.rb
+++ b/app/controllers/site_dates_controller.rb
@@ -25,7 +25,7 @@ class SiteDatesController < ApplicationController
 private
 
   def find_site
-    @site = Site.find_by!(abbr: params[:site_id])
+    @site = Site.find_by_abbr_or_id(params[:site_id])
   end
 
   def update_params

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -58,7 +58,7 @@ class SitesController < ApplicationController
 private
 
   def find_site
-    @site = Site.find_by!(abbr: params[:id])
+    @site = Site.find_by_abbr_or_id(params[:id])
   end
 
   def find_organisation

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -46,7 +46,7 @@ class SitesController < ApplicationController
   end
 
   def destroy
-    @delete_site_form = DeleteSiteForm.new(abbr: @site.abbr, **destroy_params)
+    @delete_site_form = DeleteSiteForm.new(id: @site.id, **destroy_params)
 
     if @delete_site_form.save
       redirect_to organisation_path(@site.organisation), flash: { success: "The site and all its data have been successfully deleted" }
@@ -85,7 +85,7 @@ private
   end
 
   def destroy_params
-    params.require(:delete_site_form).permit(:abbr_confirmation)
+    params.require(:delete_site_form).permit(:hostname_confirmation)
   end
 
   def check_user_is_site_manager

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -69,7 +69,6 @@ private
     params.require(:site_form).permit(
       :site_id,
       :organisation_slug,
-      :abbr,
       :tna_timestamp,
       :homepage,
       :homepage_title,

--- a/app/forms/delete_site_form.rb
+++ b/app/forms/delete_site_form.rb
@@ -4,8 +4,8 @@ class DeleteSiteForm
   include ActiveModel::Model
   include ActiveModel::Attributes
 
-  attribute :abbr
-  attribute :abbr_confirmation
+  attribute :id
+  attribute :hostname_confirmation
 
   validate :confirmation_matches
 
@@ -19,12 +19,12 @@ class DeleteSiteForm
 private
 
   def site
-    Site.find_by(abbr:)
+    Site.find_by(id:)
   end
 
   def confirmation_matches
-    if abbr_confirmation != abbr
-      errors.add(:abbr_confirmation, "The confirmation did not match")
+    if hostname_confirmation != site.default_host.hostname
+      errors.add(:hostname_confirmation, "The confirmation did not match")
     end
   end
 end

--- a/app/forms/site_form.rb
+++ b/app/forms/site_form.rb
@@ -5,7 +5,6 @@ class SiteForm
   attribute :site_id
 
   attribute :organisation_slug
-  attribute :abbr
   attribute :tna_timestamp
   attribute :homepage
   attribute :homepage_title
@@ -28,7 +27,6 @@ class SiteForm
     new(
       site_id: site.id,
       organisation_slug: site.organisation.whitehall_slug,
-      abbr: site.abbr,
       tna_timestamp: site.tna_timestamp.to_formatted_s(:number),
       homepage: site.homepage,
       extra_organisations: site.extra_organisations.map(&:id),
@@ -66,7 +64,6 @@ private
   def site
     @site ||= Site.find_or_initialize_by(id: site_id).tap do |site|
       site.assign_attributes(
-        abbr:,
         tna_timestamp:,
         homepage:,
         organisation: Organisation.find_by(whitehall_slug: organisation_slug),

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -13,7 +13,7 @@ class Host < ApplicationRecord
   validates :hostname, presence: true
   validates :hostname, uniqueness: {
     message: lambda do |_object, data|
-      site = Host.find_by(hostname: data[:value]).site.abbr
+      site = Host.find_by(hostname: data[:value]).site.default_host.hostname
       "The hostname #{data[:value]} already exists. You must delete the #{site} site to remove it"
     end,
   }

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -25,7 +25,6 @@ class Site < ApplicationRecord
   validates :tna_timestamp, presence: true
   validates :organisation, presence: true
   validates :homepage, presence: true, non_blank_url: { message: :non_blank_url }
-  validates :abbr, uniqueness: true, presence: true, format: { with: /\A[a-zA-Z0-9_-]+\z/, message: :extra_characters }
   validates :special_redirect_strategy, inclusion: { in: SPECIAL_REDIRECT_STRATEGY_TYPES.values, allow_blank: true }
   validates :global_new_url, presence: { if: :global_redirect? }
   validates :global_new_url, absence: { if: :global_archive? }

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -48,10 +48,6 @@ class Site < ApplicationRecord
     self[:mapping_count].to_i
   end
 
-  def to_param
-    abbr
-  end
-
   def global_redirect?
     global_type == "redirect"
   end
@@ -126,11 +122,15 @@ class Site < ApplicationRecord
   end
 
   def precomputed_view_name
-    @_precomputed_view_name = %(#{abbr}_all_hits)
+    @_precomputed_view_name = %(all_hits_#{id})
   end
 
   def able_to_use_view?
     precompute_all_hits_view && Postgres::MaterializedView.exists?(precomputed_view_name)
+  end
+
+  def self.find_by_abbr_or_id(abbr_or_id)
+    find_by(abbr: abbr_or_id) || find(abbr_or_id)
   end
 
 private

--- a/app/views/hits/_summary_section.html.erb
+++ b/app/views/hits/_summary_section.html.erb
@@ -5,7 +5,7 @@
     <%= link_to "See all #{category.name}", category_site_hits_path(@site, category: category.name, period: @period.query_slug) %>
   <% else %>
     <p class="no-content no-content-bordered">
-      There are no known <%= category.name.pluralize %> for <%= @site.abbr %> <%= @period.no_content %>.
+      There are no known <%= category.name.pluralize %> for <%= @site.default_host.hostname %> <%= @period.no_content %>.
     </p>
   <% end %>
 </section>

--- a/app/views/hits/category.html.erb
+++ b/app/views/hits/category.html.erb
@@ -5,6 +5,6 @@
      point_categories: [@category],
      title: "#{@category.title}",
      active: "#{@category.title}",
-     no_content_message: "There are no #{@category.plural} for #{@site.abbr} #{@period.no_content}."
+     no_content_message: "There are no #{@category.plural} for #{@site.default_host.hostname} #{@period.no_content}."
    }
 %>

--- a/app/views/hits/index.html.erb
+++ b/app/views/hits/index.html.erb
@@ -5,6 +5,6 @@
      points: @category.points,
      title: "All hits",
      active: 'All hits',
-     no_content_message: "We don’t have any traffic data for #{@site.abbr} #{@period.no_content}."
+     no_content_message: "We don’t have any traffic data for #{@site.default_host.hostname} #{@period.no_content}."
    }
 %>

--- a/app/views/hits/summary.html.erb
+++ b/app/views/hits/summary.html.erb
@@ -24,7 +24,7 @@
 
 <% if no_hits_for_any?(@sections) %>
   <p class="no-content no-content-bordered">
-    There are no known hits for the <%= @site.abbr %> summary <%= @period.no_content %>.
+    There are no known hits for the <%= @site.default_host.hostname %> summary <%= @period.no_content %>.
   </p>
 <% end  %>
 

--- a/app/views/sites/_site_form.html.erb
+++ b/app/views/sites/_site_form.html.erb
@@ -14,17 +14,6 @@
       <%= form.hidden_field :organisation_slug, value: form.object.organisation_slug %>
 
       <%= render "govuk_publishing_components/components/input", {
-        label: { text: t("helpers.label.site_form.abbr") },
-        hint: t("helpers.hint.site_form.abbr"),
-        heading_size: "m",
-        name: form.field_name(:abbr),
-        id: field_id_attribute(form.object, :abbr),
-        error_message: error_message(form.object, :abbr),
-        value: form.object.abbr,
-        width: 20
-      } %>
-
-      <%= render "govuk_publishing_components/components/input", {
         label: { text: t("helpers.label.site_form.tna_timestamp") },
         hint: t("helpers.hint.site_form.tna_timestamp").html_safe,
         heading_size: "m",

--- a/app/views/sites/confirm_destroy.html.erb
+++ b/app/views/sites/confirm_destroy.html.erb
@@ -19,7 +19,7 @@
   } %>
 
   <%= render "govuk_publishing_components/components/warning_text", {
-    text: "This will delete the #{@site.abbr} site and all the data that is associated with it.",
+    text: "This will delete the #{@site.default_host.hostname} site and all the data that is associated with it.",
     margin_bottom: true
   } %>
 
@@ -39,11 +39,11 @@
   </p>
 
   <%= render "govuk_publishing_components/components/input", {
-    label: { text: "Enter the site slug, #{@site.abbr}, to confirm that you want to delete this site and all its data." },
-    name: form.field_name(:abbr_confirmation),
-    id: field_id_attribute(form.object, :abbr_confirmation),
-    error_message: error_message(form.object, :abbr_confirmation),
-    value: form.object.abbr_confirmation,
+    label: { text: "Enter the site's primary hostname, #{@site.default_host.hostname}, to confirm that you want to delete this site and all its data." },
+    name: form.field_name(:hostname_confirmation),
+    id: field_id_attribute(form.object, :hostname_confirmation),
+    error_message: error_message(form.object, :hostname_confirmation),
+    value: form.object.hostname_confirmation,
     heading_size: "s"
   } %>
 

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -59,6 +59,40 @@
     },
     {
       "warning_type": "Cross-Site Scripting",
+      "warning_code": 84,
+      "fingerprint": "3de1c1d1db70515736baab15259c374071220d922d7ad7131900cd403cfb472b",
+      "check_name": "RenderInline",
+      "message": "Unescaped model attribute rendered inline",
+      "file": "app/views/sites/confirm_destroy.html.erb",
+      "line": 22,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross-site_scripting/",
+      "code": "render(text => \"This will delete the #{Site.find_by_abbr_or_id(params[:id]).default_host.hostname} site and all the data that is associated with it.\", { :margin_bottom => true })",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "SitesController",
+          "method": "confirm_destroy",
+          "line": 46,
+          "file": "app/controllers/sites_controller.rb",
+          "rendered": {
+            "name": "sites/confirm_destroy",
+            "file": "app/views/sites/confirm_destroy.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "sites/confirm_destroy"
+      },
+      "user_input": "Site.find_by_abbr_or_id(params[:id]).default_host.hostname",
+      "confidence": "Medium",
+      "cwe_id": [
+        79
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
       "fingerprint": "3fdaf6ede7ba5c6a4eb649900849b88fabab0d49681a98e89a3b34242f78cb36",
       "check_name": "LinkToHref",
@@ -100,6 +134,40 @@
         79
       ],
       "note": "This is a valid URL (see app/models/mapping.rb)"
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
+      "fingerprint": "63ce04cb0e7cb2864e67c346a54263872990644c940d76994cb169a8b009972e",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in `link_to` href",
+      "file": "app/views/bulk_add_batches/preview.html.erb",
+      "line": 37,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to(Site.find_by_abbr_or_id(params[:site_id]).bulk_add_batches.find(params[:id]).new_url, Site.find_by_abbr_or_id(params[:site_id]).bulk_add_batches.find(params[:id]).new_url, :class => \"breakable\")",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "BulkAddBatchesController",
+          "method": "preview",
+          "line": 36,
+          "file": "app/controllers/bulk_add_batches_controller.rb",
+          "rendered": {
+            "name": "bulk_add_batches/preview",
+            "file": "app/views/bulk_add_batches/preview.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "bulk_add_batches/preview"
+      },
+      "user_input": "Site.find_by_abbr_or_id(params[:site_id]).bulk_add_batches.find(params[:id]).new_url",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
+      "note": ""
     },
     {
       "warning_type": "Cross-Site Scripting",
@@ -159,6 +227,50 @@
       "note": "Ultimately this is interpolating a list of integers into the SQL for a WHERE...IN check"
     },
     {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
+      "fingerprint": "b34ed9665d156a41dbd8ede54224b41b64a496daafb8a2254e31dcd4f96a2238",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in `link_to` href",
+      "file": "app/views/sites/_configuration.html.erb",
+      "line": 6,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to(Site.find_by_abbr_or_id(params[:id]).homepage, Site.find_by_abbr_or_id(params[:id]).homepage, :class => \"breakable\")",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "SitesController",
+          "method": "show",
+          "line": 42,
+          "file": "app/controllers/sites_controller.rb",
+          "rendered": {
+            "name": "sites/show",
+            "file": "app/views/sites/show.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "sites/show",
+          "line": 15,
+          "file": "app/views/sites/show.html.erb",
+          "rendered": {
+            "name": "sites/_configuration",
+            "file": "app/views/sites/_configuration.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "sites/_configuration"
+      },
+      "user_input": "Site.find_by_abbr_or_id(params[:id]).homepage",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "b6d10053540be2e7224fba9d6fc112a4111f522606d2877c9dbbe4ae7845399a",
@@ -180,40 +292,6 @@
         89
       ],
       "note": "Ultimately this is interpolating a list of integers into the SQL for a WHERE...IN check"
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 4,
-      "fingerprint": "d36f2b3cd37435a8c5bcddde9ebdd53e21b569bb817a329f2927c794e2c8d9b6",
-      "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in `link_to` href",
-      "file": "app/views/bulk_add_batches/preview.html.erb",
-      "line": 37,
-      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to(Site.find_by!(:abbr => params[:site_id]).bulk_add_batches.find(params[:id]).new_url, Site.find_by!(:abbr => params[:site_id]).bulk_add_batches.find(params[:id]).new_url, :class => \"breakable\")",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "BulkAddBatchesController",
-          "method": "preview",
-          "line": 36,
-          "file": "app/controllers/bulk_add_batches_controller.rb",
-          "rendered": {
-            "name": "bulk_add_batches/preview",
-            "file": "app/views/bulk_add_batches/preview.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "bulk_add_batches/preview"
-      },
-      "user_input": "Site.find_by!(:abbr => params[:site_id]).bulk_add_batches.find(params[:id]).new_url",
-      "confidence": "Weak",
-      "cwe_id": [
-        79
-      ],
-      "note": "This is a valid URL (see app/models/mapping.rb)"
     },
     {
       "warning_type": "Cross-Site Scripting",
@@ -418,6 +496,6 @@
       "note": "This is a valid National Archives URL (see app/models/mapping.rb)"
     }
   ],
-  "updated": "2023-12-18 11:39:32 +0000",
+  "updated": "2023-12-18 11:43:12 +0000",
   "brakeman_version": "6.1.0"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -7,7 +7,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "lib/transition/import/hits_mappings_relations.rb",
-      "line": 113,
+      "line": 121,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "ActiveRecord::Base.connection.execute(\"          UPDATE mappings\\n          SET hit_count = with_counts.hit_count\\n          FROM (\\n            SELECT hits.mapping_id, SUM(hits.count) AS hit_count\\n            FROM hits\\n            #{(\"WHERE host_id #{in_site_hosts}\" or \"\")}\\n            GROUP BY hits.mapping_id\\n          ) with_counts\\n          WHERE\\n            mappings.id = with_counts.mapping_id AND\\n            mappings.hit_count IS DISTINCT FROM with_counts.hit_count\\n\")",
       "render_path": null,
@@ -18,6 +18,9 @@
       },
       "user_input": "in_site_hosts",
       "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
       "note": "Ultimately this is interpolating a list of integers into the SQL for a WHERE...IN check"
     },
     {
@@ -25,18 +28,33 @@
       "warning_code": 4,
       "fingerprint": "38b7bf3af8733d01999c901c03369bf71414a355a3b6b12f84c68fb117365470",
       "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in link_to href",
+      "message": "Potentially unsafe model attribute in `link_to` href",
       "file": "app/views/glossary/index.html.erb",
       "line": 121,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
       "code": "link_to(Mapping.where(:type => \"redirect\").first.old_url, Mapping.where(:type => \"redirect\").first.old_url)",
-      "render_path": [{"type":"controller","class":"GlossaryController","method":"index","line":6,"file":"app/controllers/glossary_controller.rb"}],
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "GlossaryController",
+          "method": "index",
+          "line": 6,
+          "file": "app/controllers/glossary_controller.rb",
+          "rendered": {
+            "name": "glossary/index",
+            "file": "app/views/glossary/index.html.erb"
+          }
+        }
+      ],
       "location": {
         "type": "template",
         "template": "glossary/index"
       },
       "user_input": "Mapping.where(:type => \"redirect\").first.old_url",
       "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
       "note": "This is a valid URL (see app/models/mapping.rb)"
     },
     {
@@ -44,19 +62,124 @@
       "warning_code": 4,
       "fingerprint": "3fdaf6ede7ba5c6a4eb649900849b88fabab0d49681a98e89a3b34242f78cb36",
       "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in link_to href",
+      "message": "Potentially unsafe model attribute in `link_to` href",
       "file": "app/views/mappings/_form.html.erb",
       "line": 25,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
       "code": "link_to(Mapping.find(params[:id]).old_url, Mapping.find(params[:id]).old_url)",
-      "render_path": [{"type":"controller","class":"MappingsController","method":"edit","line":36,"file":"app/controllers/mappings_controller.rb"},{"type":"template","name":"mappings/edit","line":11,"file":"app/views/mappings/edit.html.erb"}],
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "MappingsController",
+          "method": "edit",
+          "line": 35,
+          "file": "app/controllers/mappings_controller.rb",
+          "rendered": {
+            "name": "mappings/edit",
+            "file": "app/views/mappings/edit.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "mappings/edit",
+          "line": 11,
+          "file": "app/views/mappings/edit.html.erb",
+          "rendered": {
+            "name": "mappings/_form",
+            "file": "app/views/mappings/_form.html.erb"
+          }
+        }
+      ],
       "location": {
         "type": "template",
         "template": "mappings/_form"
       },
       "user_input": "Mapping.find(params[:id]).old_url",
       "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
       "note": "This is a valid URL (see app/models/mapping.rb)"
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
+      "fingerprint": "8c1fce5b2b7bdec13c7fa177e82b388aa05296dcd35bd7895d0957878ac03989",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in `link_to` href",
+      "file": "app/views/bulk_add_batches/preview.html.erb",
+      "line": 60,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to((Unresolved Model).new.path, (Unresolved Model).new.old_url, :class => \"breakable\")",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "BulkAddBatchesController",
+          "method": "preview",
+          "line": 36,
+          "file": "app/controllers/bulk_add_batches_controller.rb",
+          "rendered": {
+            "name": "bulk_add_batches/preview",
+            "file": "app/views/bulk_add_batches/preview.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "bulk_add_batches/preview"
+      },
+      "user_input": "(Unresolved Model).new.old_url",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
+      "note": "This is a valid URL (see app/models/mapping.rb)"
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "ae397bc95456d159e5e3fe026e81a313481987243f22826877ab10248bb0a2ac",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "lib/transition/import/hits_mappings_relations.rb",
+      "line": 60,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "ActiveRecord::Base.connection.execute(\"          INSERT INTO host_paths(host_id, path)\\n          SELECT hits.host_id, hits.path\\n          FROM   hits\\n          WHERE NOT EXISTS (\\n            SELECT 1 FROM host_paths\\n            WHERE\\n              host_paths.host_id   = hits.host_id AND\\n              host_paths.path      = hits.path\\n          )\\n          #{(\"AND hits.host_id #{in_site_hosts}\" or \"\")}\\n          GROUP  BY hits.host_id,\\n                    hits.path\\n\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Transition::Import::HitsMappingsRelations",
+        "method": "refresh_host_paths!"
+      },
+      "user_input": "in_site_hosts",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": "Ultimately this is interpolating a list of integers into the SQL for a WHERE...IN check"
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "b6d10053540be2e7224fba9d6fc112a4111f522606d2877c9dbbe4ae7845399a",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "lib/transition/import/hits_mappings_relations.rb",
+      "line": 102,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "ActiveRecord::Base.connection.execute(\"          UPDATE hits\\n          SET  mapping_id = host_paths.mapping_id\\n          FROM host_paths\\n          WHERE\\n            host_paths.host_id   = hits.host_id AND\\n            host_paths.path      = hits.path AND\\n            host_paths.mapping_id IS DISTINCT FROM hits.mapping_id\\n            #{(\"AND host_paths.host_id #{in_site_hosts}\" or \"\")}\\n\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Transition::Import::HitsMappingsRelations",
+        "method": "refresh_hits_from_host_paths!"
+      },
+      "user_input": "in_site_hosts",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": "Ultimately this is interpolating a list of integers into the SQL for a WHERE...IN check"
     },
     {
       "warning_type": "Cross-Site Scripting",
@@ -68,111 +191,62 @@
       "line": 37,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
       "code": "link_to(Site.find_by!(:abbr => params[:site_id]).bulk_add_batches.find(params[:id]).new_url, Site.find_by!(:abbr => params[:site_id]).bulk_add_batches.find(params[:id]).new_url, :class => \"breakable\")",
-      "render_path": [{"type":"controller","class":"BulkAddBatchesController","method":"preview","line":34,"file":"app/controllers/bulk_add_batches_controller.rb","rendered":{"name":"bulk_add_batches/preview","file":"app/views/bulk_add_batches/preview.html.erb"}}],
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "BulkAddBatchesController",
+          "method": "preview",
+          "line": 36,
+          "file": "app/controllers/bulk_add_batches_controller.rb",
+          "rendered": {
+            "name": "bulk_add_batches/preview",
+            "file": "app/views/bulk_add_batches/preview.html.erb"
+          }
+        }
+      ],
       "location": {
         "type": "template",
         "template": "bulk_add_batches/preview"
       },
       "user_input": "Site.find_by!(:abbr => params[:site_id]).bulk_add_batches.find(params[:id]).new_url",
       "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
       "note": "This is a valid URL (see app/models/mapping.rb)"
-    },
-    {
-      "warning_type": "Redirect",
-      "warning_code": 18,
-      "fingerprint": "533110565bf7c9e0b39c62ca6209a84c3bacb8a4d016183d56513927f785da80",
-      "check_name": "Redirect",
-      "message": "Possible unprotected redirect",
-      "file": "app/controllers/mappings_controller.rb",
-      "line": 188,
-      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
-      "code": "redirect_to(params[:return_path], redirect_to_options)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "MappingsController",
-        "method": "safely_redirect_to_start_point"
-      },
-      "user_input": "params[:return_path]",
-      "confidence": "High",
-      "note": "This is valid on the previous line (see lib/transition/off_site_redirect_checker.rb)"
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 4,
-      "fingerprint": "8c1fce5b2b7bdec13c7fa177e82b388aa05296dcd35bd7895d0957878ac03989",
-      "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in link_to href",
-      "file": "app/views/bulk_add_batches/preview.html.erb",
-      "line": 60,
-      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to((Unresolved Model).new.path, (Unresolved Model).new.old_url, :class => \"breakable\")",
-      "render_path": [{"type":"controller","class":"BulkAddBatchesController","method":"preview","line":34,"file":"app/controllers/bulk_add_batches_controller.rb"}],
-      "location": {
-        "type": "template",
-        "template": "bulk_add_batches/preview"
-      },
-      "user_input": "(Unresolved Model).new.old_url",
-      "confidence": "Weak",
-      "note": "This is a valid URL (see app/models/mapping.rb)"
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "ae397bc95456d159e5e3fe026e81a313481987243f22826877ab10248bb0a2ac",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "lib/transition/import/hits_mappings_relations.rb",
-      "line": 59,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "ActiveRecord::Base.connection.execute(\"          INSERT INTO host_paths(host_id, path)\\n          SELECT hits.host_id, hits.path\\n          FROM   hits\\n          WHERE NOT EXISTS (\\n            SELECT 1 FROM host_paths\\n            WHERE\\n              host_paths.host_id   = hits.host_id AND\\n              host_paths.path      = hits.path\\n          )\\n          #{(\"AND hits.host_id #{in_site_hosts}\" or \"\")}\\n          GROUP  BY hits.host_id,\\n                    hits.path\\n\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Transition::Import::HitsMappingsRelations",
-        "method": "refresh_host_paths!"
-      },
-      "user_input": "in_site_hosts",
-      "confidence": "Medium",
-      "note": "Ultimately this is interpolating a list of integers into the SQL for a WHERE...IN check"
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "b6d10053540be2e7224fba9d6fc112a4111f522606d2877c9dbbe4ae7845399a",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "lib/transition/import/hits_mappings_relations.rb",
-      "line": 94,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "ActiveRecord::Base.connection.execute(\"          UPDATE hits\\n          SET  mapping_id = host_paths.mapping_id\\n          FROM host_paths\\n          WHERE\\n            host_paths.host_id   = hits.host_id AND\\n            host_paths.path      = hits.path AND\\n            host_paths.mapping_id IS DISTINCT FROM hits.mapping_id\\n            #{(\"AND host_paths.host_id #{in_site_hosts}\" or \"\")}\\n\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Transition::Import::HitsMappingsRelations",
-        "method": "refresh_hits_from_host_paths!"
-      },
-      "user_input": "in_site_hosts",
-      "confidence": "Medium",
-      "note": "Ultimately this is interpolating a list of integers into the SQL for a WHERE...IN check"
     },
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
       "fingerprint": "e1e17c05d61774feca7f6e4312ee2767b42fc8f50e875db3a95425ed25ce07bc",
       "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in link_to href",
+      "message": "Potentially unsafe model attribute in `link_to` href",
       "file": "app/views/glossary/index.html.erb",
       "line": 56,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
       "code": "link_to(Mapping.where(:type => \"archive\").first.old_url, Mapping.where(:type => \"archive\").first.old_url)",
-      "render_path": [{"type":"controller","class":"GlossaryController","method":"index","line":6,"file":"app/controllers/glossary_controller.rb"}],
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "GlossaryController",
+          "method": "index",
+          "line": 6,
+          "file": "app/controllers/glossary_controller.rb",
+          "rendered": {
+            "name": "glossary/index",
+            "file": "app/views/glossary/index.html.erb"
+          }
+        }
+      ],
       "location": {
         "type": "template",
         "template": "glossary/index"
       },
       "user_input": "Mapping.where(:type => \"archive\").first.old_url",
       "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
       "note": "This is a valid URL (see app/models/mapping.rb)"
     },
     {
@@ -180,18 +254,33 @@
       "warning_code": 4,
       "fingerprint": "e559c0757414823db9d2a09c910ac6ce8d314a5e2860887955902d583fd3f2bd",
       "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in link_to href",
+      "message": "Potentially unsafe model attribute in `link_to` href",
       "file": "app/views/glossary/index.html.erb",
       "line": 123,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
       "code": "link_to(Mapping.where(:type => \"redirect\").first.new_url, Mapping.where(:type => \"redirect\").first.new_url)",
-      "render_path": [{"type":"controller","class":"GlossaryController","method":"index","line":6,"file":"app/controllers/glossary_controller.rb"}],
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "GlossaryController",
+          "method": "index",
+          "line": 6,
+          "file": "app/controllers/glossary_controller.rb",
+          "rendered": {
+            "name": "glossary/index",
+            "file": "app/views/glossary/index.html.erb"
+          }
+        }
+      ],
       "location": {
         "type": "template",
         "template": "glossary/index"
       },
       "user_input": "Mapping.where(:type => \"redirect\").first.new_url",
       "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
       "note": "The domain of redirect URLs is constrained (see app/models/mapping.rb)"
     },
     {
@@ -199,18 +288,43 @@
       "warning_code": 4,
       "fingerprint": "e768cb7d3f7cd24d68e901ca297dc767559a188a7de7753451ee59ab1a613ee3",
       "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in link_to href",
+      "message": "Potentially unsafe model attribute in `link_to` href",
       "file": "app/views/mappings/_form.html.erb",
       "line": 57,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
       "code": "link_to(\"Find on the National Archives\", Mapping.find(params[:id]).national_archive_index_url)",
-      "render_path": [{"type":"controller","class":"MappingsController","method":"edit","line":36,"file":"app/controllers/mappings_controller.rb"},{"type":"template","name":"mappings/edit","line":11,"file":"app/views/mappings/edit.html.erb"}],
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "MappingsController",
+          "method": "edit",
+          "line": 35,
+          "file": "app/controllers/mappings_controller.rb",
+          "rendered": {
+            "name": "mappings/edit",
+            "file": "app/views/mappings/edit.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "mappings/edit",
+          "line": 11,
+          "file": "app/views/mappings/edit.html.erb",
+          "rendered": {
+            "name": "mappings/_form",
+            "file": "app/views/mappings/_form.html.erb"
+          }
+        }
+      ],
       "location": {
         "type": "template",
         "template": "mappings/_form"
       },
       "user_input": "Mapping.find(params[:id]).national_archive_index_url",
       "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
       "note": "This is a valid National Archives URL (see app/models/mapping.rb)"
     },
     {
@@ -231,6 +345,9 @@
       },
       "user_input": "name",
       "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
       "note": "This is only called with constant, safe, strings"
     },
     {
@@ -251,6 +368,9 @@
       },
       "user_input": "name",
       "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
       "note": "This is only called with constant, safe, strings"
     },
     {
@@ -258,21 +378,46 @@
       "warning_code": 4,
       "fingerprint": "fc1b85ee291a773b9faac48b766ceabe3ad349538b228e0a20b6e9eb58498e20",
       "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in link_to href",
+      "message": "Potentially unsafe model attribute in `link_to` href",
       "file": "app/views/mappings/_form.html.erb",
       "line": 51,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
       "code": "link_to(Mapping.find(params[:id]).national_archive_url, Mapping.find(params[:id]).national_archive_url)",
-      "render_path": [{"type":"controller","class":"MappingsController","method":"edit","line":36,"file":"app/controllers/mappings_controller.rb"},{"type":"template","name":"mappings/edit","line":11,"file":"app/views/mappings/edit.html.erb"}],
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "MappingsController",
+          "method": "edit",
+          "line": 35,
+          "file": "app/controllers/mappings_controller.rb",
+          "rendered": {
+            "name": "mappings/edit",
+            "file": "app/views/mappings/edit.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "mappings/edit",
+          "line": 11,
+          "file": "app/views/mappings/edit.html.erb",
+          "rendered": {
+            "name": "mappings/_form",
+            "file": "app/views/mappings/_form.html.erb"
+          }
+        }
+      ],
       "location": {
         "type": "template",
         "template": "mappings/_form"
       },
       "user_input": "Mapping.find(params[:id]).national_archive_url",
       "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
       "note": "This is a valid National Archives URL (see app/models/mapping.rb)"
     }
   ],
-  "updated": "2019-12-03 14:27:21 +0000",
-  "brakeman_version": "4.7.2"
+  "updated": "2023-12-18 11:39:32 +0000",
+  "brakeman_version": "6.1.0"
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,10 +28,6 @@ en:
             hostname:
               blank:
                 Enter a hostname
-            abbr:
-              blank: Enter an abbreviated name
-              taken: Abbreviated name must be unique
-              extra_characters: Abbreviated name can only contain alphanumeric characters, underscores and dashes
             global_new_url:
               blank: Global new URL cannot be blank
               has_query: Global new URL cannot contain a query when the path is appended
@@ -62,7 +58,6 @@ en:
         special_redirect_strategy_options:
           via_aka: Via AKA
           supplier: Supplier
-        abbr: Abbreviated name
         hostname: Hostname
         tna_timestamp: TNA timestamp
         homepage: Homepage
@@ -75,7 +70,6 @@ en:
         aliases: Aliases (Optional)
     hint:
       site_form:
-        abbr: This is the owning organisation abbreviation followed by the abbreviated site name, separated by an underscore. For example, the "Obesity West Midlands" site which is owned by Public Health England would be "phe_obesitywm"
         host: This is the primary hostname for the site. For example, "www.example.com".
         tna_timestamp: This is the last good capture from the <a href="https://www.nationalarchives.gov.uk/webarchive/" class="govuk-link">UK Government Web Archives</a>. For example, "20131002172858". If the site has not been crawled by the National Archives, set a stub timestamp "20201010101010".
         homepage: This is the URL for the new site.

--- a/db/migrate/20231212143730_remove_abbreviation_not_null.rb
+++ b/db/migrate/20231212143730_remove_abbreviation_not_null.rb
@@ -1,0 +1,9 @@
+class RemoveAbbreviationNotNull < ActiveRecord::Migration[7.1]
+  def up
+    change_column :sites, :abbr, :string, limit: 255, null: true
+  end
+
+  def down
+    change_column :sites, :abbr, :string, limit: 255, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_20_093533) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_12_143730) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -159,7 +159,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_20_093533) do
 
   create_table "sites", force: :cascade do |t|
     t.integer "organisation_id", null: false
-    t.string "abbr", limit: 255, null: false
+    t.string "abbr", limit: 255
     t.string "query_params", limit: 255
     t.datetime "tna_timestamp", precision: nil, null: false
     t.string "homepage", limit: 255

--- a/features/hits_summary.feature
+++ b/features/hits_summary.feature
@@ -115,12 +115,12 @@ Scenario: No hits exist at all
   When I visit the associated site
   And I click the link "Analytics"
   Then I should not see a graph
-  And I should see "There are no known hits for the ago summary"
+  And I should see "There are no known hits for the ago.gov.uk summary"
   When I click the link "Errors"
-  Then I should see "There are no errors for ago"
+  Then I should see "There are no errors for ago.gov.uk"
   And I should not see a graph
   When I filter by the date period "Last seven days"
-  Then I should see "There are no errors for ago in this time period"
+  Then I should see "There are no errors for ago.gov.uk in this time period"
 
 @allow-rescue
 Scenario: Visit the hits summary page for an non-existent site

--- a/features/organisation.feature
+++ b/features/organisation.feature
@@ -6,8 +6,8 @@ Feature: View organisation
   Scenario: Visit an organisation page
     Given I have logged in as a GDS Editor
     And there is a bis organisation named UK Atomic Energy Authority abbreviated ukaea with these sites:
-      | abbr       | homepage                                                               |
-      | bis_ukaea  | https://www.gov.uk/government/organisations/uk-atomic-energy-authority |
+      | abbr       | homepage                                                               | default_host     |
+      | bis_ukaea  | https://www.gov.uk/government/organisations/uk-atomic-energy-authority | www.ukaea.gov.uk |
     When I visit the path /organisations/ukaea
     Then I should see the header "UK Atomic Energy Authority"
     And I should see that this organisation is an executive non-departmental public body of its parent
@@ -40,9 +40,9 @@ Feature: View organisation
   Scenario: Filter the list of sites
     Given I have logged in as a GDS Editor
     And there is a bis organisation named Companies House abbreviated companies-house with these sites:
-      | abbr             | homepage                                                    |
-      | companies        | https://www.gov.uk/government/organisations/companies-house |
-      | companies_welsh  | https://www.gov.uk/government/organisations/companies-house |
+      | abbr             | homepage                                                    | default_host           |
+      | companies        | https://www.gov.uk/government/organisations/companies-house | companies.gov.uk       |
+      | companies_welsh  | https://www.gov.uk/government/organisations/companies-house | companies_welsh.gov.uk |
     When I visit the path /organisations/companies-house
     And I filter sites by "welsh"
     Then I should see a sites table with 1 row

--- a/features/step_definitions/fixture_steps.rb
+++ b/features/step_definitions/fixture_steps.rb
@@ -1,9 +1,10 @@
-Given(/^there is a (.*) organisation named (.*) abbreviated (.*) with these sites:$/) do |parent, name, abbr, site_table|
-  # table rows are like | awb  | http://average-white-band.gov.uk/ |
+Given(/^there is a (.*) organisation named (.*) abbreviated (.*) with these sites:$/) do |parent, name, org_abbr, site_table|
+  # table rows are like | http://average-white-band.gov.uk/ |
   @parent             = create(:organisation, whitehall_slug: parent)
-  @organisation       = create(:organisation, title: name, whitehall_slug: abbr, parent_organisations: [@parent])
-  @organisation.sites = site_table.rows.map do |site_abbr, homepage|
-    create(:site, abbr: site_abbr, homepage:, organisation: @organisation)
+  @organisation       = create(:organisation, title: name, whitehall_slug: org_abbr, parent_organisations: [@parent])
+  @organisation.sites = site_table.rows.map do |_site_abbr, homepage, default_host|
+    host = create(:host, hostname: default_host)
+    create(:site, homepage:, organisation: @organisation, hosts: [host])
   end
 end
 
@@ -102,7 +103,7 @@ Given(/^the site is globally redirected with the path appended$/) do
 end
 
 Given(/^these hits exist for the Attorney General's office site:$/) do |table|
-  @site = create :site, abbr: "ago"
+  @site = create :site
   # table is a | 410         | /    | 16/10/12 | 100   |
   table.rows.map do |status, path, hit_on, count|
     create :hit,
@@ -121,12 +122,12 @@ Given(/^these hits exist for the Attorney General's office site:$/) do |table|
 end
 
 Given(/^some hits exist for the Cabinet Office site$/) do
-  site = create :site, abbr: "cabinetoffice"
+  site = create :site
   create :hit, http_status: "410", count: 20, host: site.hosts.first, path: "/cabinetofficehit"
 end
 
 Given(/^no hits exist for the Attorney General's office site$/) do
-  @site ||= create(:site, abbr: "ago")
+  @site = create(:site, abbr: "ago")
   Hit.delete_all
   DailyHitTotal.delete_all
 end

--- a/features/step_definitions/mappings_fixture_steps.rb
+++ b/features/step_definitions/mappings_fixture_steps.rb
@@ -1,11 +1,11 @@
 Given(/^a mapping exists for the site ukba$/) do
-  @site = create :site, abbr: "ukba"
+  @site = create :site
   @mapping = create(:mapping)
   @site.mappings = [@mapping]
 end
 
-Given(/^a site "([^"]*)" exists with mappings with lots of tags$/) do |site_abbr|
-  @site = create :site, abbr: site_abbr
+Given(/^a site "([^"]*)" exists with mappings with lots of tags$/) do |_site_abbr|
+  @site = create :site
   [10, 11].each do |tag_count|
     # The site dashboard only displays the 10 most popular tags. If we make it
     # so that there are 11 tags on this site, 10 of which are predictably more
@@ -20,8 +20,8 @@ Given(/^a site "([^"]*)" exists with mappings with lots of tags$/) do |site_abbr
   end
 end
 
-Given(/^a site "([^"]*)" exists with these tagged mappings:$/) do |site_abbr, tagged_paths|
-  @site = create :site, abbr: site_abbr
+Given(/^a site "([^"]*)" exists with these tagged mappings:$/) do |_site_abbr, tagged_paths|
+  @site = create :site
 
   # tagged_paths.hashes.keys # => [:path, :tags]
   tagged_paths.hashes.each do |row|

--- a/features/step_definitions/site_interaction_steps.rb
+++ b/features/step_definitions/site_interaction_steps.rb
@@ -44,11 +44,11 @@ When(/^I delete this site$/) do
 end
 
 When(/^I confirm the deletion$/) do
-  fill_in "delete_site_form[abbr_confirmation]", with: @site.abbr
+  fill_in "delete_site_form[hostname_confirmation]", with: @site.default_host.hostname
   click_button I18n.t("site.confirm_destroy.confirm")
 end
 
 When(/^I fail to confirm the deletion$/) do
-  fill_in "delete_site_form[abbr_confirmation]", with: "bogus"
+  fill_in "delete_site_form[hostname_confirmation]", with: "bogus"
   click_button I18n.t("site.confirm_destroy.confirm")
 end

--- a/features/step_definitions/site_interaction_steps.rb
+++ b/features/step_definitions/site_interaction_steps.rb
@@ -16,7 +16,6 @@ When(/^I edit this site's transition date$/) do
 end
 
 When(/^I fill in the transition site fields/) do
-  fill_in "Abbreviated name", with: "aaib"
   fill_in "TNA timestamp", with: "20141104112824"
   fill_in "Homepage", with: "https://www.gov.uk/government/organisations/air-accidents-investigation-branch"
   fill_in "Hostname", with: "www.aaib.gov.uk"

--- a/lib/tasks/import/hits/precompute.rake
+++ b/lib/tasks/import/hits/precompute.rake
@@ -3,12 +3,12 @@ require "transition/import/hits/precompute"
 namespace :import do
   namespace :hits do
     namespace :precompute do
-      desc "Set flag to start computing all hits/all-time view for a list of given site abbrs"
+      desc "Set flag to start computing all hits/all-time view for a list of given site id"
       task enable: :environment do |_, args|
         Transition::Import::Hits::Precompute.new(args.extras, true).update!
       end
 
-      desc "Set flag to stop computing all hits/all-time view for a list of given site abbrs"
+      desc "Set flag to stop computing all hits/all-time view for a list of given site id"
       task disable: :environment do |_, args|
         Transition::Import::Hits::Precompute.new(args.extras, false).update!
       end

--- a/lib/transition/import/hits/precompute.rb
+++ b/lib/transition/import/hits/precompute.rb
@@ -6,8 +6,8 @@ module Transition
       class Precompute
         include Transition::Import::ConsoleJobWrapper
 
-        def initialize(site_abbrs, new_precompute_value)
-          @site_abbrs = site_abbrs.reject(&:empty?)
+        def initialize(site_ids, new_precompute_value)
+          @site_ids = site_ids.reject(&:blank?)
           @new_precompute_value = new_precompute_value
         end
 
@@ -17,9 +17,9 @@ module Transition
           Site.transaction do
             sites.each do |site|
               if site.precompute_all_hits_view == @new_precompute_value
-                console_puts "WARN: skipping site with abbr '#{site.abbr}' - already set to #{@new_precompute_value}"
+                console_puts "WARN: skipping site with ID '#{site.id}' - already set to #{@new_precompute_value}"
               else
-                start "Setting #{site.abbr} precompute_all_hits_view to #{@new_precompute_value}" do
+                start "Setting #{site.id} precompute_all_hits_view to #{@new_precompute_value}" do
                   site.update!(precompute_all_hits_view: @new_precompute_value)
                   @updated += 1
                 end
@@ -34,13 +34,7 @@ module Transition
       private
 
         def sites
-          @site_abbrs.map { |abbr| find_site(abbr) }.compact
-        end
-
-        def find_site(abbr)
-          Site.find_by(abbr:).tap do |site|
-            console_puts "WARN: skipping site with abbr '#{abbr}' - not found" if site.nil?
-          end
+          @site_ids.map { |id| Site.find(id) }.compact
         end
 
         def inform_about_refresh

--- a/lib/transition/import/materialized_views/hits.rb
+++ b/lib/transition/import/materialized_views/hits.rb
@@ -21,7 +21,7 @@ module Transition
 
         def self.replace!
           Site.where(precompute_all_hits_view: true).each do |site|
-            view_name = "#{site.abbr}_all_hits"
+            view_name = "all_hits_#{site.id}"
 
             doing = Postgres::MaterializedView.exists?(view_name) ? "Refreshing" : "Creating"
 

--- a/lib/transition/import/revert_entirely_unsafe.rb
+++ b/lib/transition/import/revert_entirely_unsafe.rb
@@ -13,7 +13,7 @@ module Transition
         end
 
         def revert_all_data!
-          console_puts "Trying to delete site and all associated data: #{@site.abbr}"
+          console_puts "Trying to delete site and all associated data: #{@site.default_host.hostname}"
 
           destroy_site_data
         end
@@ -29,18 +29,18 @@ module Transition
 
           @site.destroy!
 
-          console_puts "Deleted site: #{@site.abbr}"
+          console_puts "Deleted site: #{@site.default_host.hostname}"
         end
 
         def destroy_all_versions
-          console_puts "Removing versions for: #{@site.abbr}"
+          console_puts "Removing versions for: #{@site.default_host.hostname}"
           @site.mappings.each do |map|
             map.versions.destroy_all
           end
         end
 
         def destroy_all_mappings
-          console_puts "Removing mappings for: #{@site.abbr}"
+          console_puts "Removing mappings for: #{@site.default_host.hostname}"
           @site.mappings.destroy_all
         end
 

--- a/spec/controllers/batches_controller_spec.rb
+++ b/spec/controllers/batches_controller_spec.rb
@@ -10,7 +10,7 @@ describe BatchesController do
 
       before do
         login_as(user)
-        get :show, params: { site_id: site.abbr, id: mappings_batch.id }
+        get :show, params: { site_id: site.id, id: mappings_batch.id }
         @parsed_response = JSON.parse(response.body)
       end
 
@@ -31,7 +31,7 @@ describe BatchesController do
     context "when batch does not exist" do
       before do
         login_as(user)
-        get :show, params: { site_id: site.abbr, id: 72 }
+        get :show, params: { site_id: site.id, id: 72 }
       end
 
       it "responds with a 404 status code" do

--- a/spec/controllers/bulk_add_batches_controller_spec.rb
+++ b/spec/controllers/bulk_add_batches_controller_spec.rb
@@ -10,7 +10,7 @@ describe BulkAddBatchesController do
   describe "#new" do
     context "without permission to edit" do
       def make_request
-        get :new, params: { site_id: site.abbr }
+        get :new, params: { site_id: site.id }
       end
 
       it_behaves_like "disallows editing by unaffiliated user"
@@ -21,14 +21,19 @@ describe BulkAddBatchesController do
         login_as gds_bob
       end
 
-      it "displays the form" do
+      it "displays the form when requesting using an abbreviation" do
         get :new, params: { site_id: site.abbr }
+        expect(response.status).to eql(200)
+      end
+
+      it "displays the form when requesting using an ID" do
+        get :new, params: { site_id: site.id }
         expect(response.status).to eql(200)
       end
 
       context "but the site is global" do
         def make_request
-          post :create, params: { site_id: global_site.abbr }
+          post :create, params: { site_id: global_site.id }
         end
 
         it_behaves_like "disallows editing of a global site"
@@ -39,7 +44,7 @@ describe BulkAddBatchesController do
   describe "#create" do
     context "without permission to edit" do
       def make_request
-        post :create, params: { site_id: site.abbr }
+        post :create, params: { site_id: site.id }
       end
 
       it_behaves_like "disallows editing by unaffiliated user"
@@ -51,7 +56,7 @@ describe BulkAddBatchesController do
       end
 
       def make_request
-        post :create, params: { site_id: global_site.abbr }
+        post :create, params: { site_id: global_site.id }
       end
 
       it_behaves_like "disallows editing of a global site"
@@ -67,7 +72,7 @@ describe BulkAddBatchesController do
       it "returns to where it came from" do
         get :preview,
             params: {
-              site_id: site.abbr,
+              site_id: site.id,
               id: batch.id,
               return_path: "/donkey",
             }
@@ -80,18 +85,18 @@ describe BulkAddBatchesController do
       it "returns to the site mappings path" do
         get :preview,
             params: {
-              site_id: site.abbr,
+              site_id: site.id,
               id: batch.id,
               return_path: "http://google.com",
             }
 
-        expect(assigns(:bulk_add_cancel_destination)).to eq(site_mappings_path(site.abbr))
+        expect(assigns(:bulk_add_cancel_destination)).to eq(site_mappings_path(site.id))
       end
     end
 
     context "for a global site" do
       def make_request
-        post :create, params: { site_id: global_site.abbr }
+        post :create, params: { site_id: global_site.id }
       end
 
       it_behaves_like "disallows editing of a global site"
@@ -101,7 +106,7 @@ describe BulkAddBatchesController do
   describe "#import" do
     context "without permission to edit" do
       def make_request
-        post :import, params: { site_id: site.abbr, id: batch.id }
+        post :import, params: { site_id: site.id, id: batch.id }
       end
 
       it_behaves_like "disallows editing by unaffiliated user"
@@ -114,7 +119,7 @@ describe BulkAddBatchesController do
 
       context "but it is global" do
         def make_request
-          post :create, params: { site_id: global_site.abbr }
+          post :create, params: { site_id: global_site.id }
         end
 
         it_behaves_like "disallows editing of a global site"
@@ -124,7 +129,7 @@ describe BulkAddBatchesController do
         def make_request
           post :import,
                params: {
-                 site_id: site.abbr,
+                 site_id: site.id,
                  update_existing: "true",
                  id: batch.id,
                }
@@ -145,7 +150,7 @@ describe BulkAddBatchesController do
         def make_request
           post :import,
                params: {
-                 site_id: site.abbr,
+                 site_id: site.id,
                  update_existing: "true",
                  id: large_batch.id,
                }
@@ -156,7 +161,7 @@ describe BulkAddBatchesController do
 
       context "a batch which has been submitted already" do
         def make_request
-          post :import, params: { site_id: site.abbr, id: batch.id }
+          post :import, params: { site_id: site.id, id: batch.id }
         end
 
         include_examples "it doesn't requeue a batch which has already been queued"
@@ -176,7 +181,7 @@ describe BulkAddBatchesController do
         end
 
         before do
-          post :import, params: { site_id: site.abbr, id: batch.id }
+          post :import, params: { site_id: site.id, id: batch.id }
         end
 
         it "creates each mapping in the batch" do
@@ -217,7 +222,7 @@ describe BulkAddBatchesController do
       it "should redirect to mappings index" do
         post :import,
              params: {
-               site_id: site.abbr,
+               site_id: site.id,
                id: batch.id,
                return_path: "http://malicious.com",
              }

--- a/spec/controllers/hits_controller_spec.rb
+++ b/spec/controllers/hits_controller_spec.rb
@@ -95,7 +95,7 @@ describe HitsController do
     let(:paths)    { category.hits.map { |h| [h.http_status, h.path, h.count] } }
 
     before do
-      expect(Site).to receive(:find_by!).and_return(site)
+      expect(Site).to receive(:find).and_return(site)
     end
 
     shared_examples "it has hits and points whether or not we used a view" do

--- a/spec/controllers/import_batches_controller_spec.rb
+++ b/spec/controllers/import_batches_controller_spec.rb
@@ -1,14 +1,14 @@
 require "rails_helper"
 
 describe ImportBatchesController do
-  let(:site) { create :site, abbr: "moj" }
+  let(:site) { create :site }
   let(:global_site) { create :site, global_type: "archive" }
   let(:gds_bob) { create(:gds_editor, name: "Bob Terwhilliger") }
 
   describe "#new" do
     context "without permission to edit" do
       def make_request
-        get :new, params: { site_id: site.abbr }
+        get :new, params: { site_id: site.id }
       end
 
       it_behaves_like "disallows editing by unaffiliated user"
@@ -20,7 +20,7 @@ describe ImportBatchesController do
       end
 
       def make_request
-        post :create, params: { site_id: global_site.abbr }
+        post :create, params: { site_id: global_site.id }
       end
 
       it_behaves_like "disallows editing of a global site"
@@ -34,7 +34,7 @@ describe ImportBatchesController do
 
     context "for a global site" do
       def make_request
-        post :create, params: { site_id: global_site.abbr }
+        post :create, params: { site_id: global_site.id }
       end
 
       it_behaves_like "disallows editing of a global site"
@@ -42,7 +42,7 @@ describe ImportBatchesController do
 
     context "without permission to edit" do
       def make_request
-        post :create, params: { site_id: site.abbr }
+        post :create, params: { site_id: site.id }
       end
 
       it_behaves_like "disallows editing by unaffiliated user"
@@ -55,7 +55,7 @@ describe ImportBatchesController do
       before do
         post :create,
              params: {
-               site_id: site.abbr,
+               site_id: site.id,
                import_batch: {
                  raw_csv: "/a,TNA\n/b,#{long_url}",
                  tag_list: "",
@@ -116,7 +116,7 @@ describe ImportBatchesController do
       before do
         post :create,
              params: {
-               site_id: site.abbr,
+               site_id: site.id,
                import_batch: {
                  raw_csv: "a,", tag_list: ""
                },
@@ -144,7 +144,7 @@ describe ImportBatchesController do
   describe "#preview" do
     context "without permission to edit" do
       def make_request
-        get :preview, params: { site_id: site.abbr, id: 1 }
+        get :preview, params: { site_id: site.id, id: 1 }
       end
 
       it_behaves_like "disallows editing by unaffiliated user"
@@ -156,7 +156,7 @@ describe ImportBatchesController do
       end
 
       def make_request
-        post :create, params: { site_id: global_site.abbr }
+        post :create, params: { site_id: global_site.id }
       end
 
       it_behaves_like "disallows editing of a global site"
@@ -172,7 +172,7 @@ describe ImportBatchesController do
 
     context "for a global site" do
       def make_request
-        post :create, params: { site_id: global_site.abbr }
+        post :create, params: { site_id: global_site.id }
       end
 
       it_behaves_like "disallows editing of a global site"
@@ -180,7 +180,7 @@ describe ImportBatchesController do
 
     context "without permission to edit" do
       def make_request
-        get :preview, params: { site_id: site.abbr, id: 1 }
+        get :preview, params: { site_id: site.id, id: 1 }
       end
 
       it_behaves_like "disallows editing by unaffiliated user"
@@ -190,7 +190,7 @@ describe ImportBatchesController do
       def make_request
         post :import,
              params: {
-               site_id: site.abbr,
+               site_id: site.id,
                import_batch: { update_existing: "true" },
                id: batch.id,
              }
@@ -205,7 +205,7 @@ describe ImportBatchesController do
       def make_request
         post :import,
              params: {
-               site_id: site.abbr,
+               site_id: site.id,
                import_batch: { update_existing: "true" },
                id: large_batch.id,
              }
@@ -216,7 +216,7 @@ describe ImportBatchesController do
 
     context "a batch which has been submitted already" do
       def make_request
-        post :import, params: { site_id: site.abbr, id: batch.id, import_batch: {} }
+        post :import, params: { site_id: site.id, id: batch.id, import_batch: {} }
       end
 
       include_examples "it doesn't requeue a batch which has already been queued"

--- a/spec/controllers/site_dates_contoller_spec.rb
+++ b/spec/controllers/site_dates_contoller_spec.rb
@@ -10,15 +10,20 @@ describe SiteDatesController do
         login_as gds_bob
       end
 
-      it "displays the form" do
+      it "displays the form when requesting using an abbreviation" do
         get :edit, params: { site_id: site.abbr }
+        expect(response.status).to eql(200)
+      end
+
+      it "displays the form when requesting using an ID" do
+        get :edit, params: { site_id: site.id }
         expect(response.status).to eql(200)
       end
     end
 
     context "when the user does not have permission" do
       def make_request
-        get :edit, params: { site_id: site.abbr }
+        get :edit, params: { site_id: site.id }
       end
 
       it_behaves_like "disallows editing by non-GDS Editors"

--- a/spec/controllers/sites_controller_spec.rb
+++ b/spec/controllers/sites_controller_spec.rb
@@ -66,8 +66,13 @@ describe SitesController do
         login_as site_manager
       end
 
-      it "displays the form" do
+      it "displays the form when requesting using an abbreviation" do
         get :edit, params: { id: site.abbr }
+        expect(response.status).to eql(200)
+      end
+
+      it "displays the form when requesting using an ID" do
+        get :edit, params: { id: site.id }
         expect(response.status).to eql(200)
       end
     end
@@ -76,7 +81,7 @@ describe SitesController do
       before { login_as stub_user }
 
       def make_request
-        get :edit, params: { organisation_id: organisation.whitehall_slug, id: site.abbr }
+        get :edit, params: { organisation_id: organisation.whitehall_slug, id: site.id }
       end
 
       it "disallows deleting by non-Site Managers" do
@@ -98,7 +103,7 @@ describe SitesController do
 
     def make_request
       post :update, params: {
-        id: site.abbr,
+        id: site.id,
         site_form: params,
       }
     end
@@ -134,14 +139,14 @@ describe SitesController do
       before { login_as site_manager }
 
       it "displays the form" do
-        get :confirm_destroy, params: { id: site.abbr }
+        get :confirm_destroy, params: { id: site.id }
         expect(response.status).to eql(200)
       end
     end
 
     context "when the user does not have permission" do
       def make_request
-        get :confirm_destroy, params: { id: site.abbr }
+        get :confirm_destroy, params: { id: site.id }
       end
 
       it_behaves_like "disallows deleting by non-Site managers"
@@ -150,7 +155,7 @@ describe SitesController do
 
   describe "#destroy" do
     def make_request
-      post :destroy, params: { id: site.abbr, delete_site_form: { abbr_confirmation: site.abbr } }
+      post :destroy, params: { id: site.id, delete_site_form: { abbr_confirmation: site.abbr } }
     end
 
     context "when the user does have permission" do

--- a/spec/controllers/sites_controller_spec.rb
+++ b/spec/controllers/sites_controller_spec.rb
@@ -155,7 +155,7 @@ describe SitesController do
 
   describe "#destroy" do
     def make_request
-      post :destroy, params: { id: site.id, delete_site_form: { abbr_confirmation: site.abbr } }
+      post :destroy, params: { id: site.id, delete_site_form: { hostname_confirmation: site.default_host.hostname } }
     end
 
     context "when the user does have permission" do

--- a/spec/controllers/versions_controller_spec.rb
+++ b/spec/controllers/versions_controller_spec.rb
@@ -12,7 +12,7 @@ describe VersionsController, versioning: true do
     context "loading the page" do
       before do
         login_as_stub_user
-        get :index, params: { mapping_id: mapping.id, site_id: site.abbr }
+        get :index, params: { mapping_id: mapping.id, site_id: site.id }
       end
 
       it "responds with the correct HTTP status code" do
@@ -34,7 +34,7 @@ describe VersionsController, versioning: true do
           mapping.reload
         end
         login_as_stub_user
-        get :index, params: { mapping_id: mapping.id, site_id: site.abbr }
+        get :index, params: { mapping_id: mapping.id, site_id: site.id }
       end
 
       it "shows details of the update when a mapping is amended" do

--- a/spec/factories/site_forms.rb
+++ b/spec/factories/site_forms.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :site_form do
-    abbr { "aaib" }
     organisation_slug { "air-accidents-investigation-branch" }
     homepage { "https://www.gov.uk/government/organisations/air-accidents-investigation-branch" }
     tna_timestamp { "20141104112824" }

--- a/spec/forms/delete_site_form_spec.rb
+++ b/spec/forms/delete_site_form_spec.rb
@@ -1,14 +1,16 @@
 require "rails_helper"
 
 describe DeleteSiteForm do
+  let(:site) { create(:site) }
+
   describe "validations" do
-    describe "#abbr_confirmation" do
-      context "when the site abbr does not match" do
+    describe "#hostname_confirmation" do
+      context "when the site hostname is incorrect" do
         it "is invalid" do
-          site_form = DeleteSiteForm.new(abbr: "cabinet-office", abbr_confirmation: "dfe")
+          site_form = DeleteSiteForm.new(id: site.id, hostname_confirmation: "incorrect.gov.uk")
 
           expect(site_form.valid?).to be false
-          expect(site_form.errors[:abbr_confirmation]).to include("The confirmation did not match")
+          expect(site_form.errors[:hostname_confirmation]).to include("The confirmation did not match")
         end
       end
     end
@@ -25,7 +27,7 @@ describe DeleteSiteForm do
 
     context "when invalid" do
       it "returns false" do
-        site_form = DeleteSiteForm.new(abbr: "cabinet-office", abbr_confirmation: "dfe")
+        site_form = DeleteSiteForm.new(id: site.id, hostname_confirmation: "incorrect.gov.uk")
 
         expect(site_form.save).to be false
         expect(mock_reverter_class).to_not have_received(:new)
@@ -35,8 +37,7 @@ describe DeleteSiteForm do
 
     context "when valid" do
       it "calls the reverter and returns true" do
-        site = create(:site, abbr: "cabinet-office")
-        site_form = DeleteSiteForm.new(abbr: "cabinet-office", abbr_confirmation: "cabinet-office")
+        site_form = DeleteSiteForm.new(id: site.id, hostname_confirmation: site.default_host.hostname)
 
         result = site_form.save
 

--- a/spec/forms/site_form_spec.rb
+++ b/spec/forms/site_form_spec.rb
@@ -58,7 +58,6 @@ describe SiteForm do
 
       expect(site_form).to have_attributes(
         organisation_slug: site.organisation.whitehall_slug,
-        abbr: site.abbr,
         tna_timestamp: "20120816224015",
         homepage: "https://www.gov.uk/government/organisations/example-org",
         extra_organisations: [extra_organisation.id],
@@ -107,7 +106,6 @@ describe SiteForm do
 
       expect(site).to be_a Site
       expect(site).to have_attributes(
-        abbr: "aaib",
         organisation:,
         homepage: "https://www.gov.uk/government/organisations/air-accidents-investigation-branch",
         tna_timestamp: Time.strptime("20141104112824", "%Y%m%d%H%M%S"),

--- a/spec/helpers/hits_helper_spec.rb
+++ b/spec/helpers/hits_helper_spec.rb
@@ -92,25 +92,25 @@ describe HitsHelper do
     end
 
     context "when a site is present" do
-      let(:site) { build :site, abbr: "site_abbr" }
+      let(:site) { create :site }
 
       context "when no category is set" do
         it "defaults to the summary with the period" do
-          expect(path).to eq("/sites/site_abbr/hits/summary?period=yesterday")
+          expect(path).to eq("/sites/#{site.id}/hits/summary?period=yesterday")
         end
       end
 
       context "when a category is set" do
         let(:category) { "errors" }
         it "links to the category and period for the site" do
-          expect(path).to eq("/sites/site_abbr/hits/category?category=errors&period=yesterday")
+          expect(path).to eq("/sites/#{site.id}/hits/category?category=errors&period=yesterday")
         end
 
         context "when the time period is default" do
           let(:period) { nil }
 
           it "links to the category without the period for the site" do
-            expect(path).to eq("/sites/site_abbr/hits/category?category=errors")
+            expect(path).to eq("/sites/#{site.id}/hits/category?category=errors")
           end
         end
       end
@@ -119,7 +119,7 @@ describe HitsHelper do
         let(:action) { "index" }
 
         it "defaults to all hits with the period" do
-          expect(path).to eq("/sites/site_abbr/hits?period=yesterday")
+          expect(path).to eq("/sites/#{site.id}/hits?period=yesterday")
         end
       end
     end

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -90,7 +90,7 @@ describe Host do
 
       context "does not already exist" do
         let!(:existing_host) { create :host, hostname: "www.cabinetoffice.gov.uk", site: }
-        let(:site) { create :site, abbr: "cabinetoffice" }
+        let(:site) { create :site }
 
         subject(:host) { build :host, hostname: "www.cabinetoffice.gov.uk" }
 
@@ -100,7 +100,7 @@ describe Host do
         end
 
         it "should have an error for invalid hostname" do
-          message = "The hostname www.cabinetoffice.gov.uk already exists. You must delete the cabinetoffice site to remove it"
+          message = "The hostname www.cabinetoffice.gov.uk already exists. You must delete the #{site.default_host.hostname} site to remove it"
           expect(host.errors_on(:hostname)).to include(message)
         end
       end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -8,12 +8,9 @@ describe Site do
   end
 
   describe "validations" do
-    it { is_expected.to validate_presence_of(:abbr) }
     it { is_expected.to validate_presence_of(:tna_timestamp) }
     it { is_expected.to validate_presence_of(:organisation) }
     it { is_expected.to validate_inclusion_of(:special_redirect_strategy).in_array(%w[via_aka supplier]) }
-    it { is_expected.to allow_value("org_site1-Modifier").for(:abbr) }
-    it { is_expected.not_to allow_value("org_www.site").for(:abbr) }
 
     describe "homepage" do
       it { is_expected.to validate_presence_of(:homepage) }

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -331,10 +331,10 @@ describe Site do
   describe "precomputed views" do
     let(:precompute) { false }
 
-    subject(:site) { build :site, abbr: "hmrc", precompute_all_hits_view: precompute }
+    subject(:site) { create :site, precompute_all_hits_view: precompute }
 
     it "calculates a conventional view name" do
-      expect(site.precomputed_view_name).to eql("hmrc_all_hits")
+      expect(site.precomputed_view_name).to eql("all_hits_#{site.id}")
     end
 
     describe "#able_to_use_view?" do

--- a/spec/requests/site_creation_spec.rb
+++ b/spec/requests/site_creation_spec.rb
@@ -17,7 +17,6 @@ describe "Site creation" do
     post organisation_sites_path(organisation), params: { site_form: params }
 
     attributes = {
-      abbr: "aaib",
       global_new_url: "https://www.gov.uk/government/organisations/air-accidents-investigation-branch/about",
       global_redirect_append_path: true,
       global_type: "redirect",
@@ -78,7 +77,6 @@ describe "Site creation" do
       post organisation_sites_path(organisation), params: { site_form: params }
 
       attributes = {
-        abbr: "aaib",
         homepage: "https://www.gov.uk/government/organisations/air-accidents-investigation-branch",
         tna_timestamp: Time.strptime("20141104112824", "%Y%m%d%H%M%S"),
         global_redirect_append_path: false,

--- a/spec/requests/site_updating_spec.rb
+++ b/spec/requests/site_updating_spec.rb
@@ -25,7 +25,6 @@ describe "Site updating" do
     put site_path(site), params: { site_form: params }
 
     attributes = {
-      abbr: "aaib",
       global_new_url: "https://www.gov.uk/government/organisations/air-accidents-investigation-branch/about",
       global_redirect_append_path: true,
       global_type: "redirect",
@@ -90,7 +89,6 @@ describe "Site updating" do
       put site_path(site), params: { site_form: params }
 
       attributes = {
-        abbr: "aaib",
         homepage: "https://www.gov.uk/government/organisations/air-accidents-investigation-branch",
         tna_timestamp: Time.strptime("20141104112824", "%Y%m%d%H%M%S"),
         global_redirect_append_path: false,


### PR DESCRIPTION
Users are currently asked for an abbreviation for sites when they set them up.  This serves no purpose, other than creating a slug for use in URLs within the Transition tool.  It is not used anywhere externally.

This is a waste of user's time and may cause confusion as to what actually needs to be entered as an abbreviation.

Therefore moving away from abbreviations and switching to IDs within URLs, rather than the abbreviation slug.  The field is removed from the create/edit form, however we maintain access to URLs that already contained a slug.

[Trello card](https://trello.com/c/HaVI5NDq)