### PR TITLE
Remove breadcrumbs to appease WCAG

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -56,14 +56,6 @@
     %>
   <% end %>
 
-  <% breadcrumbs.tap do |links| %>
-    <% if links.any? %>
-      <ul class='breadcrumb'>
-        <% links.each do |link| %><%= crumb_li(link.text, link.url, link.current?) %><% end %>
-      </ul>
-    <% end %>
-  <% end %>
-
   <%= yield %>
   <%= render partial: 'shared/go_to' %>
 <% end %>


### PR DESCRIPTION
Trello: https://trello.com/c/vB0leYNw/1393-fix-breadcrumbs-wcag-fails-in-transition

After: 
<img width="1181" alt="image" src="https://github.com/user-attachments/assets/b1432fb6-47b4-499d-ae7d-8b0b172f14b0">


This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
