### PR TITLE
Remove whenever gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,6 @@ gem "plek"
 gem "rack-utf8_sanitizer"
 gem "select2-rails", "~> 3.5.11" # Version 4 changes CSS classes considerably
 gem "sentry-sidekiq"
-gem "whenever"
 
 gem "sass"
 gem "sprockets"

--- a/Gemfile
+++ b/Gemfile
@@ -24,10 +24,9 @@ gem "paper_trail"
 gem "pg"
 gem "plek"
 gem "rack-utf8_sanitizer"
+gem "sass"
 gem "select2-rails", "~> 3.5.11" # Version 4 changes CSS classes considerably
 gem "sentry-sidekiq"
-
-gem "sass"
 gem "sprockets"
 gem "terser"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,6 @@ GEM
     capybara-select-2 (0.5.1)
     cgi (0.3.6)
     chartkick (5.1.1)
-    chronic (0.10.2)
     coderay (1.1.3)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
@@ -845,8 +844,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    whenever (1.0.0)
-      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.7.1)
@@ -902,7 +899,6 @@ DEPENDENCIES
   timecop
   web-console
   webmock
-  whenever
 
 BUNDLED WITH
    2.3.22


### PR DESCRIPTION
[Trello](https://trello.com/c/XaoSL3oM/1465-remove-whenever-gem-from-our-apps)

This was [added][1] when scheduling a Rake task to run every day, and evolved over time. However, all scheduling has since been [removed from Transition code][2] but the gem was left behind

[1]: https://github.com/alphagov/transition/commit/c35bba540fffd6d3ee0d96530c0a4b112ddbfd05
[2]: https://github.com/alphagov/transition/commit/fc90dc7276d487ca4ee67be6abc35759c9861da3

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
