### PR TITLE
Fix Sass slash as division deprecations

### DIFF
--- a/app/assets/stylesheets/legacy/filters.scss
+++ b/app/assets/stylesheets/legacy/filters.scss
@@ -60,7 +60,7 @@ a.filter-option:visited,
 
 .dropdown-text-input {
   width: 600px;
-  padding: $default-vertical-margin/2 $grid-gutter-width/2;
+  padding: calc($default-vertical-margin / 2) calc($grid-gutter-width / 2);
 }
 
 .remove-filters {

--- a/app/assets/stylesheets/legacy/tags.scss
+++ b/app/assets/stylesheets/legacy/tags.scss
@@ -1,8 +1,8 @@
 /* Tags
    ========================================================================== */
 
-$tag-padding-top-bottom: (2em/14);
-$tag-padding-left-right: (5em/14);
+$tag-padding-top-bottom: calc(2em / 14);
+$tag-padding-left-right: calc(5em / 14);
 
 %tag-foundation {
   color: $link-color;
@@ -15,7 +15,7 @@ $tag-padding-left-right: (5em/14);
   @extend %tag-foundation;
   padding: $tag-padding-top-bottom $tag-padding-left-right;
   display: inline-block;
-  margin-bottom: $default-vertical-margin / 3;
+  margin-bottom: calc($default-vertical-margin / 3);
 }
 
 .tag-active,
@@ -33,7 +33,7 @@ a.tag:hover {
 .tag .glyphicon-remove {
   @extend %glyphicon-smaller-than-text;
   position: relative;
-  top: (1em/14);
+  top: calc(1em / 14);
 }
 
 .tag-list {


### PR DESCRIPTION
[Trello](https://trello.com/c/RrKHuZkH/1361-fix-sass-deprecations-in-transition)

This fixes the following deprecation warning:

```
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.
```

See: https://sass-lang.com/documentation/breaking-changes/slash-div

## Screenshots (no changes expected)

### Filter dropdown text input and tags

#### Before

<img width="1191" alt="Screenshot 2024-09-11 at 17 25 19" src="https://github.com/user-attachments/assets/c6138df1-2b39-4264-83a0-75ffc536929a">

#### After

<img width="1180" alt="Screenshot 2024-09-11 at 17 40 23" src="https://github.com/user-attachments/assets/adb14088-26cf-472b-9014-78e407e56bec">

### Clear button

#### Before

<img width="658" alt="Screenshot 2024-09-11 at 17 28 35" src="https://github.com/user-attachments/assets/8c49c42d-0912-4957-abe0-9175b3034389">

#### After

<img width="688" alt="Screenshot 2024-09-11 at 17 40 14" src="https://github.com/user-attachments/assets/dc4e84d2-7e9d-4236-8850-b67760a5e215">

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
