### PR TITLE
Update calls to textarea with the id option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,7 +276,7 @@ GEM
     govuk_personalisation (1.1.0)
       plek (>= 1.9.0)
       rails (>= 6, < 9)
-    govuk_publishing_components (47.0.0)
+    govuk_publishing_components (50.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -309,7 +309,7 @@ GEM
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.0)
-    irb (1.15.0)
+    irb (1.15.1)
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)

--- a/app/views/sites/_site_form.html.erb
+++ b/app/views/sites/_site_form.html.erb
@@ -165,7 +165,7 @@
         },
         hint: t("helpers.hint.site_form.aliases"),
         name: form.field_name(:aliases),
-        id: field_id_attribute(form.object, :aliases),
+        textarea_id: field_id_attribute(form.object, :aliases),
         value: form.object.aliases,
         error_message: error_message(form.object, :aliases),
       } %>

--- a/app/views/sites/confirm_destroy.html.erb
+++ b/app/views/sites/confirm_destroy.html.erb
@@ -20,7 +20,7 @@
 
   <%= render "govuk_publishing_components/components/warning_text", {
     text: "This will delete the #{@site.default_host.hostname} site and all the data that is associated with it.",
-    margin_bottom: true
+    margin_bottom: 6
   } %>
 
   <p class="govuk-body">In addition to the site, this action will also remove:</p>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Update all uses of the textarea component to change the `id` option to `textarea_id`.

Tests in this PR are likely to fail until the changes to the textarea component are included in this PR with a new gem release.

## Why
Changes in https://github.com/alphagov/govuk_publishing_components/pull/4574 mean that this option needs to be updated.

## Visual changes
Shouldn't be any.

Trello card: https://trello.com/c/GQ1p2oSC/438-not-doing-add-component-wrapper-helper-to-form-textarea-component