### PR TITLE
PP-7685 Update Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,13 +2,13 @@ version: 2
 updates:
   - package-ecosystem: bundler
     directory: /
-    open-pull-requests-limit: 20
     schedule:
       interval: weekly
       day: tuesday
       time: "07:00"
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25
     groups:
       test:
         patterns:
@@ -36,6 +36,7 @@ updates:
       time: "07:00"
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25
     groups:
       test:
         patterns:
@@ -49,3 +50,5 @@ updates:
       time: "07:00"
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,12 @@ updates:
   - package-ecosystem: bundler
     directory: /
     open-pull-requests-limit: 20
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "07:00"
     cooldown:
       default-days: 3
-    schedule:
-      interval: daily
     groups:
       test:
         patterns:
@@ -28,10 +30,12 @@ updates:
   
   - package-ecosystem: npm
     directory: /
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "07:00"
     cooldown:
       default-days: 3
-    schedule:
-      interval: daily
     groups:
       test:
         patterns:
@@ -39,7 +43,9 @@ updates:
 
   - package-ecosystem: github-actions
     directory: /
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "07:00"
     cooldown:
       default-days: 3
-    schedule:
-      interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,15 +3,21 @@ updates:
   - package-ecosystem: bundler
     directory: /
     open-pull-requests-limit: 20
+    cooldown:
+      default-days: 3
     schedule:
       interval: daily
 
   - package-ecosystem: npm
     directory: /
+    cooldown:
+      default-days: 3
     schedule:
       interval: daily
 
   - package-ecosystem: github-actions
     directory: /
+    cooldown:
+      default-days: 3
     schedule:
       interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,35 @@ updates:
       default-days: 3
     schedule:
       interval: daily
-
+    groups:
+      test:
+        patterns:
+          - "factory_bot*"
+          - "capybara-*"
+          - "cucumber*"
+          - "database_cleaner*"
+          - "govuk_test"
+          - "rails-controller-testing"
+          - "rspec"
+          - "rspec-*"
+          - "shoulda-matchers"
+          - "simplecov"
+          - "timecop"
+          - "webmock"
+      activerecord:
+        patterns:
+          - "activerecord-*"
+  
   - package-ecosystem: npm
     directory: /
     cooldown:
       default-days: 3
     schedule:
       interval: daily
+    groups:
+      test:
+        patterns:
+          - "jasmine-*"
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: weekly
       day: tuesday
       time: "07:00"
+    allow:
+      - dependency-type: direct
     cooldown:
       default-days: 3
     open-pull-requests-limit: 25
@@ -34,6 +36,8 @@ updates:
       interval: weekly
       day: tuesday
       time: "07:00"
+    allow:
+      - dependency-type: direct
     cooldown:
       default-days: 3
     open-pull-requests-limit: 25

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,3 +56,19 @@ updates:
       default-days: 3
     open-pull-requests-limit: 25
 
+  # Ruby needs to be upgraded manually in multiple places, so cannot
+  # be upgraded by Dependabot. That effectively makes the below
+  # config redundant, as ruby is the only updatable thing in the
+  # Dockerfile, although this may change in the future. We hope this
+  # config will save a dev from trying to upgrade ruby via Dependabot.
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "07:00"
+    ignore:
+      - dependency-name: ruby
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 25


### PR DESCRIPTION
This PR refines Dependabot configuration to reduce noise and improve update safety. It adds Docker support (while ignoring Ruby, which must be upgraded manually), introduces cooldown periods to avoid unstable releases, groups related Bundler  and NPM updates and switches to a weekly Tuesday 7:00 UTC schedule.

It also increases the open PR limit to 25 to support batching, and restricts updates to direct dependencies only for more relevant, manageable changes. 

Security updates remain unaffected and continue to be raised immediately.