### PR TITLE
Increase dependabot PR limit for Ruby gems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: bundler
     directory: /
+    open-pull-requests-limit: 20
     schedule:
       interval: daily
 


### PR DESCRIPTION
Dependabot has a [default limit](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/troubleshooting-dependabot-errors#dependabot-cannot-open-any-more-pull-requests) of 5 for the number of pull requests it will open on a repo. We have missed some updates this week, since Dependabot has been limited to the number of PRs it can open.

This could mean we never see the PR that will fix the `puma`/`rackup` issue we have recently been having on the other dependency updates in this app.

Therefore increasing the limit to 20, as we are unlikely to exceed this.