### PR TITLE
[PP-7949] Bump govuk_publishing_components to v68.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -289,7 +289,7 @@ GEM
     govuk_personalisation (1.2.0)
       plek (>= 1.9.0)
       rails (>= 6, < 9)
-    govuk_publishing_components (67.0.1)
+    govuk_publishing_components (68.3.0)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)

--- a/app/assets/javascripts/es6-components.js
+++ b/app/assets/javascripts/es6-components.js
@@ -10,6 +10,5 @@
 //= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/checkboxes
 //= require govuk_publishing_components/components/error-summary
-//= require govuk_publishing_components/components/layout-header
 //= require govuk_publishing_components/components/radio
 //= require govuk_publishing_components/components/skip-link


### PR DESCRIPTION
I've tried to keep this as lightweight as possible, as despite the component
guide stating many more Js components than required here are needed, none of those
changed with this release, and the app did fine without them before.
So this PR merely:
- Bumps the govuk_publishing_components version
- Removes the `layout-header` es6 component, as it's no longer needed.

This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
