### PR TITLE
Fix error when a site doesn't have an abbr

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -8,6 +8,6 @@ class OrganisationsController < ApplicationController
     @organisation = Organisation.find_by!(whitehall_slug: params[:id])
     sites = @organisation.sites.includes(:hosts)
     extra_sites = @organisation.extra_sites.includes(:hosts)
-    @sites = (sites + extra_sites).sort_by(&:abbr)
+    @sites = (sites + extra_sites).sort_by { |site| site.default_host.hostname }
   end
 end

--- a/spec/controllers/organisations_controller_spec.rb
+++ b/spec/controllers/organisations_controller_spec.rb
@@ -21,8 +21,8 @@ describe OrganisationsController do
     let(:organisation) { create(:organisation, title: "HM Government Department") }
 
     before do
-      create(:site, abbr: "site-1", organisation:)
       create(:site, abbr: "site-2", organisation:)
+      create(:site, abbr: "site-1", organisation:)
       login_as_stub_user
       get :show, params: { id: organisation.whitehall_slug }
     end
@@ -31,9 +31,11 @@ describe OrganisationsController do
       expect(response.status).to be(200)
     end
 
-    it "lists the sites for the organisation" do
+    it "lists the sites for the organisation in order of default hostname" do
       expect(response.body).to include("site-1.gov.uk")
       expect(response.body).to include("site-2.gov.uk")
+
+      expect(response.body.index("site-1.gov.uk")).to be < response.body.index("site-2.gov.uk")
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/tSMIkxGp

We removed the abbr attribute for new sites in #1473.

This page raises an error when a new site without an abbr is present.

Sort by hostname instead. All sites have a default host with a hostname (confirmed in the console with `Site.all.map { |site| site.default_host.hostname }.all? { |hostname| hostname.present? }`)

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
