### PR TITLE
Add Google Tag Manager configuration to Transition

### DIFF
--- a/app/views/layouts/_google_tag_manager.html.erb
+++ b/app/views/layouts/_google_tag_manager.html.erb
@@ -1,0 +1,7 @@
+<% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
+  <%= render "govuk_publishing_components/components/google_tag_manager_script", {
+    gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],
+    gtm_auth: ENV["GOOGLE_TAG_MANAGER_AUTH"],
+    gtm_preview: ENV["GOOGLE_TAG_MANAGER_PREVIEW"],
+  } %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,7 @@
   <%= stylesheet_link_tag "legacy_layout", :media => "all" %>
   <%= javascript_include_tag "legacy_layout" %>
   <%= csrf_meta_tag %>
+  <%= render "layouts/google_tag_manager" %>
   <%= yield :extra_headers %>
 <% end %>
 <% content_for :navbar_items do %>


### PR DESCRIPTION
Based on the work we did previously on publisher in alphagov/publisher#1963

Because we already have a content_for :head block in this application, there's a very slight departure from the approach taken in publisher / signon - the layouts/google_tag_manager partial renders the tag directly, instead of setting content_for.

Tested locally with:

    GOOGLE_TAG_MANAGER_AUTH=some-auth
    GOOGLE_TAG_MANAGER_ID=some-id
    GOOGLE_TAG_MANAGER_PREVIEW=some-preview

Gives this snippet in <head>:

    <script>
    //<![CDATA[
    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
      'https://www.googletagmanager.com/gtm.js?id='+i+dl+'&gtm_cookies_win=x&gtm_auth=some-auth&gtm_preview=some-preview';f.parentNode.insertBefore(j,f);
    })(window,document,'script','dataLayer','some-id');

    //]]>
    </script>

We'll need a follow up PR to pass these environment variables through in govuk-helm-charts.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
