### PR TITLE
[PP-7021] Bump `govuk_sidekiq` to version 12.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,7 +135,7 @@ GEM
     chartkick (5.2.1)
     coderay (1.1.3)
     concurrent-ruby (1.3.8)
-    connection_pool (2.5.5)
+    connection_pool (3.0.2)
     crack (1.0.1)
       bigdecimal
       rexml
@@ -298,11 +298,11 @@ GEM
       rouge
       sprockets (>= 3)
       sprockets-rails
-    govuk_sidekiq (11.1.2)
+    govuk_sidekiq (12.0.0)
       gds-api-adapters (>= 19.1.0)
       govuk_app_config (>= 1.1)
       redis-client (>= 0.22.2)
-      sidekiq (~> 7.0, < 8)
+      sidekiq (>= 8.1.1, < 9)
     govuk_test (4.1.3)
       brakeman (>= 5.0.2)
       capybara (>= 3.36)
@@ -811,12 +811,12 @@ GEM
       sidekiq (>= 5.0)
     shoulda-matchers (8.0.1)
       activesupport (>= 7.2)
-    sidekiq (7.3.10)
-      base64
-      connection_pool (>= 2.3.0, < 3)
-      logger
-      rack (>= 2.2.4, < 3.3)
-      redis-client (>= 0.23.0, < 1)
+    sidekiq (8.1.6)
+      connection_pool (>= 3.0.0)
+      json (>= 2.16.0)
+      logger (>= 1.7.0)
+      rack (>= 3.2.0)
+      redis-client (>= 0.29.0)
     signet (0.21.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -932,4 +932,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-  4.0.10
+  4.0.17


### PR DESCRIPTION
This includes an upgrade to use Sidekiq 8.
