### PR TITLE
[PP-7701] Allow switching site to use non-global redirect

### DIFF
--- a/app/views/sites/_site_form.html.erb
+++ b/app/views/sites/_site_form.html.erb
@@ -91,6 +91,12 @@
         name: form.field_name(:global_type),
         items: [
           {
+            value: "",
+            text: t("helpers.label.site_form.global_type_options.none"),
+            hint_text: t("helpers.hint.site_form.global_type_options.none"),
+            checked: form.object.global_type.nil?
+          },
+          {
             value: Site::GLOBAL_TYPES[:archive],
             text: t("helpers.label.site_form.global_type_options.archive"),
             hint_text: t("helpers.hint.site_form.global_type_options.archive"),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,8 +51,9 @@ en:
       site_form:
         global_redirect_append_path_options:
           1: Should the path the user supplied be appended to the URL for the global redirect?
-        global_type: Global type (Optional)
+        global_type: Global type
         global_type_options:
+          none: Non-global
           redirect: Redirect
           archive: Archive
         special_redirect_strategy_options:
@@ -79,6 +80,7 @@ en:
         homepage_furl: This is the friendly URL displayed on 404/410 pages. It should redirect to the homepage. It doesn't need to include 'http' or 'https'.
         global_type: This sets a global redirect or archive for all paths.
         global_type_options:
+          none: Redirects for specific paths will be mapped manually
           redirect: All site URLs will redirect to the Global new URL
           archive: All site URLs will show a page saying the site has been archived
         query_params:  A significant querystring parameter is one which on the old website changes the content in a meaningful way - which we might therefore need to map to a different place. Query string parameters should be specified in lowercase; uppercase parameters will not be preserved during canonicalisation. Enter as a colon-separated list.

--- a/features/site.feature
+++ b/features/site.feature
@@ -122,9 +122,9 @@ Scenario: Editing a site
     | ukti            | UK Trade & Industry           |
     | go-science      | Government Office for Science |
   And a site bis exists
-  And I visit this site page
+  When I visit this site page
   And I click the link "Edit"
-  When I fill in the transition site fields
+  And I fill in the transition site fields
   And I save my changes
   Then I should be redirected to the site
 
@@ -132,8 +132,8 @@ Scenario: Editing a site's transition date as a GDS Editor
   Given I have logged in as a GDS Editor
   And the date is 29/11/19
   And a site bis exists
-  And I visit this site page
-  When I edit this site's transition date
+  When I visit this site page
+  And I edit this site's transition date
   Then I should be redirected to the site dashboard
   And I should see "Transition date updated"
   And I should see "20 September 2014"
@@ -141,7 +141,7 @@ Scenario: Editing a site's transition date as a GDS Editor
 Scenario: Editing a site's transition date as a non-GDS Editor
   Given I have logged in as a member of DCLG
   And a site dclg exists
-  And I visit this site page
+  When I visit this site page
   Then I should not see "Edit date"
   When I visit the path /sites/dclg/edit_date
   Then I should be redirected to the site dashboard

--- a/features/site.feature
+++ b/features/site.feature
@@ -147,6 +147,19 @@ Scenario: Editing a site's transition date as a non-GDS Editor
   Then I should be redirected to the site dashboard
   And I should see "Only GDS Editors can access that."
 
+Scenario: Editing a globally redirected site to use non-global mappings
+  Given I have logged in as a Site Manager
+  And a site moj_academy exists
+  And the site is globally redirected
+  When I visit this site page
+  Then I should see "All paths from moj_academy.gov.uk"
+  When I click the link "Edit"
+  And I set the site to use non-global mappings
+  And I save my changes
+  Then I should be redirected to the site dashboard
+  And I should not see "All paths from moj_academy.gov.uk"
+  And I should be able to view the site's mappings
+
 Scenario: Deleting a site as a Site Manager
   Given I have logged in as a Site Manager
   And a site bis exists

--- a/features/step_definitions/site_interaction_steps.rb
+++ b/features/step_definitions/site_interaction_steps.rb
@@ -30,6 +30,11 @@ When(/^I fill in the transition site fields/) do
   fill_in "Aliases", with: "aaib.gov.uk,aaib.com"
 end
 
+When(/^I set the site to use non-global mappings/) do
+  fill_in "Global new URL", with: ""
+  choose "Non-global"
+end
+
 Then(/^I should be on the new transition site page for the (.*) organisation$/) do |organisation_title|
   organisation = Organisation.find_by(title: organisation_title)
   i_should_be_on_the_path new_organisation_site_path(organisation)


### PR DESCRIPTION
We have an optional global type field when setting up a site. If the field is left empty, the global type will be `nil`. We present different options to users for managing sites based on whether the global type is present

Since the global type field uses radio buttons, once you've chosen an option, the only change you can make is to pick another option: you can't return to the state of having no option picked

This adds a non-global option, which is the default, to enable us to switch from having a global type to not having one. This allows us to e.g.:
- fix mistakes (a real example came up recently where we mistakenly set up a global redirect and needed to correct it, but couldn't via the UI)
- update the behaviour based on new needs
