### PR TITLE
Load the selected extra organisations into the site form correctly

### DIFF
--- a/app/forms/site_form.rb
+++ b/app/forms/site_form.rb
@@ -31,7 +31,7 @@ class SiteForm
       abbr: site.abbr,
       tna_timestamp: site.tna_timestamp.to_formatted_s(:number),
       homepage: site.homepage,
-      extra_organisations: site.extra_organisations,
+      extra_organisations: site.extra_organisations.map(&:id),
       homepage_title: site.homepage_title,
       homepage_furl: site.homepage_furl,
       global_type: site.global_type,

--- a/spec/forms/site_form_spec.rb
+++ b/spec/forms/site_form_spec.rb
@@ -61,7 +61,7 @@ describe SiteForm do
         abbr: site.abbr,
         tna_timestamp: "20120816224015",
         homepage: "https://www.gov.uk/government/organisations/example-org",
-        extra_organisations: [extra_organisation],
+        extra_organisations: [extra_organisation.id],
         homepage_title: "Homepage title",
         homepage_furl: "www.gov.uk/site",
         global_type: "redirect",


### PR DESCRIPTION
The values of the extra organisations select component correspond to the record
IDs. Currently, when the form is loaded, the previous selection is not shown correctly.


---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
