### PR TITLE
Fix non-revealing form conditional

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,3 +11,4 @@
 // GO AFTER THE REQUIRES BELOW.
 //
 //= require govuk_publishing_components/dependencies
+//= require govuk_publishing_components/components/radio


### PR DESCRIPTION
[Trello](https://trello.com/c/uB3b0Pt5/1344-fix-transition-radio-button-bug-to-allow-users-to-add-new-sites-when-selecting-a-global-type-of-redirect)

A form conditional in `app/views/sites/_site_form.html.erb` (which appears on the "New transition site" page) was not being revealed when the relevant radio option was selected. We weren't requiring the related JavaScript, so this does that

## Screenshots

### Before

<img width="607" alt="image" src="https://github.com/user-attachments/assets/3dd91fbe-c639-400b-a7ae-fcef1fc471cd">

### After

<img width="666" alt="image" src="https://github.com/user-attachments/assets/cfeea40a-138e-4579-bdb3-e3ba802eeb7d">

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
