### PR TITLE
Log hostnames instead of object identifiers

### DIFF
--- a/lib/transition/import/dns_details.rb
+++ b/lib/transition/import/dns_details.rb
@@ -15,8 +15,9 @@ module Transition
       end
 
       def import!
+        warn "Importing CNAME / A records for #{hosts.length} hosts:"
         hosts.each do |host|
-          warn "Importing CNAME / A records for #{host}"
+          warn host.hostname
 
           add_cname_record_details(host) || add_a_record_details(host)
 


### PR DESCRIPTION
Previously this logged:

    Importing CNAME / A records for #<Host:0x0000ffff70331ba0>
    Importing CNAME / A records for #<Host:0x0000ffff70331a60>
    Importing CNAME / A records for #<Host:0x0000ffff70331920>

Which is not very useful.

Pull the repeated bit of the message out of the loop, and then just log the hostnames, so we should get:

    Importing CNAME / A records for 128 hosts:
    foo.bar.com
    bar.baz.com
    ...

Instead
