### PR TITLE
Update the GTM container ID [WHIT-3365]

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,9 @@
   <%= javascript_include_tag "legacy_layout" %>
   <%= javascript_include_tag "es6-components", type: "module" %>
   <%= csrf_meta_tag %>
-  <%= render "layouts/google_tag_manager" %>
+  <%= render "layouts/google_tag_manager", {
+    gtm_id: "GTM-5T5SVMQX",
+  } %>
   <%= yield :extra_headers %>
 <% end %>
 <% content_for :navbar_items do %>


### PR DESCRIPTION
## What 

Update the GTM container ID

## Why

Request from PAs

This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
