### PR TITLE
Update Bouncer sync comments in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "rails", "7.1.3.4"
+gem "rails", "7.1.3.4" # Ideally version should be synced with Bouncer (activerecord)
 
 gem "activerecord-import"
 gem "activerecord-session_store"
@@ -19,7 +19,7 @@ gem "gretel"
 gem "htmlentities"
 gem "kaminari"
 gem "mlanett-redis-lock"
-gem "optic14n" # Ideally version should be synced with bouncer
+gem "optic14n" # Ideally version should be synced with Bouncer
 gem "paper_trail"
 gem "pg"
 gem "plek"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-do
 
 **Use GOV.UK Docker to run any commands that follow.**
 
+### Relationship with Bouncer
+
+Bouncer and Transition currently share a database. As a result, we aim to keep a
+few of their dependencies in sync (on the same version), namely:
+
+- rails (Transition) and activerecord (Bouncer)
+- optic14n
+
 ### Running the tests
 
 ```


### PR DESCRIPTION
From a cursory look through the git history, I can't find any documentation about why these need to be in sync, but under the assumption this is still correct, this makes the comments more complete

See:
- https://github.com/alphagov/bouncer/commit/cae58279aabafd8225f71fa0e90f02a10711e650
- https://github.com/alphagov/bouncer/commit/c6791bdff0ce593df35cfda7d8571ea75dbaa2b6
- https://github.com/alphagov/bouncer/pull/143#discussion_r119315712
- https://github.com/alphagov/transition/commit/e9266720fe92e8b8d9c2771bf4fc30385bba8137#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fR8

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
