### PR TITLE
Update label for aliases field

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -86,7 +86,7 @@ en:
         special_redirect_strategy_options:
           via_aka: The supplier is redirecting some paths to our aka domain
           supplier: The supplier is managing redirects to gov.uk. No traffic comes through Bouncer for this site.
-        aliases: This is a list of alias domains. Enter as a comma-separated list.
+        aliases: This is a list of alias domains. Enter as a comma-separated list, without spaces.
   site:
     confirm_destroy:
       confirm: I understand the consequences, delete this site


### PR DESCRIPTION
I was getting a cryptic error of ` is an invalid domain` when trying to add an alias domain to an existing record.

Updating the label to make it clear you cannot include spaces between the domains, else we try adding the space as a domain.