### PR TITLE
Remove all traces of old Sidekiq "worker" naming

### DIFF
--- a/app/sidekiq/mappings_batch_job.rb
+++ b/app/sidekiq/mappings_batch_job.rb
@@ -11,5 +11,3 @@ class MappingsBatchJob
     end
   end
 end
-
-MappingsBatchWorker = MappingsBatchJob


### PR DESCRIPTION
Sidekiq::Worker was deprecated a while back and
[we switched over](https://github.com/alphagov/transition/commit/1817374062f3cccda0e7f6f6777ea301447c988f)
to using Sidekiq::Job here and moved this file from app/workers.

I assume there's a reason that we kept these bits when we made those
changes. Some sort of compatibility issue?

Anyway, this setup is now preventing RSpec from running at all on my
machine. (I think it's the difference between the naming of the
MappingsBatchJob constant and its file.) So I'm hoping that it's not
needed anymore.