### PR TITLE
[PP-7949] Switch on `use_es6_components` config option

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,6 @@
 <% content_for :head do %>
   <%= stylesheet_link_tag "legacy_layout", :media => "all" %>
   <%= javascript_include_tag "legacy_layout" %>
-  <%= javascript_include_tag "es6-components", type: "module" %>
   <%= csrf_meta_tag %>
   <%= render "layouts/google_tag_manager" %>
   <%= yield :extra_headers %>

--- a/config/initializers/govuk_publishing_components.rb
+++ b/config/initializers/govuk_publishing_components.rb
@@ -1,0 +1,3 @@
+GovukPublishingComponents.configure do |config|
+  config.use_es6_components = true
+end


### PR DESCRIPTION
Correctly enables the `use_es6_components` config option, which is needed as app uses the `layout_for_admin` template.

Follow up to #2291 
https://github.com/alphagov/govuk_publishing_components/blob/c451fbe9b0ab94b7cf4bb6275019a53a8b51beac/docs/install-and-use.md#new-use_es6_components-config-option-optional

This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
