### PR TITLE
Sanitize and cleanup invalid UTF-8 characters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem "optic14n" # Ideally version should be synced with bouncer
 gem "paper_trail"
 gem "pg"
 gem "plek"
+gem "rack-utf8_sanitizer"
 gem "select2-rails", "~> 3.5.11" # Version 4 changes CSS classes considerably
 gem "sentry-sidekiq"
 gem "whenever"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -627,6 +627,8 @@ GEM
       rack (< 3)
     rack-test (2.1.0)
       rack (>= 1.3)
+    rack-utf8_sanitizer (1.9.1)
+      rack (>= 1.0, < 4.0)
     rackup (1.0.0)
       rack (< 3)
       webrick
@@ -881,6 +883,7 @@ DEPENDENCIES
   pg
   plek
   pry
+  rack-utf8_sanitizer
   rails (= 7.1.3.4)
   rails-controller-testing
   rspec-collection_matchers

--- a/config/application.rb
+++ b/config/application.rb
@@ -61,5 +61,8 @@ module Transition
     # to build, once to compress) which breaks the usage of "unquote" to use
     # CSS that has same function names as SCSS such as max
     config.assets.css_compressor = nil
+
+    # Sanitize and cleanup invalid UTF-8 characters in request URIs, headers and cookies
+    config.middleware.insert 0, Rack::UTF8Sanitizer, sanitize_null_bytes: true
   end
 end

--- a/spec/requests/null_byte_spec.rb
+++ b/spec/requests/null_byte_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+describe "NullByteSpec", type: :request do
+  it "does not error when provided with null bytes in the session cookie" do
+    cookies["_session_id"] = "123\u0000"
+
+    expect {
+      get "/"
+    }.not_to raise_error(ArgumentError, "string contains null byte")
+  end
+end


### PR DESCRIPTION
We have been seeing exceptions `string contains null byte (ArgumentError)` logged in Sentry for this application.

These are a result of an automated scan being run by Cyber Security which includes a null byte in the request (we believe it is in the session cookie).  No vulnerability is present, but the resulting error thrown by the application has resulted in a lot of noise in our Sentry alerts.

Adding a test to reproduce this problem so we are able to fix it.  Sanitising request URIs, headers and cookies to prevent the exception being raised again.

[Trello card](https://trello.com/c/B0hXNjfb)