### PR TITLE
Remove cookie rotation code from Rails 7.0 upgrade

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -61,22 +61,5 @@ module Transition
     # to build, once to compress) which breaks the usage of "unquote" to use
     # CSS that has same function names as SCSS such as max
     config.assets.css_compressor = nil
-
-    # Rotate SHA1 cookies to SHA256 (the new Rails 7 default)
-    # TODO: Remove this after existing user sessions have been rotated
-    # https://guides.rubyonrails.org/v7.0/upgrading_ruby_on_rails.html#key-generator-digest-class-changing-to-use-sha256
-    Rails.application.config.action_dispatch.cookies_rotations.tap do |cookies|
-      salt = Rails.application.config.action_dispatch.authenticated_encrypted_cookie_salt
-      secret_key_base = Rails.application.credentials.secret_key_base
-      next if secret_key_base.blank?
-
-      key_generator = ActiveSupport::KeyGenerator.new(
-        secret_key_base, iterations: 1000, hash_digest_class: OpenSSL::Digest::SHA1
-      )
-      key_len = ActiveSupport::MessageEncryptor.key_len
-      secret = key_generator.generate_key(salt, key_len)
-
-      cookies.rotate :encrypted, secret
-    end
   end
 end


### PR DESCRIPTION
When upgrading to Rails 7.0 in https://github.com/alphagov/transition/pull/1166/commits/68b50fce7f903887ebbf6ad85b714f81d821b8e6, we added some code to rotate SHA1 cookies to SHA256. A `TODO` comment was left to remove the code after the rotation had taken place, but this was never done.

Removing the code as it has served it's purpose of rotating the cookies.